### PR TITLE
Block side menu show/hide detection fix

### DIFF
--- a/packages/core/src/BlockNoteExtensions.ts
+++ b/packages/core/src/BlockNoteExtensions.ts
@@ -95,6 +95,7 @@ export const getBlockNoteExtensions = (uiFactories: UiFactories) => {
     ret.push(
       DraggableBlocksExtension.configure({
         blockSideMenuFactory: uiFactories.blockSideMenuFactory,
+        // menuDetectionElement: document.getElementById("detection-element")!,
       })
     );
   }

--- a/packages/core/src/extensions/DraggableBlocks/DraggableBlocksExtension.ts
+++ b/packages/core/src/extensions/DraggableBlocks/DraggableBlocksExtension.ts
@@ -5,6 +5,7 @@ import { createDraggableBlocksPlugin } from "./DraggableBlocksPlugin";
 export type DraggableBlocksOptions = {
   editor: Editor;
   blockSideMenuFactory: BlockSideMenuFactory;
+  menuDetectionElement: HTMLElement;
 };
 
 /**
@@ -27,6 +28,8 @@ export const DraggableBlocksExtension =
         createDraggableBlocksPlugin({
           editor: this.editor,
           blockSideMenuFactory: this.options.blockSideMenuFactory,
+          menuDetectionElement:
+            this.options.menuDetectionElement || this.editor.view.dom,
         }),
       ];
     },

--- a/packages/core/src/extensions/DraggableBlocks/DraggableBlocksPlugin.ts
+++ b/packages/core/src/extensions/DraggableBlocks/DraggableBlocksPlugin.ts
@@ -214,6 +214,7 @@ export type BlockMenuViewProps = {
   editor: Editor;
   blockMenuFactory: BlockSideMenuFactory;
   horizontalPosAnchoredAtRoot: boolean;
+  menuDetectionElement: HTMLElement;
 };
 
 export class BlockMenuView {
@@ -236,6 +237,7 @@ export class BlockMenuView {
     editor,
     blockMenuFactory,
     horizontalPosAnchoredAtRoot,
+    menuDetectionElement,
   }: BlockMenuViewProps) {
     this.editor = editor;
     this.horizontalPosAnchoredAtRoot = horizontalPosAnchoredAtRoot;
@@ -270,14 +272,21 @@ export class BlockMenuView {
 
         const block = getDraggableBlockFromCoords(coords, this.editor.view);
 
-        // Detection area which covers the width of the editor with a 100px left margin. The menu cannot be shown while
-        // the cursor is outside this area.
-        const cursorWithinDetectionArea =
-          editorBoundingBox.left + editorBoundingBox.width >= event.clientX &&
-          event.clientX >= editorBoundingBox.left - 100;
+        const detectionElementBoundingBox =
+          menuDetectionElement.getBoundingClientRect();
 
-        // Closes the menu if the mouse cursor is beyond the editor.
-        if (!block || !cursorWithinDetectionArea) {
+        const cursorWithinDetectionElement =
+          detectionElementBoundingBox.left +
+            detectionElementBoundingBox.width >=
+            event.clientX &&
+          event.clientX >= detectionElementBoundingBox.left &&
+          detectionElementBoundingBox.top +
+            detectionElementBoundingBox.height >=
+            event.clientY &&
+          event.clientY >= detectionElementBoundingBox.top;
+
+        // Closes the menu if the mouse cursor is not next to any block, or is outside the menu detection element.
+        if (!block || !cursorWithinDetectionElement) {
           if (this.menuOpen) {
             this.menuOpen = false;
             this.blockMenu.hide();
@@ -504,6 +513,7 @@ export const createDraggableBlocksPlugin = (
         editor: options.editor,
         blockMenuFactory: options.blockSideMenuFactory,
         horizontalPosAnchoredAtRoot: true,
+        menuDetectionElement: options.menuDetectionElement,
       }),
   });
 };


### PR DESCRIPTION
This PR changes when the block side menu is shown and hidden. Previously, it only hid the block side menu when the mouse cursor was beyond the horizontal range of the editor. Now, it also hides the menu if the mouse cursor is beyond the horizontal range of the editor (includes a 100px margin to the left of the editor to account for the menu itself, so that it can be clicked). However, this approach is flawed as the menu size and position can change if a custom element is used, is which case the menu will disappear even when hovered/clicked.

There are a few alternative solutions:

1. The editor's vertical and horizontal range is still used to determine when the menu is shown & hidden, but does not include the left margin for the menu itself. Instead, a timer is used to keep the menu open for some time until it's hovered over, similarly to the hyperlink hover menu. With this approach, the menu won't show up until the block it's next to is hovered.
2. The editor's vertical and horizontal range is still used to determine when the menu is shown, but again does not include a margin for the menu itself. To hide the menu, we check if the mouse cursor is within the bounding box of the editor or the menu itself. This doesn't work if there is a gap between the menu and the editor, and the menu also won't show up until the block it's next to is hovered.
3. The editor's vertical range only is still used to determine when the menu is shown & hidden, as before. However, a parent HTML element or CSS selector pointing to a single element, is also used. While the cursor is outside this element, the menu is prevented from showing. This can be implemented in a number of ways:

    1. The HTML element is provided as an option for the `DraggableBlocks` extension, which defaults to `document.body` to copy the current behaviour.
    2. A CSS ID is provided as an option for the `DraggableBlocks` extension, which defaults to e.g. `#block-side-menu-detection`. The user attaches this CSS ID to any HTML element, so that the menu stays hidden while the mouse cursor is outside of it. If no block with the ID is found, the behaviour is the same as the current implementation.

The fix used in this PR is simpler than the alternatives and seems closest to what Notion is doing. However, I think 3.ii. is the most elegant and provides the best functionality, though I want to make sure this implementation will work for Fermat.