### PR TITLE
fix: Formatting Toolbar not hiding when clicking on elements outside it

### DIFF
--- a/packages/core/src/extensions/FormattingToolbar/FormattingToolbarPlugin.ts
+++ b/packages/core/src/extensions/FormattingToolbar/FormattingToolbarPlugin.ts
@@ -110,9 +110,13 @@ export class FormattingToolbarView<BSchema extends BlockSchema> {
       return;
     }
 
+    // Checks if the focus is moving to an element outside the editor. If it is,
+    // the toolbar is hidden.
     if (
+      // An element is clicked.
       event &&
       event.relatedTarget &&
+      // Element is outside the toolbar.
       (this.formattingToolbar.element === (event.relatedTarget as Node) ||
         this.formattingToolbar.element?.contains(event.relatedTarget as Node))
     ) {

--- a/packages/core/src/extensions/FormattingToolbar/FormattingToolbarPlugin.ts
+++ b/packages/core/src/extensions/FormattingToolbar/FormattingToolbarPlugin.ts
@@ -169,12 +169,6 @@ export class FormattingToolbarView<BSchema extends BlockSchema> {
       this.formattingToolbar.render(this.getDynamicParams(), true);
       this.toolbarIsOpen = true;
 
-      // TODO: Is this necessary? Also for other menu plugins.
-      // Listener stops focus moving to the menu on click.
-      this.formattingToolbar.element!.addEventListener("mousedown", (event) =>
-        event.preventDefault()
-      );
-
       return;
     }
 
@@ -196,12 +190,6 @@ export class FormattingToolbarView<BSchema extends BlockSchema> {
     ) {
       this.formattingToolbar.hide();
       this.toolbarIsOpen = false;
-
-      // Listener stops focus moving to the menu on click.
-      this.formattingToolbar.element!.removeEventListener(
-        "mousedown",
-        (event) => event.preventDefault()
-      );
 
       return;
     }

--- a/packages/core/src/extensions/FormattingToolbar/FormattingToolbarPlugin.ts
+++ b/packages/core/src/extensions/FormattingToolbar/FormattingToolbarPlugin.ts
@@ -111,10 +111,10 @@ export class FormattingToolbarView<BSchema extends BlockSchema> {
     }
 
     if (
-      event?.relatedTarget &&
-      this.formattingToolbar.element?.parentNode?.contains(
-        event.relatedTarget as Node
-      )
+      event &&
+      event.relatedTarget &&
+      (this.formattingToolbar.element === (event.relatedTarget as Node) ||
+        this.formattingToolbar.element?.contains(event.relatedTarget as Node))
     ) {
       return;
     }

--- a/packages/core/src/extensions/HyperlinkToolbar/HyperlinkToolbarPlugin.ts
+++ b/packages/core/src/extensions/HyperlinkToolbar/HyperlinkToolbarPlugin.ts
@@ -57,6 +57,7 @@ class HyperlinkToolbarView {
     };
 
     this.editor.view.dom.addEventListener("mouseover", this.mouseOverHandler);
+    document.addEventListener("click", this.clickHandler, true);
     document.addEventListener("scroll", this.scrollHandler);
   }
 
@@ -99,6 +100,24 @@ class HyperlinkToolbarView {
     this.startMenuUpdateTimer();
 
     return false;
+  };
+
+  clickHandler = (event: MouseEvent) => {
+    if (
+      // Toolbar is open.
+      this.hyperlinkMark &&
+      // An element is clicked.
+      event &&
+      event.target &&
+      // Element is outside the editor.
+      this.editor.view.dom !== (event.target as Node) &&
+      !this.editor.view.dom.contains(event.target as Node) &&
+      // Element is outside the toolbar.
+      this.hyperlinkToolbar.element !== (event.target as Node) &&
+      !this.hyperlinkToolbar.element?.contains(event.target as Node)
+    ) {
+      this.hyperlinkToolbar.hide();
+    }
   };
 
   scrollHandler = () => {

--- a/packages/react/src/FormattingToolbar/components/LinkToolbarButton.tsx
+++ b/packages/react/src/FormattingToolbar/components/LinkToolbarButton.tsx
@@ -62,7 +62,6 @@ export const LinkToolbarButton = (props: HyperlinkButtonProps) => {
 
   return (
     <Tippy
-      appendTo={document.body}
       content={creationMenu}
       onShow={updateCreationMenu}
       interactive={true}


### PR DESCRIPTION
The formatting toolbar is supposed to hide if the editor blurs, unless the element the focus is moving to is the formatting toolbar itself. The condition which checked for this was incorrect, and instead checked if the focus moved to any descendant of the formatting toolbar's parent element. Since the formatting toolbar gets appended to the `doc`, it meant that the toolbar would not be closed if clicking on any element inside the `doc`.

Closes #161

TODO:
- [x] Fix Tippy in the link creation menu
  - Link creation menu inputs are not selectable if the popup is appended to the button. Has to be appended to `document.body` to select inputs with the mouse. Because of that, toolbar disappears since popup is not a descendant. There is an easy fix but it's extremely ugly.
- [x] Fix hyperlink toolbar also not disappearing