### PR TITLE
Drag handle add button test fix

### DIFF
--- a/tests/end-to-end/draghandle/draghandle.test.ts
+++ b/tests/end-to-end/draghandle/draghandle.test.ts
@@ -134,6 +134,8 @@ test.describe("Check Draghandle functionality", () => {
   test("Click add button for non-selected empty block", async () => {
     await executeSlashCommand(page, "h1");
     await page.keyboard.type("Heading 1");
+    // Wait for animation to finish
+    await page.waitForTimeout(350);
     await hoverAndAddBlockFromDragHandle(page, PARAGRAPH_SELECTOR, "h1");
 
     await compareDocToSnapshot(page, "addnonselectedemptyblock");

--- a/tests/end-to-end/draghandle/draghandle.test.ts-snapshots/addnonselectedemptyblock-chromium-linux.json
+++ b/tests/end-to-end/draghandle/draghandle.test.ts-snapshots/addnonselectedemptyblock-chromium-linux.json
@@ -30,7 +30,7 @@
         {
           "type": "blockContainer",
           "attrs": {
-            "id": "2",
+            "id": "1",
             "textColor": "default",
             "backgroundColor": "default"
           },
@@ -47,7 +47,7 @@
         {
           "type": "blockContainer",
           "attrs": {
-            "id": "1",
+            "id": "2",
             "textColor": "default",
             "backgroundColor": "default"
           },

--- a/tests/end-to-end/draghandle/draghandle.test.ts-snapshots/addnonselectedemptyblock-firefox-linux.json
+++ b/tests/end-to-end/draghandle/draghandle.test.ts-snapshots/addnonselectedemptyblock-firefox-linux.json
@@ -30,7 +30,7 @@
         {
           "type": "blockContainer",
           "attrs": {
-            "id": "2",
+            "id": "1",
             "textColor": "default",
             "backgroundColor": "default"
           },
@@ -47,7 +47,7 @@
         {
           "type": "blockContainer",
           "attrs": {
-            "id": "1",
+            "id": "2",
             "textColor": "default",
             "backgroundColor": "default"
           },

--- a/tests/end-to-end/draghandle/draghandle.test.ts-snapshots/addnonselectedemptyblock-webkit-linux.json
+++ b/tests/end-to-end/draghandle/draghandle.test.ts-snapshots/addnonselectedemptyblock-webkit-linux.json
@@ -30,7 +30,7 @@
         {
           "type": "blockContainer",
           "attrs": {
-            "id": "2",
+            "id": "1",
             "textColor": "default",
             "backgroundColor": "default"
           },
@@ -47,7 +47,7 @@
         {
           "type": "blockContainer",
           "attrs": {
-            "id": "1",
+            "id": "2",
             "textColor": "default",
             "backgroundColor": "default"
           },


### PR DESCRIPTION
One of the drag handle tests was causing issues after the latest release since it wasn't waiting for a heading animation to finish, but this PR fixes it.