### PR TITLE
wip: custom blocks typing and API

### DIFF
--- a/packages/core/src/BlockNoteExtensions.ts
+++ b/packages/core/src/BlockNoteExtensions.ts
@@ -16,6 +16,7 @@ import { Underline } from "@tiptap/extension-underline";
 import { BackgroundColorExtension } from "./extensions/BackgroundColor/BackgroundColorExtension";
 import { BackgroundColorMark } from "./extensions/BackgroundColor/BackgroundColorMark";
 import { blocks } from "./extensions/Blocks";
+import { BlockSpec } from "./extensions/Blocks/api/blockTypes";
 import blockStyles from "./extensions/Blocks/nodes/Block.module.css";
 import { BlockSideMenuFactory } from "./extensions/DraggableBlocks/BlockSideMenuFactoryTypes";
 import { DraggableBlocksExtension } from "./extensions/DraggableBlocks/DraggableBlocksExtension";
@@ -46,6 +47,7 @@ export const getBlockNoteExtensions = (opts: {
   editor: BlockNoteEditor;
   uiFactories: UiFactories;
   slashCommands: BaseSlashMenuItem[];
+  blocks: BlockSpec[];
 }) => {
   const ret: Extensions = [
     extensions.ClipboardTextSerializer,
@@ -88,6 +90,7 @@ export const getBlockNoteExtensions = (opts: {
 
     // custom blocks:
     ...blocks,
+    ...opts.blocks.map((b) => b.node),
 
     Dropcursor.configure({ width: 5, color: "#ddeeff" }),
     History,

--- a/packages/core/src/api/blockManipulation/blockManipulation.ts
+++ b/packages/core/src/api/blockManipulation/blockManipulation.ts
@@ -2,13 +2,14 @@ import { Editor } from "@tiptap/core";
 import { Node } from "prosemirror-model";
 import {
   BlockIdentifier,
-  PartialBlock,
+  BlockTemplate,
+  PartialBlockTemplate,
 } from "../../extensions/Blocks/api/blockTypes";
 import { blockToNode } from "../nodeConversions/nodeConversions";
 import { getNodeById } from "../util/nodeUtil";
 
-export function insertBlocks(
-  blocksToInsert: PartialBlock[],
+export function insertBlocks<Block extends BlockTemplate<any, any>>(
+  blocksToInsert: PartialBlockTemplate<Block>[],
   referenceBlock: BlockIdentifier,
   placement: "before" | "after" | "nested" = "before",
   editor: Editor
@@ -56,9 +57,9 @@ export function insertBlocks(
   editor.view.dispatch(editor.state.tr.insert(insertionPos, nodesToInsert));
 }
 
-export function updateBlock(
+export function updateBlock<Block extends BlockTemplate<any, any>>(
   blockToUpdate: BlockIdentifier,
-  update: PartialBlock,
+  update: PartialBlockTemplate<Block>,
   editor: Editor
 ) {
   const id =
@@ -115,9 +116,9 @@ export function removeBlocks(
   }
 }
 
-export function replaceBlocks(
+export function replaceBlocks<Block extends BlockTemplate<any, any>>(
   blocksToRemove: BlockIdentifier[],
-  blocksToInsert: PartialBlock[],
+  blocksToInsert: PartialBlockTemplate<Block>[],
   editor: Editor
 ) {
   insertBlocks(blocksToInsert, blocksToRemove[0], "before", editor);

--- a/packages/core/src/api/formatConversions/formatConversions.ts
+++ b/packages/core/src/api/formatConversions/formatConversions.ts
@@ -7,13 +7,14 @@ import remarkParse from "remark-parse";
 import remarkRehype from "remark-rehype";
 import remarkStringify from "remark-stringify";
 import { unified } from "unified";
-import { Block } from "../../extensions/Blocks/api/blockTypes";
+import { BlockTemplate } from "../../extensions/Blocks/api/blockTypes";
+
 import { blockToNode, nodeToBlock } from "../nodeConversions/nodeConversions";
 import { removeUnderlines } from "./removeUnderlinesRehypePlugin";
 import { simplifyBlocks } from "./simplifyBlocksRehypePlugin";
 
 export async function blocksToHTML(
-  blocks: Block[],
+  blocks: BlockTemplate<any, any>[],
   schema: Schema
 ): Promise<string> {
   const htmlParentElement = document.createElement("div");
@@ -40,14 +41,14 @@ export async function blocksToHTML(
 export async function HTMLToBlocks(
   html: string,
   schema: Schema
-): Promise<Block[]> {
+): Promise<BlockTemplate<any, any>[]> {
   const htmlNode = document.createElement("div");
   htmlNode.innerHTML = html.trim();
 
   const parser = DOMParser.fromSchema(schema);
   const parentNode = parser.parse(htmlNode);
 
-  const blocks: Block[] = [];
+  const blocks: BlockTemplate<any, any>[] = [];
 
   for (let i = 0; i < parentNode.firstChild!.childCount; i++) {
     blocks.push(nodeToBlock(parentNode.firstChild!.child(i)));
@@ -57,7 +58,7 @@ export async function HTMLToBlocks(
 }
 
 export async function blocksToMarkdown(
-  blocks: Block[],
+  blocks: BlockTemplate<any, any>[],
   schema: Schema
 ): Promise<string> {
   const markdownString = await unified()
@@ -74,7 +75,7 @@ export async function blocksToMarkdown(
 export async function markdownToBlocks(
   markdown: string,
   schema: Schema
-): Promise<Block[]> {
+): Promise<BlockTemplate<any, any>[]> {
   const htmlString = await unified()
     .use(remarkParse)
     .use(remarkGfm)

--- a/packages/core/src/api/nodeConversions/nodeConversions.ts
+++ b/packages/core/src/api/nodeConversions/nodeConversions.ts
@@ -1,10 +1,10 @@
 import { Mark } from "@tiptap/pm/model";
 import { Node, Schema } from "prosemirror-model";
 import {
-  Block,
-  blockProps,
-  PartialBlock,
+  BlockTemplate,
+  PartialBlockTemplate,
 } from "../../extensions/Blocks/api/blockTypes";
+
 import {
   ColorStyle,
   InlineContent,
@@ -104,7 +104,10 @@ export function inlineContentToNodes(
 /**
  * Converts a BlockNote block to a TipTap node.
  */
-export function blockToNode(block: PartialBlock, schema: Schema) {
+export function blockToNode<Block extends BlockTemplate<any, any>>(
+  block: PartialBlockTemplate<Block>,
+  schema: Schema
+) {
   let id = block.id;
 
   if (id === undefined) {
@@ -213,7 +216,7 @@ function contentNodeToInlineContent(contentNode: Node) {
 /**
  * Convert a TipTap node to a BlockNote block.
  */
-export function nodeToBlock(
+export function nodeToBlock<Block extends BlockTemplate<any, any>>(
   node: Node,
   blockCache?: WeakMap<Node, Block>
 ): Block {

--- a/packages/core/src/extensions/Blocks/api/block.ts
+++ b/packages/core/src/extensions/Blocks/api/block.ts
@@ -1,0 +1,63 @@
+import { Node } from "@tiptap/core";
+import { PropSpec } from "./blockTypes";
+
+// A function to create a "BlockSpec" from a tiptap node.
+// we use this to create the block specs for the built-in blocks
+export function createBlockFromTiptapNode<
+  Type extends string,
+  Props extends readonly PropSpec[]
+>(
+  blockType: Type,
+  options: {
+    props: Props;
+  },
+  node: Node<any, any>
+) {
+  if (node.name !== blockType) {
+    throw Error(
+      "Node must be of type " + blockType + ", but is of type" + node.name + "."
+    );
+  }
+
+  // TODO: how to handle markdown / html conversions
+
+  // the return type gives us runtime access to the block name, props, and tiptap node
+  // but is also used to generate (derive) the type for the block spec
+  // so that we can have a strongly typed BlockNoteEditor API
+  return {
+    type: blockType,
+    node,
+    acceptedProps: options.props,
+  };
+}
+
+// A function to create custom block for API consumers
+// we want to hide the tiptap node from API consumers and provide a simpler API surface instead
+export function createCustomBlock<
+  Type extends string,
+  Props extends readonly PropSpec[]
+>(
+  blockType: Type,
+  options: (
+    | {
+        // for blocks with a single inline content element
+        inlineContent: true;
+        render: () => { dom: HTMLElement; contentDOM: HTMLElement };
+      }
+    | {
+        // for custom blocks that don't support content
+        inlineContent: false;
+        render: () => { dom: HTMLElement };
+      }
+  ) & {
+    props: Props;
+    // todo: possibly add parseDom options / other options we need
+  }
+) {
+  const node = Node.create({
+    name: blockType,
+    // TODO, create node from render / inlineContent / other props from options
+  });
+
+  return createBlockFromTiptapNode(blockType, { props: options.props }, node);
+}

--- a/packages/core/src/extensions/Blocks/api/blockTypes.ts
+++ b/packages/core/src/extensions/Blocks/api/blockTypes.ts
@@ -1,7 +1,9 @@
 /** Define the main block types **/
 
+import { createBlockFromTiptapNode } from "./block";
 import { InlineContent, PartialInlineContent } from "./inlineContentTypes";
 
+// the type of a block exposed to API consumers
 export type BlockTemplate<
   // Type of the block.
   // Examples might include: "paragraph", "heading", or "bulletListItem".
@@ -14,77 +16,102 @@ export type BlockTemplate<
   type: Type;
   props: Props;
   content: InlineContent[];
-  children: Block[];
 };
 
-export type DefaultBlockProps = {
-  backgroundColor: string;
-  textColor: string;
-  textAlignment: "left" | "center" | "right" | "justify";
+// information about a blocks props when defining Block types
+export type PropSpec = {
+  name: string;
+  values?: readonly string[];
+  default: string;
 };
 
-export type NumberedListItemBlock = BlockTemplate<
-  "numberedListItem",
-  DefaultBlockProps
->;
+// define the default Props
+export const defaultBlockProps = [
+  {
+    name: "backgroundColor",
+    default: "transparent", // TODO think if this makes sense
+  },
+  {
+    name: "textColor",
+    default: "black", // TODO
+  },
+  {
+    name: "textAlignment",
+    values: ["left", "center", "right", "justify"],
+    default: "left",
+  },
+] as const; // TODO: upgrade typescript and use satisfies PropSpec
 
-export type BulletListItemBlock = BlockTemplate<
-  "bulletListItem",
-  DefaultBlockProps
->;
-
-export type HeadingBlock = BlockTemplate<
-  "heading",
-  DefaultBlockProps & {
-    level: "1" | "2" | "3";
-  }
->;
-
-export type ParagraphBlock = BlockTemplate<"paragraph", DefaultBlockProps>;
-
-export type Block =
-  | ParagraphBlock
-  | HeadingBlock
-  | BulletListItemBlock
-  | NumberedListItemBlock;
-
-export type BlockIdentifier = string | Block;
+export type BlockIdentifier = string | { id: string };
 
 /** Define "Partial Blocks", these are for updating or creating blocks */
-export type PartialBlockTemplate<B extends Block> = B extends Block
-  ? Partial<Omit<B, "props" | "children" | "content" | "type">> & {
-      type?: B["type"];
-      props?: Partial<B["props"]>;
-      content?: string | PartialInlineContent[];
-      children?: PartialBlock[];
-    }
-  : never;
+export type PartialBlockTemplate<B extends BlockTemplate<any, any>> =
+  B extends BlockTemplate<any, any>
+    ? Partial<Omit<B, "props" | "children" | "content" | "type">> & {
+        type?: B["type"];
+        props?: Partial<B["props"]>;
+        content?: string | PartialInlineContent[];
+        children?: PartialBlockTemplate<B>[];
+      }
+    : never;
 
-export type PartialBlock = PartialBlockTemplate<Block>;
+// export type BlockPropsTemplate<
+//   B extends BlockTemplate<any, any>,
+//   Props
+// > = Props extends PartialBlockTemplate<B>["props"] ? keyof Props : never;
 
-export type BlockPropsTemplate<Props> = Props extends Block["props"]
-  ? keyof Props
-  : never;
+// ExtractElement is a utility typ for PropsFromPropSpec that extracts the element with a specific key K from a union type T
+// Example: ExtractElement<{ name: "level"; values: readonly ["warn", "error"]; }, "level"> will result in
+// { name: "level"; values: readonly ["warn", "error"]; }
+type ExtractElement<T, K> = T extends { name: K } ? T : never;
+
+// ConfigValue is a utility type for PropsFromPropSpec that gets the value type from an object T.
+// If T has a `values` property, it uses the element type of the tuple (indexed by `number`),
+// otherwise, it defaults to `string`.
+// Example: ConfigValue<{ values: readonly ["warn", "error"] }> will result in "warn" | "error"
+type ConfigValue<T> = T extends { values: readonly any[] }
+  ? T["values"][number]
+  : string;
+
+// PropsFromPropSpec is a mapped type that iterates over the keys (names) in the PropSpec array and constructs a
+// new object type with properties corresponding to the keys in the PropSpec array and their value types.
+// Example: With the provided PropSpec array:
+//    let config = [{ name: "level", values: ["warn", "error"] }, { name: "triggerOn", values: ["startup", "shutdown"] }, { name: "anystring" }] as const;
+// PropsFromPropSpec will result in
+//    { level: "warn" | "error", triggerOn: "startup" | "shutdown", anystring: string }
+export type PropsFromPropSpec<T extends readonly PropSpec[]> = {
+  [K in T[number]["name"]]: ConfigValue<ExtractElement<T[number], K>>;
+};
+
+// the return type of createBlockFromTiptapNode
+export type BlockSpec = ReturnType<typeof createBlockFromTiptapNode>;
+
+// create the Block type from registererd block types (BlockSpecs)
+export type BlockFromBlockSpec<T extends BlockSpec> = BlockTemplate<
+  T["type"],
+  PropsFromPropSpec<T["acceptedProps"]>
+>;
 
 /**
  * Expose blockProps. This is currently not very nice, but it's expected this
  * will change anyway once we allow for custom blocks
  */
+// TODO: we can now use BlockSpec values
 
-export const globalProps: Array<keyof DefaultBlockProps> = [
-  "backgroundColor",
-  "textColor",
-  "textAlignment",
-];
+// export const globalProps: Array<keyof DefaultBlockProps> = [
+//   "backgroundColor",
+//   "textColor",
+//   "textAlignment",
+// ];
 
-export const blockProps: Record<Block["type"], Set<string>> = {
-  paragraph: new Set<keyof ParagraphBlock["props"]>([...globalProps]),
-  heading: new Set<keyof HeadingBlock["props"]>([
-    ...globalProps,
-    "level" as const,
-  ]),
-  numberedListItem: new Set<keyof NumberedListItemBlock["props"]>([
-    ...globalProps,
-  ]),
-  bulletListItem: new Set<keyof BulletListItemBlock["props"]>([...globalProps]),
-};
+// export const blockProps: Record<Block["type"], Set<string>> = {
+//   paragraph: new Set<keyof ParagraphBlock["props"]>([...globalProps]),
+//   heading: new Set<keyof HeadingBlock["props"]>([
+//     ...globalProps,
+//     "level" as const,
+//   ]),
+//   numberedListItem: new Set<keyof NumberedListItemBlock["props"]>([
+//     ...globalProps,
+//   ]),
+//   bulletListItem: new Set<keyof BulletListItemBlock["props"]>([...globalProps]),
+// };

--- a/packages/core/src/extensions/Blocks/api/defaultBlocks.ts
+++ b/packages/core/src/extensions/Blocks/api/defaultBlocks.ts
@@ -1,0 +1,72 @@
+import { HeadingBlockContent } from "../nodes/BlockContent/HeadingBlockContent/HeadingBlockContent";
+import { BulletListItemBlockContent } from "../nodes/BlockContent/ListItemBlockContent/BulletListItemBlockContent/BulletListItemBlockContent";
+import { NumberedListItemBlockContent } from "../nodes/BlockContent/ListItemBlockContent/NumberedListItemBlockContent/NumberedListItemBlockContent";
+import { ParagraphBlockContent } from "../nodes/BlockContent/ParagraphBlockContent/ParagraphBlockContent";
+import { createBlockFromTiptapNode } from "./block";
+import { BlockFromBlockSpec, defaultBlockProps } from "./blockTypes";
+
+// this file defines the default blocks that are available in the editor
+// and their types (Block types)
+
+export const NumberedListItemBlock = createBlockFromTiptapNode(
+  "numberedListItem",
+  {
+    props: defaultBlockProps,
+  },
+  NumberedListItemBlockContent
+);
+
+export type NumberedListItemBlockType = BlockFromBlockSpec<
+  typeof NumberedListItemBlock
+>;
+
+export const BulletListItemBlock = createBlockFromTiptapNode(
+  "bulletListItem",
+  {
+    props: defaultBlockProps,
+  },
+  BulletListItemBlockContent
+);
+
+export type BulletListItemBlockType = BlockFromBlockSpec<
+  typeof BulletListItemBlock
+>;
+
+export const HeadingBlock = createBlockFromTiptapNode(
+  "heading",
+  {
+    props: [
+      ...defaultBlockProps,
+      {
+        name: "level",
+        values: ["1", "2", "3"],
+        default: "1",
+      },
+    ] as const,
+  },
+  HeadingBlockContent
+);
+
+export type HeadingBlockType = BlockFromBlockSpec<typeof HeadingBlock>;
+
+export const ParagraphBlock = createBlockFromTiptapNode(
+  "paragraph",
+  {
+    props: defaultBlockProps,
+  },
+  ParagraphBlockContent
+);
+
+export type ParagraphBlockType = BlockFromBlockSpec<typeof ParagraphBlock>;
+
+export const defaultBlocks = [
+  NumberedListItemBlock,
+  BulletListItemBlock,
+  HeadingBlock,
+  ParagraphBlock,
+];
+export type DefaultBlockTypes =
+  | NumberedListItemBlockType
+  | BulletListItemBlockType
+  | HeadingBlockType
+  | ParagraphBlockType;

--- a/packages/core/src/extensions/Blocks/index.ts
+++ b/packages/core/src/extensions/Blocks/index.ts
@@ -1,19 +1,11 @@
 import { Node } from "@tiptap/core";
 import { BlockContainer } from "./nodes/BlockContainer";
-import { BlockGroup } from "./nodes/BlockGroup";
-import { ParagraphBlockContent } from "./nodes/BlockContent/ParagraphBlockContent/ParagraphBlockContent";
-import { HeadingBlockContent } from "./nodes/BlockContent/HeadingBlockContent/HeadingBlockContent";
-import { BulletListItemBlockContent } from "./nodes/BlockContent/ListItemBlockContent/BulletListItemBlockContent/BulletListItemBlockContent";
-import { NumberedListItemBlockContent } from "./nodes/BlockContent/ListItemBlockContent/NumberedListItemBlockContent/NumberedListItemBlockContent";
+import { TableCol } from "./nodes/BlockContent/TableContent/TableCol";
 import { TableContent } from "./nodes/BlockContent/TableContent/TableContent";
 import { TableRow } from "./nodes/BlockContent/TableContent/TableRow";
-import { TableCol } from "./nodes/BlockContent/TableContent/TableCol";
+import { BlockGroup } from "./nodes/BlockGroup";
 
 export const blocks: any[] = [
-  ParagraphBlockContent,
-  HeadingBlockContent,
-  BulletListItemBlockContent,
-  NumberedListItemBlockContent,
   TableContent,
   TableRow,
   TableCol,


### PR DESCRIPTION
I'm curious what you think if this approach. I think this direction will make it possible to register custom blocks while keeping a strongly typed API.

This PR does:

- refactor of registration of built-in block types. 
- makes it possible to have a strongly typed `BlockNoteEditor` which API matches the Blocks that have been defined. This will make it possible to add support for custom blocks, while keeping a strongly typed API
- As part of this, `globalProps` and `blockProps` have been removed, because they should be dynamically configurable as well (based on the "registered blocks" in the editor).

TODO:
- make it compile (nodeToBlock, etc)
- use the new BlockSpec types instead of `globalProps` / `blockProps`
- how to handle markdown / html
- design + implement custom block interface
- test / add tests
- ...