### PR TITLE
fix: dragging multiple blocks

### DIFF
--- a/packages/core/src/extensions/DraggableBlocks/DraggableBlocksPlugin.ts
+++ b/packages/core/src/extensions/DraggableBlocks/DraggableBlocksPlugin.ts
@@ -208,7 +208,9 @@ function dragStart(e: DragEvent, view: EditorView) {
     const { from, to } = blockPositionsFromSelection(selection, doc);
 
     const draggedBlockInSelection = from <= pos && pos < to;
-    const multipleBlocksSelected = selection.$anchor.node() !== selection.$head.node() || selection instanceof MultipleNodeSelection;
+    const multipleBlocksSelected =
+      selection.$anchor.node() !== selection.$head.node() ||
+      selection instanceof MultipleNodeSelection;
 
     if (draggedBlockInSelection && multipleBlocksSelected) {
       view.dispatch(

--- a/packages/core/src/extensions/DraggableBlocks/DraggableBlocksPlugin.ts
+++ b/packages/core/src/extensions/DraggableBlocks/DraggableBlocksPlugin.ts
@@ -208,7 +208,7 @@ function dragStart(e: DragEvent, view: EditorView) {
     const { from, to } = blockPositionsFromSelection(selection, doc);
 
     const draggedBlockInSelection = from <= pos && pos < to;
-    const multipleBlocksSelected = selection.$anchor.node() !== selection.$head.node();
+    const multipleBlocksSelected = selection.$anchor.node() !== selection.$head.node() || selection instanceof MultipleNodeSelection;
 
     if (draggedBlockInSelection && multipleBlocksSelected) {
       view.dispatch(

--- a/packages/core/src/extensions/DraggableBlocks/DraggableBlocksPlugin.ts
+++ b/packages/core/src/extensions/DraggableBlocks/DraggableBlocksPlugin.ts
@@ -208,9 +208,7 @@ function dragStart(e: DragEvent, view: EditorView) {
     const { from, to } = blockPositionsFromSelection(selection, doc);
 
     const draggedBlockInSelection = from <= pos && pos < to;
-    const multipleBlocksSelected = !selection.$anchor
-      .node()
-      .eq(selection.$head.node());
+    const multipleBlocksSelected = selection.$anchor.node() !== selection.$head.node();
 
     if (draggedBlockInSelection && multipleBlocksSelected) {
       view.dispatch(


### PR DESCRIPTION
Solves: https://github.com/TypeCellOS/BlockNote/issues/80

[Nodes eq method](https://github.com/ProseMirror/prosemirror-model/blob/95298fb02744e1a8f41eae50f8a6afde583a8817/src/node.js#L118) returns true if the two nodes are either the same instance or if their markup and content is the same. In this case the markup or content of the Nodes do not matter and the condition should only be true when the instance is not the same.

When dropping a selection of multiple blocks outside of the editor the selection type stays the same as it got set [here](https://github.com/TypeCellOS/BlockNote/blob/main/packages/core/src/extensions/DraggableBlocks/DraggableBlocksPlugin.ts#L217). If the selection gets dragged again and is of type `MultipleNodeSelection` we can be sure that the user drags multiple blocks at once. 