### PR TITLE
add defaultStyles option, reorganize styles

### DIFF
--- a/packages/core/src/BlockNoteEditor.ts
+++ b/packages/core/src/BlockNoteEditor.ts
@@ -34,13 +34,48 @@ export type BlockNoteEditorOptions = {
   // TODO: Figure out if enableBlockNoteExtensions/disableHistoryExtension are needed and document them.
   enableBlockNoteExtensions: boolean;
   disableHistoryExtension: boolean;
+  /**
+   * Factories used to create a custom UI for BlockNote
+   */
   uiFactories: UiFactories;
+  /**
+   * TODO: why is this called slashCommands and not slashMenuItems?
+   *
+   * @default defaultSlashMenuItems from `./extensions/SlashMenu`
+   */
   slashCommands: BaseSlashMenuItem[];
+
+  /**
+   * The HTML element that should be used as the parent element for the editor.
+   *
+   * @default: undefined, the editor is not attached to the DOM
+   */
   parentElement: HTMLElement;
+  /**
+   * An object containing attributes that should be added to the editor's HTML element.
+   *
+   * @example { class: "my-editor-class" }
+   */
   editorDOMAttributes: Record<string, string>;
+  /**
+   *  A callback function that runs when the editor is ready to be used.
+   */
   onEditorReady: (editor: BlockNoteEditor) => void;
+  /**
+   * A callback function that runs whenever the editor's contents change.
+   */
   onEditorContentChange: (editor: BlockNoteEditor) => void;
+  /**
+   * A callback function that runs whenever the text cursor position changes.
+   */
   onTextCursorPositionChange: (editor: BlockNoteEditor) => void;
+
+  /**
+   * Use default BlockNote font and reset the styles of <p> <li> <h1> elements etc., that are used in BlockNote.
+   *
+   * @default true
+   */
+  defaultStyles: boolean;
 
   // tiptap options, undocumented
   _tiptapOptions: any;
@@ -61,6 +96,12 @@ export class BlockNoteEditor {
   }
 
   constructor(options: Partial<BlockNoteEditorOptions> = {}) {
+    // apply defaults
+    options = {
+      defaultStyles: true,
+      ...options,
+    };
+
     const blockNoteExtensions = getBlockNoteExtensions({
       editor: this,
       uiFactories: options.uiFactories || {},
@@ -93,6 +134,7 @@ export class BlockNoteEditor {
           class: [
             styles.bnEditor,
             styles.bnRoot,
+            options.defaultStyles ? styles.defaultStyles : "",
             options.editorDOMAttributes?.class || "",
           ].join(" "),
         },

--- a/packages/core/src/editor.module.css
+++ b/packages/core/src/editor.module.css
@@ -3,6 +3,11 @@
 .bnEditor {
   outline: none;
   margin-left: 50px;
+
+  /* Define a set of colors to be used throughout the app for consistency
+  see https://atlassian.design/foundations/color for more info */
+  --N800: #172b4d; /* Dark neutral used for tooltips and text on light background */
+  --N40: #dfe1e6; /* Light neutral used for subtle borders and text on dark background */
 }
 
 /*
@@ -25,13 +30,22 @@ Tippy popups that are appended to document.body directly
   box-sizing: inherit;
 }
 
-.bnEditor,
-.dragPreview {
-  /* Define a set of colors to be used throughout the app for consistency
-  see https://atlassian.design/foundations/color for more info */
-  --N800: #172b4d; /* Dark neutral used for tooltips and text on light background */
-  --N40: #dfe1e6; /* Light neutral used for subtle borders and text on dark background */
+/* reset styles, they will be set on blockContent */
+.defaultStyles p,
+.defaultStyles h1,
+.defaultStyles h2,
+.defaultStyles h3,
+.defaultStyles li {
+  all: unset;
+  margin: 0;
+  padding: 0;
+  font-size: inherit;
+}
 
+.defaultStyles,
+.dragPreview {
+  font-size: 16px;
+  font-weight: normal;
   font-family: "Inter", "SF Pro Display", -apple-system, BlinkMacSystemFont,
     "Open Sans", "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell",
     "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;

--- a/packages/core/src/editor.module.css
+++ b/packages/core/src/editor.module.css
@@ -42,8 +42,7 @@ Tippy popups that are appended to document.body directly
   font-size: inherit;
 }
 
-.defaultStyles,
-.dragPreview {
+.defaultStyles {
   font-size: 16px;
   font-weight: normal;
   font-family: "Inter", "SF Pro Display", -apple-system, BlinkMacSystemFont,

--- a/packages/core/src/extensions/Blocks/nodes/Block.module.css
+++ b/packages/core/src/extensions/Blocks/nodes/Block.module.css
@@ -3,21 +3,11 @@ BASIC STYLES
 */
 
 .blockOuter {
-  /* padding-bottom: 15px; */
-  font-size: 16px;
   line-height: 1.5;
-  transition: all 0.2s;
-  font-weight: normal;
-}
-
-.block {
-  /* content: ""; */
-  transition: all 0.2s;
-  margin: 0px;
+  transition: margin 0.2s;
 }
 
 .blockContent {
-  font-size: 1em;
   padding: 3px 0;
   transition: font-size 0.2s;
   /* display: inline-block; */
@@ -27,18 +17,6 @@ BASIC STYLES
   /* content: ""; */
   transition: all 0.2s;
   /*margin: 0px;*/
-}
-
-/* reset styles, they will be set on blockContent */
-.blockContent p,
-.blockContent h1,
-.blockContent h2,
-.blockContent h3,
-.blockContent li {
-  all: unset;
-  margin: 0;
-  padding: 0;
-  font-size: inherit;
 }
 
 /*

--- a/packages/core/src/extensions/DraggableBlocks/DraggableBlocksPlugin.ts
+++ b/packages/core/src/extensions/DraggableBlocks/DraggableBlocksPlugin.ts
@@ -158,8 +158,26 @@ function setDragImage(view: EditorView, from: number, to = from) {
   // dataTransfer.setDragImage(element) only works if element is attached to the DOM.
   unsetDragImage();
   dragImageElement = parentClone;
+
+  // TODO: This is hacky, need a better way of assigning classes to the editor so that they can also be applied to the
+  //  drag preview.
+  const classes = view.dom.className.split(" ");
+  const inheritedClasses = classes
+    .filter(
+      (className) =>
+        !className.includes("bn") &&
+        !className.includes("ProseMirror") &&
+        !className.includes("editor")
+    )
+    .join(" ");
+
   dragImageElement.className =
-    dragImageElement.className + " " + styles.dragPreview;
+    dragImageElement.className +
+    " " +
+    styles.dragPreview +
+    " " +
+    inheritedClasses;
+
   document.body.appendChild(dragImageElement);
 }
 

--- a/packages/website/docs/docs/editor.md
+++ b/packages/website/docs/docs/editor.md
@@ -1,6 +1,6 @@
 # Customizing the Editor
 
-There are a number of options that you can pass to `useBlockNote()`, which you can use to customize the editor. You can find the full list of these below:
+There are a number of options (all optional) that you can pass to `useBlockNote()`, which you can use to customize the editor. You can find the full list of these below:
 
 ```typescript
 export type BlockNoteEditorOptions = {
@@ -10,10 +10,11 @@ export type BlockNoteEditorOptions = {
   onTextCursorPositionChange: (editor: BlockNoteEditor) => void;
   slashMenuItems: ReactSlashMenuItem[];
   uiFactories: UiFactories;
+  defaultStyles: boolean;
 };
 ```
 
-`editorDOMAttributes:` An object containing attributes that should be added to the editor's HTML element.
+`editorDOMAttributes:` An object containing attributes that should be added to the editor's HTML element. E.g.: pass `{ class: "my-editor-class" }` to set a custom classname.
 
 `onEditorReady:` A callback function that runs when the editor is ready to be used.
 
@@ -24,3 +25,5 @@ export type BlockNoteEditorOptions = {
 `slashMenuItems:` The commands that are listed in the editor's [Slash Menu](/docs/slash-menu). If this option isn't defined, a default list of commands is loaded.
 
 `uiFactories:` Factories used to create a custom UI for BlockNote, which you can find out more about in [Creating Your Own UI Elements](/docs/vanilla-js#creating-your-own-ui-elements).
+
+`defaultStyles`: Use default BlockNote font and reset the styles of `<p>` `<li>` `<h1>` elements etc., that are used in BlockNote. (true by default)

--- a/packages/website/docs/docs/editor.md
+++ b/packages/website/docs/docs/editor.md
@@ -1,9 +1,9 @@
 # Customizing the Editor
 
-There are a number of options (all optional) that you can pass to `useBlockNote()`, which you can use to customize the editor. You can find the full list of these below:
+There are a number of options that you can pass to `useBlockNote()`, which you can use to customize the editor. You can find the full list of these below:
 
 ```typescript
-export type BlockNoteEditorOptions = {
+export type BlockNoteEditorOptions = Partial<{
   editorDOMAttributes: Record<string, string>;
   onEditorReady: (editor: BlockNoteEditor) => void;
   onEditorContentChange: (editor: BlockNoteEditor) => void;
@@ -11,10 +11,10 @@ export type BlockNoteEditorOptions = {
   slashMenuItems: ReactSlashMenuItem[];
   uiFactories: UiFactories;
   defaultStyles: boolean;
-};
+}>;
 ```
 
-`editorDOMAttributes:` An object containing attributes that should be added to the editor's HTML element. E.g.: pass `{ class: "my-editor-class" }` to set a custom classname.
+`editorDOMAttributes:` An object containing attributes that should be added to the editor's HTML element. For example, you can pass `{ class: "my-editor-class" }` to set a custom class name.
 
 `onEditorReady:` A callback function that runs when the editor is ready to be used.
 
@@ -26,4 +26,4 @@ export type BlockNoteEditorOptions = {
 
 `uiFactories:` Factories used to create a custom UI for BlockNote, which you can find out more about in [Creating Your Own UI Elements](/docs/vanilla-js#creating-your-own-ui-elements).
 
-`defaultStyles`: Use default BlockNote font and reset the styles of `<p>` `<li>` `<h1>` elements etc., that are used in BlockNote. (true by default)
+`defaultStyles`: Whether to use the default font and reset the styles of `<p>`, `<li>`, `<h1>`, etc. elements that are used in BlockNote. Defaults to true if undefined.


### PR DESCRIPTION
Fixes https://github.com/TypeCellOS/BlockNote/issues/144. With this change, users can prevent the "css reset" of block styles

Todo:

- [x] validate there are no regressions on Playwright
- [ ] I noticed a bug in the formattingtoolbar, double check if that's resolved
- [x] make it work for dragPreview as well