### PR TITLE
fix bubblemenu loop bug

### DIFF
--- a/packages/core/src/extensions/Blocks/PreviousBlockTypePlugin.ts
+++ b/packages/core/src/extensions/Blocks/PreviousBlockTypePlugin.ts
@@ -23,13 +23,13 @@ export const PreviousBlockTypePlugin = () => {
       return {
         update: async (view, _prevState) => {
           if (this.key?.getState(view.state).needsUpdate) {
-            // use setImmediate to clear the decorations so that at least
+            // use setTimeout 0 to clear the decorations so that at least
             // for one DOM-render the decorations have been applied
-            setImmediate(() => {
+            setTimeout(() => {
               view.dispatch(
                 view.state.tr.setMeta(PLUGIN_KEY, { clearUpdate: true })
               );
-            });
+            }, 0);
           }
         },
       };

--- a/packages/core/src/extensions/BubbleMenu/component/BubbleMenu.tsx
+++ b/packages/core/src/extensions/BubbleMenu/component/BubbleMenu.tsx
@@ -179,9 +179,7 @@ export const BubbleMenu = (props: { editor: Editor }) => {
         onClick={() =>
           props.editor.chain().focus().sinkListItem("tcblock").run()
         }
-        isDisabled={
-          !props.editor.can().chain().focus().sinkListItem("tcblock").run()
-        }
+        isDisabled={!props.editor.can().sinkListItem("tcblock")}
         mainTooltip="Indent"
         secondaryTooltip={formatKeyboardShortcut("Tab")}
         icon={RiIndentIncrease}
@@ -191,9 +189,7 @@ export const BubbleMenu = (props: { editor: Editor }) => {
         onClick={() =>
           props.editor.chain().focus().liftListItem("tcblock").run()
         }
-        isDisabled={
-          !props.editor.can().chain().focus().liftListItem("tcblock").run()
-        }
+        isDisabled={!props.editor.can().liftListItem("tcblock")}
         mainTooltip="Decrease Indent"
         secondaryTooltip={formatKeyboardShortcut("Shift+Tab")}
         icon={RiIndentDecrease}


### PR DESCRIPTION
- don't call "focus" for isDisabled checks
- Also fixes a different bug, apparently `setImmediate` is not available on all browsers

_update_: I think decrease indent doesn't show disabled correctly yet, but at least the bug is gone