### PR TITLE
fix: Address React Warning when clicking DragHandleMenuItem

### DIFF
--- a/packages/react/src/BlockSideMenu/components/DragHandleMenuItem.tsx
+++ b/packages/react/src/BlockSideMenu/components/DragHandleMenuItem.tsx
@@ -5,13 +5,14 @@ export type DragHandleMenuItemProps = PolymorphicComponentProps<"button"> & {
   closeMenu: () => void;
 };
 
-export const DragHandleMenuItem = (props: DragHandleMenuItemProps) => (
-  <Menu.Item
-    {...props}
+export const DragHandleMenuItem = (props: DragHandleMenuItemProps) => {
+  const {closeMenu, onClick, ...propsToPassThrough} = props;
+  return <Menu.Item
+    {...propsToPassThrough}
     onClick={(event) => {
-      props.closeMenu();
-      props.onClick?.(event);
+      closeMenu();
+      onClick?.(event);
     }}>
     {props.children}
-  </Menu.Item>
-);
+  </Menu.Item>;
+};


### PR DESCRIPTION
Filter out closeMenu from the props so React stops warning about it.

To generate the warning without this change, simply click on the drag handle menu with your dev console open.

![Screenshot 2023-05-24 at 8 26 20 PM](https://github.com/TypeCellOS/BlockNote/assets/39360/c6a5c6d4-666c-4ed7-a6c4-376fb94f4924)
