### PR TITLE
fix: slashmenu dropdown positioning on edge of page

### DIFF
--- a/packages/react/src/SlashMenu/components/SlashMenu.tsx
+++ b/packages/react/src/SlashMenu/components/SlashMenu.tsx
@@ -1,7 +1,9 @@
-import { createStyles, Menu } from "@mantine/core";
 import * as _ from "lodash";
-import { SlashMenuItem } from "./SlashMenuItem";
+
+import { Menu, createStyles } from "@mantine/core";
+
 import { ReactSlashMenuItem } from "../ReactSlashMenuItem";
+import { SlashMenuItem } from "./SlashMenuItem";
 
 export type SlashMenuProps = {
   items: ReactSlashMenuItem[];
@@ -49,7 +51,8 @@ export function SlashMenu(props: SlashMenuProps) {
        */
       defaultOpened={true}
       trigger={"hover"}
-      closeDelay={10000000}>
+      closeDelay={10000000}
+      styles={{ dropdown: { position: "static" } }}>
       <Menu.Dropdown className={classes.root}>
         {renderedItems.length > 0 ? (
           renderedItems


### PR DESCRIPTION
martine menu dropdown position style is set to "absolute". 
The tippy container's ( the parent of dropdown menu ) computed width and height are 0.
This makes popper overflow not work when change the type of last several blocks.

before fix, popper's overflow detection not work:
![Screenshot 2023-04-14 at 18 17 10](https://user-images.githubusercontent.com/101185214/232019936-95c5ce87-c585-49e2-a5f6-b7359e62842f.png)

after fix, popper's default flip behavior work:
![Screenshot 2023-04-14 at 18 22 11](https://user-images.githubusercontent.com/101185214/232019181-85ccc108-1d72-4053-8213-5710beed59bf.png)
