### PR TITLE
fix: Error caused by converting `hardBreak` nodes

### DIFF
--- a/packages/core/src/api/nodeConversions/__snapshots__/nodeConversions.test.ts.snap
+++ b/packages/core/src/api/nodeConversions/__snapshots__/nodeConversions.test.ts.snap
@@ -183,6 +183,298 @@ exports[`Simple ProseMirror Node Conversions > Convert simple node to block 1`] 
 }
 `;
 
+exports[`hard breaks > Convert a block with a hard break 1`] = `
+{
+  "attrs": {
+    "backgroundColor": "default",
+    "id": "4",
+    "textColor": "default",
+  },
+  "content": [
+    {
+      "attrs": {
+        "textAlignment": "left",
+      },
+      "content": [
+        {
+          "text": "Text1",
+          "type": "text",
+        },
+        {
+          "type": "hardBreak",
+        },
+        {
+          "text": "Text2",
+          "type": "text",
+        },
+      ],
+      "type": "paragraph",
+    },
+  ],
+  "type": "blockContainer",
+}
+`;
+
+exports[`hard breaks > Convert a block with a hard break and different styles 1`] = `
+{
+  "attrs": {
+    "backgroundColor": "default",
+    "id": "4",
+    "textColor": "default",
+  },
+  "content": [
+    {
+      "attrs": {
+        "textAlignment": "left",
+      },
+      "content": [
+        {
+          "text": "Text1",
+          "type": "text",
+        },
+        {
+          "type": "hardBreak",
+        },
+        {
+          "marks": [
+            {
+              "type": "bold",
+            },
+          ],
+          "text": "Text2",
+          "type": "text",
+        },
+      ],
+      "type": "paragraph",
+    },
+  ],
+  "type": "blockContainer",
+}
+`;
+
+exports[`hard breaks > Convert a block with a hard break at the end 1`] = `
+{
+  "attrs": {
+    "backgroundColor": "default",
+    "id": "4",
+    "textColor": "default",
+  },
+  "content": [
+    {
+      "attrs": {
+        "textAlignment": "left",
+      },
+      "content": [
+        {
+          "text": "Text1",
+          "type": "text",
+        },
+        {
+          "type": "hardBreak",
+        },
+      ],
+      "type": "paragraph",
+    },
+  ],
+  "type": "blockContainer",
+}
+`;
+
+exports[`hard breaks > Convert a block with a hard break at the start 1`] = `
+{
+  "attrs": {
+    "backgroundColor": "default",
+    "id": "4",
+    "textColor": "default",
+  },
+  "content": [
+    {
+      "attrs": {
+        "textAlignment": "left",
+      },
+      "content": [
+        {
+          "type": "hardBreak",
+        },
+        {
+          "text": "Text1",
+          "type": "text",
+        },
+      ],
+      "type": "paragraph",
+    },
+  ],
+  "type": "blockContainer",
+}
+`;
+
+exports[`hard breaks > Convert a block with a hard break between links 1`] = `
+{
+  "attrs": {
+    "backgroundColor": "default",
+    "id": "4",
+    "textColor": "default",
+  },
+  "content": [
+    {
+      "attrs": {
+        "textAlignment": "left",
+      },
+      "content": [
+        {
+          "marks": [
+            {
+              "attrs": {
+                "class": null,
+                "href": "https://www.website.com",
+                "target": "_blank",
+              },
+              "type": "link",
+            },
+          ],
+          "text": "Link1",
+          "type": "text",
+        },
+        {
+          "type": "hardBreak",
+        },
+        {
+          "marks": [
+            {
+              "attrs": {
+                "class": null,
+                "href": "https://www.website2.com",
+                "target": "_blank",
+              },
+              "type": "link",
+            },
+          ],
+          "text": "Link2",
+          "type": "text",
+        },
+      ],
+      "type": "paragraph",
+    },
+  ],
+  "type": "blockContainer",
+}
+`;
+
+exports[`hard breaks > Convert a block with a hard break in a link 1`] = `
+{
+  "attrs": {
+    "backgroundColor": "default",
+    "id": "4",
+    "textColor": "default",
+  },
+  "content": [
+    {
+      "attrs": {
+        "textAlignment": "left",
+      },
+      "content": [
+        {
+          "marks": [
+            {
+              "attrs": {
+                "class": null,
+                "href": "https://www.website.com",
+                "target": "_blank",
+              },
+              "type": "link",
+            },
+          ],
+          "text": "Link1",
+          "type": "text",
+        },
+        {
+          "type": "hardBreak",
+        },
+        {
+          "marks": [
+            {
+              "attrs": {
+                "class": null,
+                "href": "https://www.website.com",
+                "target": "_blank",
+              },
+              "type": "link",
+            },
+          ],
+          "text": "Link1",
+          "type": "text",
+        },
+      ],
+      "type": "paragraph",
+    },
+  ],
+  "type": "blockContainer",
+}
+`;
+
+exports[`hard breaks > Convert a block with multiple hard breaks 1`] = `
+{
+  "attrs": {
+    "backgroundColor": "default",
+    "id": "4",
+    "textColor": "default",
+  },
+  "content": [
+    {
+      "attrs": {
+        "textAlignment": "left",
+      },
+      "content": [
+        {
+          "text": "Text1",
+          "type": "text",
+        },
+        {
+          "type": "hardBreak",
+        },
+        {
+          "text": "Text2",
+          "type": "text",
+        },
+        {
+          "type": "hardBreak",
+        },
+        {
+          "text": "Text3",
+          "type": "text",
+        },
+      ],
+      "type": "paragraph",
+    },
+  ],
+  "type": "blockContainer",
+}
+`;
+
+exports[`hard breaks > Convert a block with only a hard break 1`] = `
+{
+  "attrs": {
+    "backgroundColor": "default",
+    "id": "4",
+    "textColor": "default",
+  },
+  "content": [
+    {
+      "attrs": {
+        "textAlignment": "left",
+      },
+      "content": [
+        {
+          "type": "hardBreak",
+        },
+      ],
+      "type": "paragraph",
+    },
+  ],
+  "type": "blockContainer",
+}
+`;
+
 exports[`links > Convert a block with link 1`] = `
 {
   "attrs": {

--- a/packages/core/src/api/nodeConversions/nodeConversions.test.ts
+++ b/packages/core/src/api/nodeConversions/nodeConversions.test.ts
@@ -261,3 +261,239 @@ describe("links", () => {
     expect(outputBlock).toStrictEqual(fullOriginalBlock);
   });
 });
+
+describe("hard breaks", () => {
+  it("Convert a block with a hard break", async () => {
+    const block: PartialBlock<DefaultBlockSchema> = {
+      id: UniqueID.options.generateID(),
+      type: "paragraph",
+      content: [
+        {
+          type: "text",
+          text: "Text1\nText2",
+          styles: {},
+        },
+      ],
+    };
+    const node = blockToNode(block, tt.schema);
+    expect(node).toMatchSnapshot();
+    const outputBlock = nodeToBlock<DefaultBlockSchema>(
+      node,
+      defaultBlockSchema
+    );
+
+    // Temporary fix to set props to {}, because at this point
+    // we don't have an easy way to access default props at runtime,
+    // so partialBlockToBlockForTesting will not set them.
+    (outputBlock as any).props = {};
+    const fullOriginalBlock = partialBlockToBlockForTesting(block);
+
+    expect(outputBlock).toStrictEqual(fullOriginalBlock);
+  });
+
+  it("Convert a block with multiple hard breaks", async () => {
+    const block: PartialBlock<DefaultBlockSchema> = {
+      id: UniqueID.options.generateID(),
+      type: "paragraph",
+      content: [
+        {
+          type: "text",
+          text: "Text1\nText2\nText3",
+          styles: {},
+        },
+      ],
+    };
+    const node = blockToNode(block, tt.schema);
+    expect(node).toMatchSnapshot();
+    const outputBlock = nodeToBlock<DefaultBlockSchema>(
+      node,
+      defaultBlockSchema
+    );
+
+    // Temporary fix to set props to {}, because at this point
+    // we don't have an easy way to access default props at runtime,
+    // so partialBlockToBlockForTesting will not set them.
+    (outputBlock as any).props = {};
+    const fullOriginalBlock = partialBlockToBlockForTesting(block);
+
+    expect(outputBlock).toStrictEqual(fullOriginalBlock);
+  });
+
+  it("Convert a block with a hard break at the start", async () => {
+    const block: PartialBlock<DefaultBlockSchema> = {
+      id: UniqueID.options.generateID(),
+      type: "paragraph",
+      content: [
+        {
+          type: "text",
+          text: "\nText1",
+          styles: {},
+        },
+      ],
+    };
+    const node = blockToNode(block, tt.schema);
+    expect(node).toMatchSnapshot();
+    const outputBlock = nodeToBlock<DefaultBlockSchema>(
+      node,
+      defaultBlockSchema
+    );
+
+    // Temporary fix to set props to {}, because at this point
+    // we don't have an easy way to access default props at runtime,
+    // so partialBlockToBlockForTesting will not set them.
+    (outputBlock as any).props = {};
+    const fullOriginalBlock = partialBlockToBlockForTesting(block);
+
+    expect(outputBlock).toStrictEqual(fullOriginalBlock);
+  });
+
+  it("Convert a block with a hard break at the end", async () => {
+    const block: PartialBlock<DefaultBlockSchema> = {
+      id: UniqueID.options.generateID(),
+      type: "paragraph",
+      content: [
+        {
+          type: "text",
+          text: "Text1\n",
+          styles: {},
+        },
+      ],
+    };
+    const node = blockToNode(block, tt.schema);
+    expect(node).toMatchSnapshot();
+    const outputBlock = nodeToBlock<DefaultBlockSchema>(
+      node,
+      defaultBlockSchema
+    );
+
+    // Temporary fix to set props to {}, because at this point
+    // we don't have an easy way to access default props at runtime,
+    // so partialBlockToBlockForTesting will not set them.
+    (outputBlock as any).props = {};
+    const fullOriginalBlock = partialBlockToBlockForTesting(block);
+
+    expect(outputBlock).toStrictEqual(fullOriginalBlock);
+  });
+
+  it("Convert a block with only a hard break", async () => {
+    const block: PartialBlock<DefaultBlockSchema> = {
+      id: UniqueID.options.generateID(),
+      type: "paragraph",
+      content: [
+        {
+          type: "text",
+          text: "\n",
+          styles: {},
+        },
+      ],
+    };
+    const node = blockToNode(block, tt.schema);
+    expect(node).toMatchSnapshot();
+    const outputBlock = nodeToBlock<DefaultBlockSchema>(
+      node,
+      defaultBlockSchema
+    );
+
+    // Temporary fix to set props to {}, because at this point
+    // we don't have an easy way to access default props at runtime,
+    // so partialBlockToBlockForTesting will not set them.
+    (outputBlock as any).props = {};
+    const fullOriginalBlock = partialBlockToBlockForTesting(block);
+
+    expect(outputBlock).toStrictEqual(fullOriginalBlock);
+  });
+
+  it("Convert a block with a hard break and different styles", async () => {
+    const block: PartialBlock<DefaultBlockSchema> = {
+      id: UniqueID.options.generateID(),
+      type: "paragraph",
+      content: [
+        {
+          type: "text",
+          text: "Text1\n",
+          styles: {},
+        },
+        {
+          type: "text",
+          text: "Text2",
+          styles: { bold: true },
+        },
+      ],
+    };
+    const node = blockToNode(block, tt.schema);
+    expect(node).toMatchSnapshot();
+    const outputBlock = nodeToBlock<DefaultBlockSchema>(
+      node,
+      defaultBlockSchema
+    );
+
+    // Temporary fix to set props to {}, because at this point
+    // we don't have an easy way to access default props at runtime,
+    // so partialBlockToBlockForTesting will not set them.
+    (outputBlock as any).props = {};
+    const fullOriginalBlock = partialBlockToBlockForTesting(block);
+
+    expect(outputBlock).toStrictEqual(fullOriginalBlock);
+  });
+
+  it("Convert a block with a hard break in a link", async () => {
+    const block: PartialBlock<DefaultBlockSchema> = {
+      id: UniqueID.options.generateID(),
+      type: "paragraph",
+      content: [
+        {
+          type: "link",
+          href: "https://www.website.com",
+          content: "Link1\nLink1",
+        },
+      ],
+    };
+    const node = blockToNode(block, tt.schema);
+    expect(node).toMatchSnapshot();
+    const outputBlock = nodeToBlock<DefaultBlockSchema>(
+      node,
+      defaultBlockSchema
+    );
+
+    // Temporary fix to set props to {}, because at this point
+    // we don't have an easy way to access default props at runtime,
+    // so partialBlockToBlockForTesting will not set them.
+    (outputBlock as any).props = {};
+    const fullOriginalBlock = partialBlockToBlockForTesting(block);
+
+    expect(outputBlock).toStrictEqual(fullOriginalBlock);
+  });
+
+  it("Convert a block with a hard break between links", async () => {
+    const block: PartialBlock<DefaultBlockSchema> = {
+      id: UniqueID.options.generateID(),
+      type: "paragraph",
+      content: [
+        {
+          type: "link",
+          href: "https://www.website.com",
+          content: "Link1\n",
+        },
+        {
+          type: "link",
+          href: "https://www.website2.com",
+          content: "Link2",
+        },
+      ],
+    };
+    const node = blockToNode(block, tt.schema);
+    expect(node).toMatchSnapshot();
+    const outputBlock = nodeToBlock<DefaultBlockSchema>(
+      node,
+      defaultBlockSchema
+    );
+
+    // Temporary fix to set props to {}, because at this point
+    // we don't have an easy way to access default props at runtime,
+    // so partialBlockToBlockForTesting will not set them.
+    (outputBlock as any).props = {};
+    const fullOriginalBlock = partialBlockToBlockForTesting(block);
+
+    expect(outputBlock).toStrictEqual(fullOriginalBlock);
+  });
+});

--- a/packages/core/src/api/nodeConversions/nodeConversions.ts
+++ b/packages/core/src/api/nodeConversions/nodeConversions.ts
@@ -76,7 +76,10 @@ function linkToNodes(link: PartialLink, schema: Schema): Node[] {
       return node.mark([...node.marks, linkMark]);
     }
 
-    return node;
+    if (node.type.name === "hardBreak") {
+      return node;
+    }
+    throw new Error("unexpected node type");
   });
 }
 
@@ -189,20 +192,18 @@ function contentNodeToInlineContent(contentNode: Node) {
     // hardBreak nodes do not have an InlineContent equivalent, instead we
     // add a newline to the previous node.
     if (node.type.name === "hardBreak") {
-      // Current content exists.
       if (currentContent) {
-        // Current content is text.
+        // Current content exists.
         if (currentContent.type === "text") {
+          // Current content is text.
           currentContent.text += "\n";
-        }
-        // Current content is a link.
-        else if (currentContent.type === "link") {
+        } else if (currentContent.type === "link") {
+          // Current content is a link.
           currentContent.content[currentContent.content.length - 1].text +=
             "\n";
         }
-      }
-      // Current content does not exist.
-      else {
+      } else {
+        // Current content does not exist.
         currentContent = {
           type: "text",
           text: "\n",
@@ -233,16 +234,15 @@ function contentNodeToInlineContent(contentNode: Node) {
     if (currentContent) {
       // Current content is text.
       if (currentContent.type === "text") {
-        // Node is text (same type as current content).
         if (!linkMark) {
-          // Styles are the same.
+          // Node is text (same type as current content).
           if (
             JSON.stringify(currentContent.styles) === JSON.stringify(styles)
           ) {
+            // Styles are the same.
             currentContent.text += node.textContent;
-          }
-          // Styles are different.
-          else {
+          } else {
+            // Styles are different.
             content.push(currentContent);
             currentContent = {
               type: "text",
@@ -250,9 +250,8 @@ function contentNodeToInlineContent(contentNode: Node) {
               styles,
             };
           }
-        }
-        // Node is a link (different type to current content).
-        else {
+        } else {
+          // Node is a link (different type to current content).
           content.push(currentContent);
           currentContent = {
             type: "link",
@@ -266,11 +265,10 @@ function contentNodeToInlineContent(contentNode: Node) {
             ],
           };
         }
-      }
-      // Current content is a link.
-      else if (currentContent.type === "link") {
-        // Node is a link (same type as current content).
+      } else if (currentContent.type === "link") {
+        // Current content is a link.
         if (linkMark) {
+          // Node is a link (same type as current content).
           // Link URLs are the same.
           if (currentContent.href === linkMark.attrs.href) {
             // Styles are the same.
@@ -281,18 +279,16 @@ function contentNodeToInlineContent(contentNode: Node) {
             ) {
               currentContent.content[currentContent.content.length - 1].text +=
                 node.textContent;
-            }
-            // Styles are different.
-            else {
+            } else {
+              // Styles are different.
               currentContent.content.push({
                 type: "text",
                 text: node.textContent,
                 styles,
               });
             }
-          }
-          // Link URLs are different.
-          else {
+          } else {
+            // Link URLs are different.
             content.push(currentContent);
             currentContent = {
               type: "link",
@@ -306,9 +302,8 @@ function contentNodeToInlineContent(contentNode: Node) {
               ],
             };
           }
-        }
-        // Node is text (different type to current content).
-        else {
+        } else {
+          // Node is text (different type to current content).
           content.push(currentContent);
           currentContent = {
             type: "text",

--- a/packages/core/src/extensions/Blocks/api/inlineContentTypes.ts
+++ b/packages/core/src/extensions/Blocks/api/inlineContentTypes.ts
@@ -22,10 +22,6 @@ export type StyledText = {
   styles: Styles;
 };
 
-export type HardBreak = {
-  type: "break";
-};
-
 export type Link = {
   type: "link";
   href: string;
@@ -36,5 +32,5 @@ export type PartialLink = Omit<Link, "content"> & {
   content: string | Link["content"];
 };
 
-export type InlineContent = StyledText | HardBreak | Link;
-export type PartialInlineContent = StyledText | HardBreak | PartialLink;
+export type InlineContent = StyledText | Link;
+export type PartialInlineContent = StyledText | PartialLink;

--- a/packages/core/src/extensions/Blocks/api/inlineContentTypes.ts
+++ b/packages/core/src/extensions/Blocks/api/inlineContentTypes.ts
@@ -22,6 +22,10 @@ export type StyledText = {
   styles: Styles;
 };
 
+export type HardBreak = {
+  type: "break";
+};
+
 export type Link = {
   type: "link";
   href: string;
@@ -32,5 +36,5 @@ export type PartialLink = Omit<Link, "content"> & {
   content: string | Link["content"];
 };
 
-export type InlineContent = StyledText | Link;
-export type PartialInlineContent = StyledText | PartialLink;
+export type InlineContent = StyledText | HardBreak | Link;
+export type PartialInlineContent = StyledText | HardBreak | PartialLink;


### PR DESCRIPTION
When you press Shift+Tab in a block, it creates a new line in the same block which TIpTap/ProseMirror store as a `hardBreak` node. It turns out we completely forgot about these when doing inline content conversions, so this PR remedies that.

This also fixes the `Empty text nodes are not allowed` error that some people have been getting, mentioned in issues #184 and #216.

Closes #184
Closes #216