### PR TITLE
fix: Side menu showing when editor isn't focused.

### DIFF
--- a/packages/core/src/BlockNoteEditor.ts
+++ b/packages/core/src/BlockNoteEditor.ts
@@ -154,6 +154,10 @@ export class BlockNoteEditor<BSchema extends BlockSchema = DefaultBlockSchema> {
     return this._tiptapEditor.view.dom as HTMLDivElement;
   }
 
+  public isFocused() {
+    return this._tiptapEditor.view.hasFocus();
+  }
+
   public focus() {
     this._tiptapEditor.view.focus();
   }

--- a/packages/core/src/extensions/DraggableBlocks/DraggableBlocksPlugin.ts
+++ b/packages/core/src/extensions/DraggableBlocks/DraggableBlocksPlugin.ts
@@ -375,6 +375,21 @@ export class BlockMenuView<BSchema extends BlockSchema> {
       return;
     }
 
+    // Checks if the block side menu should be hidden when the editor isn't
+    // focused.
+    if (
+      // Either editor should be focused
+      !this.editor.isFocused() &&
+      // Or the block side menu should be focused (e.g. dragging, clicking)
+      document.activeElement !== this.blockMenu.element &&
+      !this.blockMenu.element?.contains(document.activeElement) &&
+      // And the menu should be open
+      this.menuOpen
+    ) {
+      this.blockMenu.hide();
+      return;
+    }
+
     // Editor itself may have padding or other styling which affects size/position, so we get the boundingRect of
     // the first child (i.e. the blockGroup that wraps all blocks in the editor) for a more accurate bounding box.
     const editorBoundingBox = (


### PR DESCRIPTION
It probably doesn't make sense to show the block side menu if the editor isn't focused, since the user could be interacting with elements somewhere completely different in the page and it's just distracting to have the side menu moving around. See issue #201 for an example of this. This PR makes it so that the side menu is hidden when the editor or its menus aren't focused.

There is another approach to this, i.e. exposing a `forceSideMenuHide` function in the API, though imo the former solution is more intuitive and requires less from consumers.

Closes #201
Also helps with #185, but doesn't solve the issue completely