### PR TITLE
chore: setup typescript project references so IDE shows hints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,7 @@ packages/*/types
 examples/*/types
 /.pnp
 .pnp.js
-
+tsconfig.tsbuildinfo
 # testing
 coverage
 

--- a/examples/editor/tsconfig.json
+++ b/examples/editor/tsconfig.json
@@ -14,14 +14,13 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
-    "jsx": "react-jsx"
-    // "paths": {
-    //   "@blocknote/core": ["../../packages/core/src"]
-    // }
+    "jsx": "react-jsx",
+    "composite": true
   },
   "include": ["src"],
   "references": [
-    { "path": "./tsconfig.node.json" }
-    // { "path": "../../packages/core/tsconfig.json" }
+    { "path": "./tsconfig.node.json" },
+    { "path": "../../packages/core/" },
+    { "path": "../../packages/react/" }
   ]
 }

--- a/examples/vanilla/tsconfig.json
+++ b/examples/vanilla/tsconfig.json
@@ -14,14 +14,16 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
-    "jsx": "react-jsx"
+    "jsx": "react-jsx",
+    "composite": true
     // "paths": {
     //   "@blocknote/core": ["../../packages/core/src"]
     // }
   },
   "include": ["src"],
   "references": [
-    { "path": "./tsconfig.node.json" }
-    // { "path": "../../packages/core/tsconfig.json" }
+    { "path": "./tsconfig.node.json" },
+    { "path": "../../packages/core/" },
+    { "path": "../../packages/react/" }
   ]
 }

--- a/packages/react/tsconfig.json
+++ b/packages/react/tsconfig.json
@@ -20,5 +20,10 @@
     "composite": true,
     "skipLibCheck": true
   },
-  "include": ["src"]
+  "include": ["src"],
+  "references": [
+    {
+      "path": "../core"
+    }
+  ]
 }

--- a/packages/website/tsconfig.json
+++ b/packages/website/tsconfig.json
@@ -18,7 +18,8 @@
     "skipLibCheck": true,
     "paths": {
       "@theme/*": ["./docs/.vitepress/theme/*"]
-    }
+    },
+    "composite": true
   },
   "include": [
     "src",
@@ -28,5 +29,6 @@
     // Also need to explicitly include Markdown files to have TS intellisense work with Volar
     "docs/**/*.md"
   ],
+  "references": [{ "path": "../core/" }, { "path": "../react/" }],
   "exclude": ["node_modules/"]
 }


### PR DESCRIPTION
This should enable IDE hints for typescript types across packages, without requiring a new build

Discussed on discord: https://discord.com/channels/928190961455087667/1015169282444894219/1119898650231971921