### PR TITLE
Use correct defaultItems in the React Slash Menu Example

### DIFF
--- a/packages/website/docs/docs/slash-menu.md
+++ b/packages/website/docs/docs/slash-menu.md
@@ -44,12 +44,11 @@ BlockNote comes with a variety of built-in Slash Menu items, which are used to c
 If you want to change, remove & reorder the default items , you first import and copy them to a new array. From there, you can edit the array how you like, then pass it to `useBlockNote`:
 
 ```typescript
-import { defaultSlashMenuItems } from "@blocknote/core";
-import { BlockNoteView, useBlockNote } from "@blocknote/react";
+import { BlockNoteView, useBlockNote, defaultReactSlashMenuItems } from "@blocknote/react";
 import "@blocknote/core/style.css";
 
 function App() {
-  const newSlashMenuItems: ReactSlashMenuItem[] = defaultSlashMenuItems;
+  const newSlashMenuItems: ReactSlashMenuItem[] = defaultReactSlashMenuItems;
 
   // Edit newSlashMenuItems
   ...


### PR DESCRIPTION
```typescript
import { BlockNoteView, useBlockNote, defaultReactSlashMenuItems } from "@blocknote/react";
import "@blocknote/core/style.css";

function App() {
  const newSlashMenuItems: ReactSlashMenuItem[] = defaultReactSlashMenuItems;

  // Edit newSlashMenuItems
  ...

  const editor = useBlockNote({ slashMenuItems: newSlashMenuItems });

  return <BlockNoteView editor={editor} />;
}
```

Currently the example says:
`const newSlashMenuItems: ReactSlashMenuItem[] = defaultSlashMenuItems;`
leading to a type mismatch```
 type 'BaseSlashMenuItem[]' is not assignable to type 'ReactSlashMenuItem[]'.
  Type 'BaseSlashMenuItem' is missing the following properties from type 'ReactSlashMenuItem': group, iconts(2322)
```


This PR solves the issue by using the correct `defaultReactSlashMenuItems`