### PR TITLE
Keep track of sub-lists ordering seperately from the top level

### DIFF
--- a/packages/core/src/extensions/Blocks/OrderedListPlugin.ts
+++ b/packages/core/src/extensions/Blocks/OrderedListPlugin.ts
@@ -2,39 +2,55 @@ import { Plugin, PluginKey } from "prosemirror-state";
 
 const PLUGIN_KEY = new PluginKey(`ordered-list`);
 
+function getLetterForNumber(number: number): string {
+  let s = "",
+    t;
+
+  while (number > 0) {
+    t = (number - 1) % 26;
+    s = String.fromCharCode(65 + t) + s;
+    number = ((number - t) / 26) | 0;
+  }
+  return s;
+}
+
 export const OrderedListPlugin = () => {
   return new Plugin({
     key: PLUGIN_KEY,
     appendTransaction: (_transactions, _oldState, newState) => {
       const newTr = newState.tr;
       let modified = false;
-      let count = 1;
-      let skip = 0;
+
+      let countByDepth = new Map<number, number>();
+      let prevDepth = 1;
       newState.doc.descendants((node, pos) => {
-        if (node.type.name === "tcblock" && !node.attrs.listType) {
-          count = 1;
+        const depth = newState.doc.resolve(pos).depth;
+        if (node.type.name !== "tcblock") {
+          return;
         }
-        if (
-          skip === 0 &&
-          node.type.name === "tcblock" &&
-          node.attrs.listType === "oli"
-        ) {
-          skip = node.content.childCount;
+        if (node.attrs.listType !== "oli") {
+          countByDepth.set(depth, 0);
+        } else {
+          if (prevDepth < depth) countByDepth.set(depth, 0);
+          let currentCount = (countByDepth.get(depth) || 0) + 1;
+          countByDepth.set(depth, currentCount);
           // This assumes that the content node is always the first child of the oli block,
           // as the content model grows this assumption may need to change
-          if (node.content.child(0).attrs.position !== `${count}.`) {
-            // TODO: @DAlperin currently sub-items just continue from the order of the parent,
-            //  sub-items should be ordered separately with letters or roman numerals or some such
+          if (
+            node.content.child(0).attrs.position !== `${currentCount}.` ||
+            prevDepth !== depth
+          ) {
+            let display: string | number = 0;
+            if (depth === 1 || Math.ceil(depth / 3) % 2 === 0)
+              display = currentCount;
+            else if (depth > 1) display = getLetterForNumber(currentCount);
             newTr.setNodeMarkup(pos + 1, undefined, {
               ...node.attrs,
-              position: `${count}.`,
+              position: `${display}.`,
             });
             modified = true;
           }
-
-          count++;
-        } else if (skip > 0) {
-          skip--;
+          prevDepth = depth;
         }
       });
       if (modified) {


### PR DESCRIPTION
Currently it restarts numbering for each new sublist, but it could be letters/numerals or any other thing the logic is the same. That being said, any preference letters or roman numerals for sub-lists?