### PR TITLE
Custom blocks docs

### DIFF
--- a/packages/core/src/editor.module.css
+++ b/packages/core/src/editor.module.css
@@ -38,7 +38,6 @@ Tippy popups that are appended to document.body directly
 .defaultStyles h3,
 .defaultStyles li {
   all: unset !important;
-  flex-grow: 1 !important;
   margin: 0;
   padding: 0;
   font-size: inherit;

--- a/packages/core/src/extensions/Blocks/api/block.ts
+++ b/packages/core/src/extensions/Blocks/api/block.ts
@@ -186,6 +186,14 @@ export function createBlockSpec<
 
         // Render elements
         const rendered = blockConfig.render(block as any, editor);
+        // Add inlineContent class to inline content
+        if ("contentDOM" in rendered) {
+          rendered.contentDOM.className = `${
+            rendered.contentDOM.className
+              ? rendered.contentDOM.className + " "
+              : ""
+          }${styles.inlineContent}`;
+        }
         // Add elements to blockContent
         blockContent.appendChild(rendered.dom);
 

--- a/packages/core/src/extensions/Blocks/nodes/Block.module.css
+++ b/packages/core/src/extensions/Blocks/nodes/Block.module.css
@@ -7,14 +7,25 @@ BASIC STYLES
   transition: margin 0.2s;
 }
 
+/*Ensures blocks & block content spans editor width*/
+.block {
+  display: flex;
+}
+
+/*Ensures block content inside React node views spans editor width*/
+.reactNodeViewRenderer {
+  display: flex;
+  flex-grow: 1;
+}
+
 .blockContent {
   padding: 3px 0;
+  flex-grow: 1;
   transition: font-size 0.2s;
   /*
   because the content elements are display: block
   we use flex to position them next to list markers
   */
-  display: flex;
 }
 
 .blockContent::before {
@@ -225,8 +236,8 @@ NESTED BLOCKS
 
 /* PLACEHOLDERS*/
 
-.blockContent.isEmpty > :first-child:before,
-.blockContent.isFilter > :first-child:before {
+.isEmpty .inlineContent:before,
+.isFilter .inlineContent:before {
   /*float: left; */
   content: "";
   pointer-events: none;
@@ -236,33 +247,33 @@ NESTED BLOCKS
   font-style: italic;
 }
 
-[data-theme="light"] .blockContent.isEmpty > :first-child:before,
-.blockContent.isFilter > :first-child:before {
+[data-theme="light"] .isEmpty .inlineContent:before,
+.isFilter .inlineContent:before {
   color: #cccccc;
 }
 
-[data-theme="dark"] .blockContent.isEmpty > :first-child:before,
-.blockContent.isFilter > :first-child:before {
+[data-theme="dark"] .isEmpty .inlineContent:before,
+.isFilter .inlineContent:before {
   color: #999999;
 }
 
 /* TODO: would be nicer if defined from code */
 
-.blockContent.isEmpty.hasAnchor > :first-child:before {
+.isEmpty.hasAnchor .inlineContent:before {
   content: "Enter text or type '/' for commands";
 }
 
-.blockContent.isFilter.hasAnchor > :first-child:before {
+.blockContent.isFilter.hasAnchor .inlineContent:before {
   content: "Type to filter";
 }
 
-.blockContent[data-content-type="heading"].isEmpty > :first-child::before {
+.blockContent[data-content-type="heading"].isEmpty .inlineContent:before {
   content: "Heading";
 }
 
-.blockContent[data-content-type="bulletListItem"].isEmpty > :first-child:before,
+.blockContent[data-content-type="bulletListItem"].isEmpty .inlineContent:before,
 .blockContent[data-content-type="numberedListItem"].isEmpty
-  > :first-child:before {
+.inlineContent:before {
   content: "List";
 }
 

--- a/packages/core/src/extensions/Blocks/nodes/Block.module.css
+++ b/packages/core/src/extensions/Blocks/nodes/Block.module.css
@@ -10,6 +10,7 @@ BASIC STYLES
 /*Ensures blocks & block content spans editor width*/
 .block {
   display: flex;
+  flex-direction: column;
 }
 
 /*Ensures block content inside React node views spans editor width*/

--- a/packages/core/src/extensions/Blocks/nodes/BlockContent/HeadingBlockContent/HeadingBlockContent.ts
+++ b/packages/core/src/extensions/Blocks/nodes/BlockContent/HeadingBlockContent/HeadingBlockContent.ts
@@ -70,7 +70,7 @@ export const HeadingBlockContent = createTipTapBlock<"heading">({
         class: styles.blockContent,
         "data-content-type": this.name,
       }),
-      ["h" + node.attrs.level, 0],
+      ["h" + node.attrs.level, { class: styles.inlineContent }, 0],
     ];
   },
 });

--- a/packages/core/src/extensions/Blocks/nodes/BlockContent/ListItemBlockContent/BulletListItemBlockContent/BulletListItemBlockContent.ts
+++ b/packages/core/src/extensions/Blocks/nodes/BlockContent/ListItemBlockContent/BulletListItemBlockContent/BulletListItemBlockContent.ts
@@ -88,7 +88,7 @@ export const BulletListItemBlockContent = createTipTapBlock<"bulletListItem">({
         class: styles.blockContent,
         "data-content-type": this.name,
       }),
-      ["p", 0],
+      ["p", { class: styles.inlineContent }, 0],
     ];
   },
 });

--- a/packages/core/src/extensions/Blocks/nodes/BlockContent/ListItemBlockContent/NumberedListItemBlockContent/NumberedListItemBlockContent.ts
+++ b/packages/core/src/extensions/Blocks/nodes/BlockContent/ListItemBlockContent/NumberedListItemBlockContent/NumberedListItemBlockContent.ts
@@ -114,7 +114,7 @@ export const NumberedListItemBlockContent =
         }),
         // we use a <p> tag, because for <li> tags we'd need to add a <ul> parent for around siblings to be semantically correct,
         // which would be quite cumbersome
-        ["p", 0],
+        ["p", { class: styles.inlineContent }, 0],
       ];
     },
   });

--- a/packages/core/src/extensions/Blocks/nodes/BlockContent/ParagraphBlockContent/ParagraphBlockContent.ts
+++ b/packages/core/src/extensions/Blocks/nodes/BlockContent/ParagraphBlockContent/ParagraphBlockContent.ts
@@ -23,7 +23,7 @@ export const ParagraphBlockContent = createTipTapBlock<"paragraph">({
         class: styles.blockContent,
         "data-content-type": this.name,
       }),
-      ["p", 0],
+      ["p", { class: styles.inlineContent }, 0],
     ];
   },
 });

--- a/packages/core/src/extensions/Placeholder/PlaceholderExtension.ts
+++ b/packages/core/src/extensions/Placeholder/PlaceholderExtension.ts
@@ -72,6 +72,7 @@ export const Placeholder = Extension.create<PlaceholderOptions>({
               if ((hasAnchor || !this.options.showOnlyCurrent) && isEmpty) {
                 const classes = [this.options.emptyNodeClass];
 
+                // TODO: Doesn't work?
                 if (this.editor.isEmpty) {
                   classes.push(this.options.emptyEditorClass);
                 }

--- a/packages/react/src/FormattingToolbar/components/DefaultButtons/TextAlignButton.tsx
+++ b/packages/react/src/FormattingToolbar/components/DefaultButtons/TextAlignButton.tsx
@@ -1,9 +1,10 @@
 import {
   BlockNoteEditor,
-  DefaultBlockSchema,
+  BlockSchema,
   DefaultProps,
+  PartialBlock,
 } from "@blocknote/core";
-import { useCallback } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { IconType } from "react-icons";
 import {
   RiAlignCenter,
@@ -22,10 +23,31 @@ const icons: Record<TextAlignment, IconType> = {
   justify: RiAlignJustify,
 };
 
-export const TextAlignButton = (props: {
-  editor: BlockNoteEditor<DefaultBlockSchema>;
+export const TextAlignButton = <BSchema extends BlockSchema>(props: {
+  editor: BlockNoteEditor<BSchema>;
   textAlignment: TextAlignment;
 }) => {
+  const [show, setShow] = useState(true);
+
+  useEffect(() => {
+    const selection = props.editor.getSelection();
+
+    if (selection) {
+      for (const block of selection.blocks) {
+        if (!("textAlignment" in block.props)) {
+          setShow(false);
+        }
+      }
+    } else {
+      const block = props.editor.getTextCursorPosition().block;
+      console.log(block);
+
+      if (!("textAlignment" in block.props)) {
+        setShow(false);
+      }
+    }
+  }, [props.editor]);
+
   const setTextAlignment = useCallback(
     (textAlignment: TextAlignment) => {
       props.editor.focus();
@@ -36,16 +58,22 @@ export const TextAlignButton = (props: {
         for (const block of selection.blocks) {
           props.editor.updateBlock(block, {
             props: { textAlignment: textAlignment },
-          });
+          } as PartialBlock<BSchema>);
         }
       } else {
-        props.editor.updateBlock(props.editor.getTextCursorPosition().block, {
+        const block = props.editor.getTextCursorPosition().block;
+
+        props.editor.updateBlock(block, {
           props: { textAlignment: textAlignment },
-        });
+        } as PartialBlock<BSchema>);
       }
     },
     [props.editor]
   );
+
+  if (!show) {
+    return null;
+  }
 
   return (
     <ToolbarButton

--- a/packages/react/src/ReactBlockSpec.tsx
+++ b/packages/react/src/ReactBlockSpec.tsx
@@ -11,12 +11,11 @@ import {
 } from "@blocknote/core";
 import {
   NodeViewContent,
-  NodeViewContentProps,
   NodeViewProps,
   NodeViewWrapper,
   ReactNodeViewRenderer,
 } from "@tiptap/react";
-import { FC } from "react";
+import { FC, HTMLAttributes } from "react";
 import { blockStyles } from "@blocknote/core";
 
 // extend BlockConfig but use a react render function
@@ -39,8 +38,13 @@ export type ReactBlockConfig<
   }>;
 };
 
-export const ContentDOM = (props: NodeViewContentProps) => (
-  <NodeViewContent {...props} />
+export const InlineContent = (props: HTMLAttributes<HTMLDivElement>) => (
+  <NodeViewContent
+    {...props}
+    className={`${props.className ? props.className + " " : ""}${
+      blockStyles.inlineContent
+    }`}
+  />
 );
 
 // A function to create custom block for API consumers
@@ -115,7 +119,9 @@ export function createReactBlockSpec<
         );
       };
 
-      return ReactNodeViewRenderer(BlockContent);
+      return ReactNodeViewRenderer(BlockContent, {
+        className: blockStyles.reactNodeViewRenderer,
+      });
     },
   });
 

--- a/packages/react/src/SharedComponents/Toolbar/components/ToolbarDropdown.tsx
+++ b/packages/react/src/SharedComponents/Toolbar/components/ToolbarDropdown.tsx
@@ -18,6 +18,10 @@ export type ToolbarDropdownProps = {
 export function ToolbarDropdown(props: ToolbarDropdownProps) {
   const activeItem = props.items.filter((p) => p.isSelected)[0];
 
+  if (!activeItem) {
+    return null;
+  }
+
   return (
     <Menu exitTransitionDuration={0} disabled={props.isDisabled}>
       <Menu.Target>

--- a/packages/website/docs/docs/block-types.md
+++ b/packages/website/docs/docs/block-types.md
@@ -110,19 +110,25 @@ In addition to the default block types that BlockNote offers, you can also make 
 import {
   BlockNoteEditor,
   defaultBlockSchema,
+  defaultProps,
 } from "@blocknote/core";
 import {
   BlockNoteView,
   useBlockNote,
-  createReactBlockSpec
-} from "@blocknote/core";
-
+  createReactBlockSpec,
+  InlineContent,
+  ReactSlashMenuItem,
+  defaultReactSlashMenuItems,
+} from "@blocknote/react";
 import "@blocknote/core/style.css";
+import { RiImage2Fill } from "react-icons/ri";
 
 export default function App() {
+  // Configuration for a custom image block.
   const ImageBlockConfig = {
     type: "image",
     propSchema: {
+      ...defaultProps,
       src: {
         default: "https://via.placeholder.com/1000",
       },
@@ -133,8 +139,7 @@ export default function App() {
         style={{
         display: "flex",
           flexDirection: "column",
-        }}
-      >
+      }}>
         <img
           style={{
             width: "100%",
@@ -145,10 +150,35 @@ export default function App() {
         />
         <InlineContent />
       </div>
-    )
+    ),
   };
 
+  // Converts the image block config to a BlockSpec for BlockNote to use.
   const ImageBlock = createReactBlockSpec(ImageBlockConfig);
+
+  // Creates a slash menu item for inserting an image block.
+  const insertImage = new ReactSlashMenuItem(
+    "Insert Image",
+    (editor) => {
+      const src: string | null = prompt("Enter image URL");
+      editor.insertBlocks(
+        [
+          {
+            type: "image",
+            props: {
+              src: src || "https://via.placeholder.com/1000",
+            },
+          },
+        ],
+        editor.getTextCursorPosition().block,
+        "after"
+      );
+    },
+    ["image", "img", "picture", "media"],
+    "Media",
+    <RiImage2Fill />,
+    "Insert an image"
+  );
 
   // Creates a new editor instance.
   const editor: BlockNoteEditor | null = useBlockNote({
@@ -159,7 +189,8 @@ export default function App() {
       // Adds the custom image block.
       image: ImageBlock,
     },
-  })
+    slashCommands: [...defaultReactSlashMenuItems, insertImage],
+  });
 
   // Renders the editor instance using a React component.
   return <BlockNoteView editor={editor} />;
@@ -260,21 +291,12 @@ After creating `BlockConfig`s for all of our custom blocks, we need to convert t
 function createReactBlockSpec(blockConfig: BlockConfig): BlockSpec {...};
 ```
 
-Now, all we need to do is pass it to the editor using the `blockSchema` option, which tells BlockNote which blocks to use. Let's look again at the image block from the demo as an example:
+Now, all we need to do is pass it to the editor using the `blockSchema` option, which tells BlockNote which blocks to use. Let's again look at the image block from the demo as an example:
 
 ```typescript jsx
-import {
-  BlockNoteEditor,
-  defaultBlockSchema,
-} from "@blocknote/core";
-import {
-  useBlockNote,
-  createReactBlockSpec
-} from "@blocknote/core";
+const ImageBlock = createReactBlockSpec(ImageBlockConfig);
 
 ...
-
-const ImageBlock = createReactBlockSpec(ImageBlockConfig);
 
 // Creates a new editor instance.
 const editor: BlockNoteEditor | null = useBlockNote({

--- a/packages/website/docs/docs/blocks.md
+++ b/packages/website/docs/docs/blocks.md
@@ -51,7 +51,7 @@ type Block = {
 
 `props:` The block's properties, which are stored in a set of key/value pairs and specify how the block looks and behaves. Different block types have different props - see [Block Types & Properties](/docs/block-types) for more.
 
-`content:` The block's content, represented as an array of `InlineContent` objects. This does not include content from any nested blocks. For more information on `InlineContent` objects, visit [Inline Content](/docs/inline-content).
+`content:` The block's rich text content, represented as an array of `InlineContent` objects. This does not include content from any nested blocks. For more information on `InlineContent` objects, visit [Inline Content](/docs/inline-content).
 
 `children:` Any blocks nested inside the block. The nested blocks are also represented using `Block` objects.
 

--- a/tests/utils/customblocks/Alert.tsx
+++ b/tests/utils/customblocks/Alert.tsx
@@ -45,7 +45,7 @@ export const Alert = createBlockSpec({
     const parent = document.createElement("div");
     parent.setAttribute(
       "style",
-      `display: flex; flex-grow: 1; background-color: ${
+      `display: flex; background-color: ${
         values[block.props.type as keyof typeof values].backgroundColor
       }`
     );

--- a/tests/utils/customblocks/Image.tsx
+++ b/tests/utils/customblocks/Image.tsx
@@ -7,7 +7,7 @@ export const Image = createBlockSpec({
   propSchema: {
     ...defaultProps,
     src: {
-      default: "https://via.placeholder.com/150",
+      default: "https://via.placeholder.com/1000",
     },
   } as const,
   containsInlineContent: true,
@@ -15,11 +15,13 @@ export const Image = createBlockSpec({
     const image = document.createElement("img");
     image.setAttribute("src", block.props.src);
     image.setAttribute("contenteditable", "false");
-    image.setAttribute("border", "1px solid black");
+    image.setAttribute("style", "width: 100%");
 
     const caption = document.createElement("div");
+    caption.setAttribute("style", "flex-grow: 1");
 
     const parent = document.createElement("div");
+    parent.setAttribute("style", "display: flex; flex-direction: column;");
     parent.appendChild(image);
     parent.appendChild(caption);
 

--- a/tests/utils/customblocks/ReactAlert.tsx
+++ b/tests/utils/customblocks/ReactAlert.tsx
@@ -1,5 +1,5 @@
 import {
-  ContentDOM,
+  InlineContent,
   createReactBlockSpec,
   ReactSlashMenuItem,
 } from "@blocknote/react";
@@ -98,7 +98,7 @@ export const ReactAlert = createReactBlockSpec({
           }}>
           {values[type as keyof typeof values].icon}
         </div>
-        <ContentDOM />
+        <InlineContent />
       </div>
     );
   },

--- a/tests/utils/customblocks/ReactImage.tsx
+++ b/tests/utils/customblocks/ReactImage.tsx
@@ -1,0 +1,58 @@
+import {
+  InlineContent,
+  createReactBlockSpec,
+  ReactSlashMenuItem,
+} from "@blocknote/react";
+import { defaultProps } from "@blocknote/core";
+import { RiImage2Fill } from "react-icons/ri";
+
+export const ReactImage = createReactBlockSpec({
+  type: "reactImage" as const,
+  propSchema: {
+    ...defaultProps,
+    src: {
+      default: "https://via.placeholder.com/1000",
+    },
+  } as const,
+  containsInlineContent: true,
+  render: ({ block }) => {
+    return (
+      <div
+        style={{
+          display: "flex",
+          flexDirection: "column",
+        }}>
+        <img
+          style={{
+            width: "100%",
+          }}
+          src={block.props.src}
+          alt={"Image"}
+          contentEditable={false}
+        />
+        <InlineContent />
+      </div>
+    );
+  },
+});
+
+export const insertReactImage = new ReactSlashMenuItem<{
+  reactImage: typeof ReactImage;
+}>(
+  "Insert React Image",
+  (editor) => {
+    editor.insertBlocks(
+      [
+        {
+          type: "reactImage",
+        },
+      ],
+      editor.getTextCursorPosition().block,
+      "after"
+    );
+  },
+  ["react", "reactImage", "react image", "image", "img", "picture", "media"],
+  "Media",
+  <RiImage2Fill />,
+  "Insert an image"
+);


### PR DESCRIPTION
This PR adds documentation for custom blocks and fixes a few smaller issues with them. There are still a few things that need changing:

- [ ] Automatically setting `contentEditable="false"` on all elements except the `contentDOM`/`InlineContent` and its ancestors (https://discuss.prosemirror.net/t/contenteditable-islands-prevents-selection/3938).
- [ ] Finalize naming for types & functions.
- [ ] Make it so you don't have to call `createBlockSpec` manually? Not sure if this is something we want since we probably want to keep the ability to create BlockSpecs from scratch and add them to the schema.