### PR TITLE
ordered lists

### DIFF
--- a/packages/core/src/extensions/Blocks/OrderedListPlugin.ts
+++ b/packages/core/src/extensions/Blocks/OrderedListPlugin.ts
@@ -1,4 +1,4 @@
-import {Plugin, PluginKey} from "prosemirror-state";
+import { Plugin, PluginKey } from "prosemirror-state";
 
 const PLUGIN_KEY = new PluginKey(`ordered-list`);
 
@@ -6,30 +6,41 @@ export const OrderedListPlugin = () => {
   return new Plugin({
     key: PLUGIN_KEY,
     appendTransaction: (_transactions, _oldState, newState) => {
-      const newTr = newState.tr
-      let modified = false
-      let count = 1
-      let skip = 0
+      const newTr = newState.tr;
+      let modified = false;
+      let count = 1;
+      let skip = 0;
       newState.doc.descendants((node, pos) => {
-        if (node.type.name === "tcblock" && !node.attrs.listType) count = 1
-        if (skip == 0 && node.type.name === "tcblock" && node.attrs.listType === "oli") {
-          skip = node.content.childCount
+        if (node.type.name === "tcblock" && !node.attrs.listType) {
+          count = 1;
+        }
+        if (
+          skip === 0 &&
+          node.type.name === "tcblock" &&
+          node.attrs.listType === "oli"
+        ) {
+          skip = node.content.childCount;
           // This assumes that the content node is always the first child of the oli block,
           // as the content model grows this assumption may need to change
           if (node.content.child(0).attrs.position !== `${count}.`) {
             // TODO: @DAlperin currently sub-items just continue from the order of the parent,
             //  sub-items should be ordered separately with letters or roman numerals or some such
-            newTr.setNodeMarkup(pos+1, undefined, {...node.attrs, position: `${count}.`})
-            modified = true
+            newTr.setNodeMarkup(pos + 1, undefined, {
+              ...node.attrs,
+              position: `${count}.`,
+            });
+            modified = true;
           }
 
-          count++
-        } else if (skip > 0) skip--
-      })
-      if (modified){
-        return newTr
+          count++;
+        } else if (skip > 0) {
+          skip--;
+        }
+      });
+      if (modified) {
+        return newTr;
       }
-      return null
-    }
-  })
-}
+      return null;
+    },
+  });
+};

--- a/packages/core/src/extensions/Blocks/nodes/Block.ts
+++ b/packages/core/src/extensions/Blocks/nodes/Block.ts
@@ -3,7 +3,7 @@ import { Selection } from "prosemirror-state";
 import styles from "./Block.module.css";
 import { PreviousBlockTypePlugin } from "../PreviousBlockTypePlugin";
 import { textblockTypeInputRuleSameNodeType } from "../rule";
-import {OrderedListPlugin} from "../OrderedListPlugin";
+import { OrderedListPlugin } from "../OrderedListPlugin";
 
 export interface IBlock {
   HTMLAttributes: Record<string, any>;

--- a/packages/core/src/extensions/Blocks/nodes/Content.ts
+++ b/packages/core/src/extensions/Blocks/nodes/Content.ts
@@ -18,12 +18,12 @@ export const ContentBlock = Node.create<IBlock>({
         default: undefined,
         renderHTML: (attributes) => {
           return {
-            "data-position": attributes.position
-          }
+            "data-position": attributes.position,
+          };
         },
-        parseHTML: (element) => element.getAttribute("data-position")
-      }
-    }
+        parseHTML: (element) => element.getAttribute("data-position"),
+      },
+    };
   },
 
   content: "inline*",


### PR DESCRIPTION
Sweet! I'll keep the commit on `main`. Have now also protected that branch :)

I think it might be better to set the `position` attribute on `Block` instead of `Content`. This is more inline with the rest of the codebase (all relevant attributes are on the `Block` level). However, you'd probably need to use a hack like this; https://stackoverflow.com/a/42035304/194651 (or alternatively, set a `data-*` dom attribute using decorations?)

I applied some codeformatting (this is done automatically when using the prettier plugin for vscode).

Does `skip` do anything atm btw?