### PR TITLE
fix: Scrolling responsiveness & UI element overflow

### DIFF
--- a/examples/vanilla/src/ui/blockSideMenuFactory.ts
+++ b/examples/vanilla/src/ui/blockSideMenuFactory.ts
@@ -37,9 +37,9 @@ export const blockSideMenuFactory: BlockSideMenuFactory<DefaultBlockSchema> = (
         container.style.display = "block";
       }
 
-      container.style.top = params.referenceRect.y + "px";
+      container.style.top = staticParams.getReferenceRect()!.y + "px";
       container.style.left =
-        params.referenceRect.x - container.offsetWidth + "px";
+        staticParams.getReferenceRect()!.x - container.offsetWidth + "px";
     },
     hide: () => {
       container.style.display = "none";

--- a/examples/vanilla/src/ui/formattingToolbarFactory.ts
+++ b/examples/vanilla/src/ui/formattingToolbarFactory.ts
@@ -38,8 +38,8 @@ export const formattingToolbarFactory: FormattingToolbarFactory<
         "bold" in staticParams.editor.getActiveStyles()
           ? "unset bold"
           : "set bold";
-      container.style.top = params.referenceRect.y + "px";
-      container.style.left = params.referenceRect.x + "px";
+      container.style.top = staticParams.getReferenceRect()!.y + "px";
+      container.style.left = staticParams.getReferenceRect()!.x + "px";
     },
     hide: () => {
       container.style.display = "none";

--- a/examples/vanilla/src/ui/hyperlinkToolbarFactory.ts
+++ b/examples/vanilla/src/ui/hyperlinkToolbarFactory.ts
@@ -43,8 +43,8 @@ export const hyperlinkToolbarFactory: HyperlinkToolbarFactory = (
         container.style.display = "block";
       }
 
-      container.style.top = params.referenceRect.y + "px";
-      container.style.left = params.referenceRect.x + "px";
+      container.style.top = staticParams.getReferenceRect()!.y + "px";
+      container.style.left = staticParams.getReferenceRect()!.x + "px";
     },
     hide: () => {
       container.style.display = "none";

--- a/examples/vanilla/src/ui/slashMenuFactory.ts
+++ b/examples/vanilla/src/ui/slashMenuFactory.ts
@@ -53,8 +53,8 @@ export const slashMenuFactory: SuggestionsMenuFactory<
         container.style.display = "block";
       }
 
-      container.style.top = params.referenceRect.y + "px";
-      container.style.left = params.referenceRect.x + "px";
+      container.style.top = staticParams.getReferenceRect()!.y + "px";
+      container.style.left = staticParams.getReferenceRect()!.x + "px";
     },
     hide: () => {
       container.style.display = "none";

--- a/packages/core/src/extensions/DraggableBlocks/BlockSideMenuFactoryTypes.ts
+++ b/packages/core/src/extensions/DraggableBlocks/BlockSideMenuFactoryTypes.ts
@@ -12,6 +12,8 @@ export type BlockSideMenuStaticParams<BSchema extends BlockSchema> = {
 
   freezeMenu: () => void;
   unfreezeMenu: () => void;
+
+  getReferenceRect: () => DOMRect | undefined;
 };
 
 export type BlockSideMenuDynamicParams<BSchema extends BlockSchema> = {

--- a/packages/core/src/extensions/DraggableBlocks/BlockSideMenuFactoryTypes.ts
+++ b/packages/core/src/extensions/DraggableBlocks/BlockSideMenuFactoryTypes.ts
@@ -18,8 +18,6 @@ export type BlockSideMenuStaticParams<BSchema extends BlockSchema> = {
 
 export type BlockSideMenuDynamicParams<BSchema extends BlockSchema> = {
   block: Block<BSchema>;
-
-  referenceRect: DOMRect;
 };
 
 export type BlockSideMenu<BSchema extends BlockSchema> = EditorElement<

--- a/packages/core/src/extensions/DraggableBlocks/BlockSideMenuFactoryTypes.ts
+++ b/packages/core/src/extensions/DraggableBlocks/BlockSideMenuFactoryTypes.ts
@@ -13,7 +13,7 @@ export type BlockSideMenuStaticParams<BSchema extends BlockSchema> = {
   freezeMenu: () => void;
   unfreezeMenu: () => void;
 
-  getReferenceRect: () => DOMRect | undefined;
+  getReferenceRect: () => DOMRect;
 };
 
 export type BlockSideMenuDynamicParams<BSchema extends BlockSchema> = {

--- a/packages/core/src/extensions/DraggableBlocks/DraggableBlocksPlugin.ts
+++ b/packages/core/src/extensions/DraggableBlocks/DraggableBlocksPlugin.ts
@@ -250,6 +250,8 @@ export class BlockMenuView<BSchema extends BlockSchema> {
   menuOpen = false;
   menuFrozen = false;
 
+  private lastPosition: DOMRect | undefined;
+
   constructor({
     tiptapEditor,
     editor,
@@ -271,9 +273,6 @@ export class BlockMenuView<BSchema extends BlockSchema> {
 
     // Shows or updates menu position whenever the cursor moves, if the menu isn't frozen.
     document.body.addEventListener("mousemove", this.onMouseMove, true);
-
-    // Makes menu scroll with the page.
-    document.addEventListener("scroll", this.onScroll);
 
     // Hides and unfreezes the menu whenever the user selects the editor with the mouse or presses a key.
     // TODO: Better integration with suggestions menu and only editor scope?
@@ -463,20 +462,6 @@ export class BlockMenuView<BSchema extends BlockSchema> {
     }
   };
 
-  onScroll = () => {
-    // Editor itself may have padding or other styling which affects size/position, so we get the boundingRect of
-    // the first child (i.e. the blockGroup that wraps all blocks in the editor) for a more accurate bounding box.
-    const editorBoundingBox = (
-      this.ttEditor.view.dom.firstChild! as HTMLElement
-    ).getBoundingClientRect();
-
-    this.horizontalPosAnchor = editorBoundingBox.x;
-
-    if (this.menuOpen) {
-      this.blockMenu.render(this.getDynamicParams(), false);
-    }
-  };
-
   destroy() {
     if (this.menuOpen) {
       this.menuOpen = false;
@@ -487,7 +472,6 @@ export class BlockMenuView<BSchema extends BlockSchema> {
     this.ttEditor.view.dom.removeEventListener("dragstart", this.onDragStart);
     document.body.removeEventListener("drop", this.onDrop);
     document.body.removeEventListener("mousedown", this.onMouseDown);
-    document.removeEventListener("scroll", this.onScroll);
     document.body.removeEventListener("keydown", this.onKeyDown);
   }
 
@@ -558,11 +542,12 @@ export class BlockMenuView<BSchema extends BlockSchema> {
       },
       getReferenceRect: () => {
         if (!this.menuOpen) {
-          return;
+          return this.lastPosition;
         }
 
         const blockContent = this.hoveredBlock!.firstChild! as HTMLElement;
         const blockContentBoundingBox = blockContent.getBoundingClientRect();
+        this.lastPosition = blockContentBoundingBox;
 
         return new DOMRect(
           this.horizontalPosAnchoredAtRoot

--- a/packages/core/src/extensions/DraggableBlocks/DraggableBlocksPlugin.ts
+++ b/packages/core/src/extensions/DraggableBlocks/DraggableBlocksPlugin.ts
@@ -556,6 +556,23 @@ export class BlockMenuView<BSchema extends BlockSchema> {
       unfreezeMenu: () => {
         this.menuFrozen = false;
       },
+      getReferenceRect: () => {
+        if (!this.menuOpen) {
+          return;
+        }
+
+        const blockContent = this.hoveredBlock!.firstChild! as HTMLElement;
+        const blockContentBoundingBox = blockContent.getBoundingClientRect();
+
+        return new DOMRect(
+          this.horizontalPosAnchoredAtRoot
+            ? this.horizontalPosAnchor
+            : blockContentBoundingBox.x,
+          blockContentBoundingBox.y,
+          blockContentBoundingBox.width,
+          blockContentBoundingBox.height
+        );
+      },
     };
   }
 

--- a/packages/core/src/extensions/DraggableBlocks/DraggableBlocksPlugin.ts
+++ b/packages/core/src/extensions/DraggableBlocks/DraggableBlocksPlugin.ts
@@ -542,21 +542,23 @@ export class BlockMenuView<BSchema extends BlockSchema> {
       },
       getReferenceRect: () => {
         if (!this.menuOpen) {
+          if (this.lastPosition === undefined) {
+            throw new Error(
+              "Attempted to access block reference rect before rendering block side menu."
+            );
+          }
+
           return this.lastPosition;
         }
 
         const blockContent = this.hoveredBlock!.firstChild! as HTMLElement;
         const blockContentBoundingBox = blockContent.getBoundingClientRect();
+        if (this.horizontalPosAnchoredAtRoot) {
+          blockContentBoundingBox.x = this.horizontalPosAnchor;
+        }
         this.lastPosition = blockContentBoundingBox;
 
-        return new DOMRect(
-          this.horizontalPosAnchoredAtRoot
-            ? this.horizontalPosAnchor
-            : blockContentBoundingBox.x,
-          blockContentBoundingBox.y,
-          blockContentBoundingBox.width,
-          blockContentBoundingBox.height
-        );
+        return blockContentBoundingBox;
       },
     };
   }

--- a/packages/core/src/extensions/DraggableBlocks/DraggableBlocksPlugin.ts
+++ b/packages/core/src/extensions/DraggableBlocks/DraggableBlocksPlugin.ts
@@ -562,19 +562,8 @@ export class BlockMenuView<BSchema extends BlockSchema> {
   }
 
   getDynamicParams(): BlockSideMenuDynamicParams<BSchema> {
-    const blockContent = this.hoveredBlock!.firstChild! as HTMLElement;
-    const blockContentBoundingBox = blockContent.getBoundingClientRect();
-
     return {
       block: this.editor.getBlock(this.hoveredBlock!.getAttribute("data-id")!)!,
-      referenceRect: new DOMRect(
-        this.horizontalPosAnchoredAtRoot
-          ? this.horizontalPosAnchor
-          : blockContentBoundingBox.x,
-        blockContentBoundingBox.y,
-        blockContentBoundingBox.width,
-        blockContentBoundingBox.height
-      ),
     };
   }
 }

--- a/packages/core/src/extensions/FormattingToolbar/FormattingToolbarFactoryTypes.ts
+++ b/packages/core/src/extensions/FormattingToolbar/FormattingToolbarFactoryTypes.ts
@@ -8,9 +8,7 @@ export type FormattingToolbarStaticParams<BSchema extends BlockSchema> = {
   getReferenceRect: () => DOMRect | undefined;
 };
 
-export type FormattingToolbarDynamicParams = {
-  referenceRect: DOMRect;
-};
+export type FormattingToolbarDynamicParams = {};
 
 export type FormattingToolbar = EditorElement<FormattingToolbarDynamicParams>;
 export type FormattingToolbarFactory<BSchema extends BlockSchema> =

--- a/packages/core/src/extensions/FormattingToolbar/FormattingToolbarFactoryTypes.ts
+++ b/packages/core/src/extensions/FormattingToolbar/FormattingToolbarFactoryTypes.ts
@@ -5,7 +5,7 @@ import { BlockSchema } from "../Blocks/api/blockTypes";
 export type FormattingToolbarStaticParams<BSchema extends BlockSchema> = {
   editor: BlockNoteEditor<BSchema>;
 
-  getReferenceRect: () => DOMRect | undefined;
+  getReferenceRect: () => DOMRect;
 };
 
 export type FormattingToolbarDynamicParams = {};

--- a/packages/core/src/extensions/FormattingToolbar/FormattingToolbarFactoryTypes.ts
+++ b/packages/core/src/extensions/FormattingToolbar/FormattingToolbarFactoryTypes.ts
@@ -4,15 +4,15 @@ import { BlockSchema } from "../Blocks/api/blockTypes";
 
 export type FormattingToolbarStaticParams<BSchema extends BlockSchema> = {
   editor: BlockNoteEditor<BSchema>;
+
+  getReferenceRect: () => DOMRect | undefined;
 };
 
 export type FormattingToolbarDynamicParams = {
   referenceRect: DOMRect;
 };
 
-export type FormattingToolbar = EditorElement<
-  FormattingToolbarDynamicParams
->;
+export type FormattingToolbar = EditorElement<FormattingToolbarDynamicParams>;
 export type FormattingToolbarFactory<BSchema extends BlockSchema> =
   ElementFactory<
     FormattingToolbarStaticParams<BSchema>,

--- a/packages/core/src/extensions/FormattingToolbar/FormattingToolbarPlugin.ts
+++ b/packages/core/src/extensions/FormattingToolbar/FormattingToolbarPlugin.ts
@@ -233,6 +233,8 @@ export class FormattingToolbarView<BSchema extends BlockSchema> {
   getStaticParams(): FormattingToolbarStaticParams<BSchema> {
     return {
       editor: this.editor,
+      getReferenceRect: () =>
+        this.toolbarIsOpen ? this.getSelectionBoundingBox() : undefined,
     };
   }
 

--- a/packages/core/src/extensions/FormattingToolbar/FormattingToolbarPlugin.ts
+++ b/packages/core/src/extensions/FormattingToolbar/FormattingToolbarPlugin.ts
@@ -226,6 +226,12 @@ export class FormattingToolbarView<BSchema extends BlockSchema> {
       editor: this.editor,
       getReferenceRect: () => {
         if (!this.toolbarIsOpen) {
+          if (this.lastPosition === undefined) {
+            throw new Error(
+              "Attempted to access selection reference rect before rendering formatting toolbar."
+            );
+          }
+
           return this.lastPosition;
         }
 

--- a/packages/core/src/extensions/FormattingToolbar/FormattingToolbarPlugin.ts
+++ b/packages/core/src/extensions/FormattingToolbar/FormattingToolbarPlugin.ts
@@ -44,6 +44,8 @@ export class FormattingToolbarView<BSchema extends BlockSchema> {
 
   public prevWasEditable: boolean | null = null;
 
+  private lastPosition: DOMRect | undefined;
+
   public shouldShow: (props: {
     view: EditorView;
     state: EditorState;
@@ -80,8 +82,6 @@ export class FormattingToolbarView<BSchema extends BlockSchema> {
 
     this.ttEditor.on("focus", this.focusHandler);
     this.ttEditor.on("blur", this.blurHandler);
-
-    document.addEventListener("scroll", this.scrollHandler);
   }
 
   viewMousedownHandler = () => {
@@ -126,12 +126,6 @@ export class FormattingToolbarView<BSchema extends BlockSchema> {
     if (this.toolbarIsOpen) {
       this.formattingToolbar.hide();
       this.toolbarIsOpen = false;
-    }
-  };
-
-  scrollHandler = () => {
-    if (this.toolbarIsOpen) {
-      this.formattingToolbar.render(this.getDynamicParams(), false);
     }
   };
 
@@ -206,8 +200,6 @@ export class FormattingToolbarView<BSchema extends BlockSchema> {
 
     this.ttEditor.off("focus", this.focusHandler);
     this.ttEditor.off("blur", this.blurHandler);
-
-    document.removeEventListener("scroll", this.scrollHandler);
   }
 
   getSelectionBoundingBox() {
@@ -233,8 +225,16 @@ export class FormattingToolbarView<BSchema extends BlockSchema> {
   getStaticParams(): FormattingToolbarStaticParams<BSchema> {
     return {
       editor: this.editor,
-      getReferenceRect: () =>
-        this.toolbarIsOpen ? this.getSelectionBoundingBox() : undefined,
+      getReferenceRect: () => {
+        if (!this.toolbarIsOpen) {
+          return this.lastPosition;
+        }
+
+        const selectionBoundingBox = this.getSelectionBoundingBox();
+        this.lastPosition = selectionBoundingBox;
+
+        return selectionBoundingBox;
+      },
     };
   }
 

--- a/packages/core/src/extensions/FormattingToolbar/FormattingToolbarPlugin.ts
+++ b/packages/core/src/extensions/FormattingToolbar/FormattingToolbarPlugin.ts
@@ -9,7 +9,6 @@ import { EditorView } from "prosemirror-view";
 import { BlockNoteEditor, BlockSchema } from "../..";
 import {
   FormattingToolbar,
-  FormattingToolbarDynamicParams,
   FormattingToolbarFactory,
   FormattingToolbarStaticParams,
 } from "./FormattingToolbarFactoryTypes";
@@ -164,7 +163,7 @@ export class FormattingToolbarView<BSchema extends BlockSchema> {
       !this.preventShow &&
       (shouldShow || this.preventHide)
     ) {
-      this.formattingToolbar.render(this.getDynamicParams(), true);
+      this.formattingToolbar.render({}, true);
       this.toolbarIsOpen = true;
 
       return;
@@ -176,7 +175,7 @@ export class FormattingToolbarView<BSchema extends BlockSchema> {
       !this.preventShow &&
       (shouldShow || this.preventHide)
     ) {
-      this.formattingToolbar.render(this.getDynamicParams(), false);
+      this.formattingToolbar.render({}, false);
       return;
     }
 
@@ -235,12 +234,6 @@ export class FormattingToolbarView<BSchema extends BlockSchema> {
 
         return selectionBoundingBox;
       },
-    };
-  }
-
-  getDynamicParams(): FormattingToolbarDynamicParams {
-    return {
-      referenceRect: this.getSelectionBoundingBox(),
     };
   }
 }

--- a/packages/core/src/extensions/HyperlinkToolbar/HyperlinkToolbarFactoryTypes.ts
+++ b/packages/core/src/extensions/HyperlinkToolbar/HyperlinkToolbarFactoryTypes.ts
@@ -10,8 +10,6 @@ export type HyperlinkToolbarStaticParams = {
 export type HyperlinkToolbarDynamicParams = {
   url: string;
   text: string;
-
-  referenceRect: DOMRect;
 };
 
 export type HyperlinkToolbar = EditorElement<HyperlinkToolbarDynamicParams>;

--- a/packages/core/src/extensions/HyperlinkToolbar/HyperlinkToolbarFactoryTypes.ts
+++ b/packages/core/src/extensions/HyperlinkToolbar/HyperlinkToolbarFactoryTypes.ts
@@ -3,6 +3,8 @@ import { EditorElement, ElementFactory } from "../../shared/EditorElement";
 export type HyperlinkToolbarStaticParams = {
   editHyperlink: (url: string, text: string) => void;
   deleteHyperlink: () => void;
+
+  getReferenceRect: () => DOMRect | undefined;
 };
 
 export type HyperlinkToolbarDynamicParams = {

--- a/packages/core/src/extensions/HyperlinkToolbar/HyperlinkToolbarFactoryTypes.ts
+++ b/packages/core/src/extensions/HyperlinkToolbar/HyperlinkToolbarFactoryTypes.ts
@@ -4,7 +4,7 @@ export type HyperlinkToolbarStaticParams = {
   editHyperlink: (url: string, text: string) => void;
   deleteHyperlink: () => void;
 
-  getReferenceRect: () => DOMRect | undefined;
+  getReferenceRect: () => DOMRect;
 };
 
 export type HyperlinkToolbarDynamicParams = {

--- a/packages/core/src/extensions/HyperlinkToolbar/HyperlinkToolbarPlugin.ts
+++ b/packages/core/src/extensions/HyperlinkToolbar/HyperlinkToolbarPlugin.ts
@@ -255,6 +255,14 @@ class HyperlinkToolbarView {
 
         this.hyperlinkToolbar.hide();
       },
+      getReferenceRect: () =>
+        this.hyperlinkMark
+          ? posToDOMRect(
+              this.editor.view,
+              this.hyperlinkMarkRange!.from,
+              this.hyperlinkMarkRange!.to
+            )
+          : undefined,
     };
   }
 

--- a/packages/core/src/extensions/HyperlinkToolbar/HyperlinkToolbarPlugin.ts
+++ b/packages/core/src/extensions/HyperlinkToolbar/HyperlinkToolbarPlugin.ts
@@ -251,6 +251,12 @@ class HyperlinkToolbarView {
       },
       getReferenceRect: () => {
         if (!this.hyperlinkMark) {
+          if (this.lastPosition === undefined) {
+            throw new Error(
+              "Attempted to access hyperlink reference rect before rendering hyperlink toolbar."
+            );
+          }
+
           return this.lastPosition;
         }
 

--- a/packages/core/src/extensions/HyperlinkToolbar/HyperlinkToolbarPlugin.ts
+++ b/packages/core/src/extensions/HyperlinkToolbar/HyperlinkToolbarPlugin.ts
@@ -36,6 +36,8 @@ class HyperlinkToolbarView {
   hyperlinkMark: Mark | undefined;
   hyperlinkMarkRange: Range | undefined;
 
+  private lastPosition: DOMRect | undefined;
+
   constructor({ editor, hyperlinkToolbarFactory }: HyperlinkToolbarViewProps) {
     this.editor = editor;
 
@@ -58,7 +60,6 @@ class HyperlinkToolbarView {
 
     this.editor.view.dom.addEventListener("mouseover", this.mouseOverHandler);
     document.addEventListener("click", this.clickHandler, true);
-    document.addEventListener("scroll", this.scrollHandler);
   }
 
   mouseOverHandler = (event: MouseEvent) => {
@@ -117,12 +118,6 @@ class HyperlinkToolbarView {
       !this.hyperlinkToolbar.element?.contains(event.target as Node)
     ) {
       this.hyperlinkToolbar.hide();
-    }
-  };
-
-  scrollHandler = () => {
-    if (this.hyperlinkMark !== undefined) {
-      this.hyperlinkToolbar.render(this.getDynamicParams(), false);
     }
   };
 
@@ -220,7 +215,6 @@ class HyperlinkToolbarView {
       "mouseover",
       this.mouseOverHandler
     );
-    document.removeEventListener("scroll", this.scrollHandler);
   }
 
   getStaticParams(): HyperlinkToolbarStaticParams {
@@ -255,14 +249,20 @@ class HyperlinkToolbarView {
 
         this.hyperlinkToolbar.hide();
       },
-      getReferenceRect: () =>
-        this.hyperlinkMark
-          ? posToDOMRect(
-              this.editor.view,
-              this.hyperlinkMarkRange!.from,
-              this.hyperlinkMarkRange!.to
-            )
-          : undefined,
+      getReferenceRect: () => {
+        if (!this.hyperlinkMark) {
+          return this.lastPosition;
+        }
+
+        const hyperlinkBoundingBox = posToDOMRect(
+          this.editor.view,
+          this.hyperlinkMarkRange!.from,
+          this.hyperlinkMarkRange!.to
+        );
+        this.lastPosition = hyperlinkBoundingBox;
+
+        return hyperlinkBoundingBox;
+      },
     };
   }
 

--- a/packages/core/src/extensions/HyperlinkToolbar/HyperlinkToolbarPlugin.ts
+++ b/packages/core/src/extensions/HyperlinkToolbar/HyperlinkToolbarPlugin.ts
@@ -273,11 +273,6 @@ class HyperlinkToolbarView {
         this.hyperlinkMarkRange!.from,
         this.hyperlinkMarkRange!.to
       ),
-      referenceRect: posToDOMRect(
-        this.editor.view,
-        this.hyperlinkMarkRange!.from,
-        this.hyperlinkMarkRange!.to
-      ),
     };
   }
 }

--- a/packages/core/src/shared/EditorElement.ts
+++ b/packages/core/src/shared/EditorElement.ts
@@ -1,9 +1,7 @@
 export type RequiredStaticParams = Record<string, any> & {
   getReferenceRect: () => DOMRect | undefined;
 };
-export type RequiredDynamicParams = Record<string, any> & {
-  referenceRect: DOMRect;
-};
+export type RequiredDynamicParams = Record<string, any> & {};
 
 export type EditorElement<ElementDynamicParams extends RequiredDynamicParams> =
   {

--- a/packages/core/src/shared/EditorElement.ts
+++ b/packages/core/src/shared/EditorElement.ts
@@ -1,4 +1,6 @@
-export type RequiredStaticParams = Record<string, any>;
+export type RequiredStaticParams = Record<string, any> & {
+  getReferenceRect: () => DOMRect | undefined;
+};
 export type RequiredDynamicParams = Record<string, any> & {
   referenceRect: DOMRect;
 };

--- a/packages/core/src/shared/EditorElement.ts
+++ b/packages/core/src/shared/EditorElement.ts
@@ -1,5 +1,5 @@
 export type RequiredStaticParams = Record<string, any> & {
-  getReferenceRect: () => DOMRect | undefined;
+  getReferenceRect: () => DOMRect;
 };
 export type RequiredDynamicParams = Record<string, any> & {};
 

--- a/packages/core/src/shared/plugins/suggestion/SuggestionPlugin.ts
+++ b/packages/core/src/shared/plugins/suggestion/SuggestionPlugin.ts
@@ -195,6 +195,17 @@ class SuggestionPluginView<
   getStaticParams(): SuggestionsMenuStaticParams<T> {
     return {
       itemCallback: (item: T) => this.itemCallback(item),
+      getReferenceRect: () => {
+        const decorationNode = document.querySelector(
+          `[data-decoration-id="${this.pluginState.decorationId}"]`
+        );
+
+        if (!decorationNode) {
+          return undefined;
+        }
+
+        return decorationNode.getBoundingClientRect();
+      },
     };
   }
 

--- a/packages/core/src/shared/plugins/suggestion/SuggestionPlugin.ts
+++ b/packages/core/src/shared/plugins/suggestion/SuggestionPlugin.ts
@@ -107,6 +107,8 @@ class SuggestionPluginView<
   pluginState: SuggestionPluginState<T>;
   itemCallback: (item: T) => void;
 
+  private lastPosition: DOMRect | undefined;
+
   constructor({
     editor,
     pluginKey,
@@ -137,15 +139,7 @@ class SuggestionPluginView<
     };
 
     this.suggestionsMenu = suggestionsMenuFactory(this.getStaticParams());
-
-    document.addEventListener("scroll", this.handleScroll);
   }
-
-  handleScroll = () => {
-    if (this.pluginKey.getState(this.editor._tiptapEditor.state).active) {
-      this.suggestionsMenu.render(this.getDynamicParams(), false);
-    }
-  };
 
   update(view: EditorView, prevState: EditorState) {
     const prev = this.pluginKey.getState(prevState);
@@ -188,10 +182,6 @@ class SuggestionPluginView<
     }
   }
 
-  destroy() {
-    document.removeEventListener("scroll", this.handleScroll);
-  }
-
   getStaticParams(): SuggestionsMenuStaticParams<T> {
     return {
       itemCallback: (item: T) => this.itemCallback(item),
@@ -201,10 +191,14 @@ class SuggestionPluginView<
         );
 
         if (!decorationNode) {
-          return undefined;
+          return this.lastPosition;
         }
 
-        return decorationNode.getBoundingClientRect();
+        const triggerCharacterBoundingBox =
+          decorationNode.getBoundingClientRect();
+        this.lastPosition = triggerCharacterBoundingBox;
+
+        return triggerCharacterBoundingBox;
       },
     };
   }

--- a/packages/core/src/shared/plugins/suggestion/SuggestionPlugin.ts
+++ b/packages/core/src/shared/plugins/suggestion/SuggestionPlugin.ts
@@ -204,14 +204,9 @@ class SuggestionPluginView<
   }
 
   getDynamicParams(): SuggestionsMenuDynamicParams<T> {
-    const decorationNode = document.querySelector(
-      `[data-decoration-id="${this.pluginState.decorationId}"]`
-    );
-
     return {
       items: this.pluginState.items,
       keyboardHoveredItemIndex: this.pluginState.keyboardHoveredItemIndex!,
-      referenceRect: decorationNode!.getBoundingClientRect(),
     };
   }
 }

--- a/packages/core/src/shared/plugins/suggestion/SuggestionPlugin.ts
+++ b/packages/core/src/shared/plugins/suggestion/SuggestionPlugin.ts
@@ -191,6 +191,12 @@ class SuggestionPluginView<
         );
 
         if (!decorationNode) {
+          if (this.lastPosition === undefined) {
+            throw new Error(
+              "Attempted to access trigger character reference rect before rendering suggestions menu."
+            );
+          }
+
           return this.lastPosition;
         }
 

--- a/packages/core/src/shared/plugins/suggestion/SuggestionsMenuFactoryTypes.ts
+++ b/packages/core/src/shared/plugins/suggestion/SuggestionsMenuFactoryTypes.ts
@@ -4,7 +4,7 @@ import { SuggestionItem } from "./SuggestionItem";
 export type SuggestionsMenuStaticParams<T extends SuggestionItem> = {
   itemCallback: (item: T) => void;
 
-  getReferenceRect: () => DOMRect | undefined;
+  getReferenceRect: () => DOMRect;
 };
 
 export type SuggestionsMenuDynamicParams<T extends SuggestionItem> = {

--- a/packages/core/src/shared/plugins/suggestion/SuggestionsMenuFactoryTypes.ts
+++ b/packages/core/src/shared/plugins/suggestion/SuggestionsMenuFactoryTypes.ts
@@ -3,6 +3,8 @@ import { SuggestionItem } from "./SuggestionItem";
 
 export type SuggestionsMenuStaticParams<T extends SuggestionItem> = {
   itemCallback: (item: T) => void;
+
+  getReferenceRect: () => DOMRect | undefined;
 };
 
 export type SuggestionsMenuDynamicParams<T extends SuggestionItem> = {

--- a/packages/core/src/shared/plugins/suggestion/SuggestionsMenuFactoryTypes.ts
+++ b/packages/core/src/shared/plugins/suggestion/SuggestionsMenuFactoryTypes.ts
@@ -10,8 +10,6 @@ export type SuggestionsMenuStaticParams<T extends SuggestionItem> = {
 export type SuggestionsMenuDynamicParams<T extends SuggestionItem> = {
   items: T[];
   keyboardHoveredItemIndex: number;
-
-  referenceRect: DOMRect;
 };
 
 export type SuggestionsMenu<T extends SuggestionItem> = EditorElement<

--- a/packages/react/src/BlockNoteTheme.ts
+++ b/packages/react/src/BlockNoteTheme.ts
@@ -268,6 +268,7 @@ export const getBlockNoteTheme = (
       SlashMenu: {
         styles: () => ({
           root: {
+            position: "relative",
             ".mantine-Menu-item": {
               // Icon
               ".mantine-Menu-itemIcon": {

--- a/packages/react/src/ElementFactory/components/EditorElementComponentWrapper.tsx
+++ b/packages/react/src/ElementFactory/components/EditorElementComponentWrapper.tsx
@@ -64,7 +64,7 @@ export function EditorElementComponentWrapper<
             ? !contentCleared
               ? getReferenceClientRect
               : undefined
-            : props.staticParams.getReferenceRect
+            : (props.staticParams.getReferenceRect as () => DOMRect)
         }
         interactive={true}
         onShow={onShow}

--- a/packages/react/src/ElementFactory/components/EditorElementComponentWrapper.tsx
+++ b/packages/react/src/ElementFactory/components/EditorElementComponentWrapper.tsx
@@ -1,6 +1,6 @@
 import { MantineProvider, MantineThemeOverride } from "@mantine/core";
 import Tippy, { TippyProps } from "@tippyjs/react";
-import { RequiredDynamicParams } from "@blocknote/core";
+import { RequiredDynamicParams, RequiredStaticParams } from "@blocknote/core";
 import { FC, useCallback, useState } from "react";
 
 /**
@@ -13,7 +13,7 @@ import { FC, useCallback, useState } from "react";
  * mounted under.
  */
 export function EditorElementComponentWrapper<
-  ElementStaticParams extends Record<string, any>,
+  ElementStaticParams extends RequiredStaticParams,
   ElementDynamicParams extends RequiredDynamicParams
 >(props: {
   rootElement: HTMLElement;
@@ -55,8 +55,16 @@ export function EditorElementComponentWrapper<
             />
           ) : undefined
         }
+        // Tippy automatically reacts to the reference bounding box changing
+        // positions using `staticParams.getReferenceRect`. While the element is
+        // being hidden and animated, it instead uses the last known position.
+        // Otherwise, the position is undefined.
         getReferenceClientRect={
-          !contentCleared ? getReferenceClientRect : undefined
+          !props.isOpen
+            ? !contentCleared
+              ? getReferenceClientRect
+              : undefined
+            : props.staticParams.getReferenceRect
         }
         interactive={true}
         onShow={onShow}

--- a/packages/react/src/ElementFactory/components/EditorElementComponentWrapper.tsx
+++ b/packages/react/src/ElementFactory/components/EditorElementComponentWrapper.tsx
@@ -28,11 +28,6 @@ export function EditorElementComponentWrapper<
 
   const [contentCleared, setContentCleared] = useState(false);
 
-  const getReferenceClientRect = useCallback(
-    () => props.dynamicParams!.referenceRect,
-    [props.dynamicParams]
-  );
-
   const onShow = useCallback(() => {
     setContentCleared(false);
     document.body.appendChild(props.rootElement);
@@ -55,16 +50,11 @@ export function EditorElementComponentWrapper<
             />
           ) : undefined
         }
-        // Tippy automatically reacts to the reference bounding box changing
-        // positions using `staticParams.getReferenceRect`. While the element is
-        // being hidden and animated, it instead uses the last known position.
-        // Otherwise, the position is undefined.
+        // Type cast is needed as getReferenceRect will return `undefined` when
+        // the editor is initialized but the element hasn't been rendered yet.
+        // Otherwise, it will always return a `DOMRect`.
         getReferenceClientRect={
-          !props.isOpen
-            ? !contentCleared
-              ? getReferenceClientRect
-              : undefined
-            : (props.staticParams.getReferenceRect as () => DOMRect)
+          props.staticParams.getReferenceRect as () => DOMRect
         }
         interactive={true}
         onShow={onShow}

--- a/packages/react/src/ElementFactory/components/EditorElementComponentWrapper.tsx
+++ b/packages/react/src/ElementFactory/components/EditorElementComponentWrapper.tsx
@@ -53,9 +53,7 @@ export function EditorElementComponentWrapper<
         // Type cast is needed as getReferenceRect will return `undefined` when
         // the editor is initialized but the element hasn't been rendered yet.
         // Otherwise, it will always return a `DOMRect`.
-        getReferenceClientRect={
-          props.staticParams.getReferenceRect as () => DOMRect
-        }
+        getReferenceClientRect={props.staticParams.getReferenceRect}
         interactive={true}
         onShow={onShow}
         onHidden={onHidden}

--- a/packages/react/src/ElementFactory/components/ReactElementFactory.tsx
+++ b/packages/react/src/ElementFactory/components/ReactElementFactory.tsx
@@ -1,7 +1,11 @@
 import { FC } from "react";
 import { TippyProps } from "@tippyjs/react";
 import { createRoot } from "react-dom/client";
-import { EditorElement, RequiredDynamicParams } from "@blocknote/core";
+import {
+  EditorElement,
+  RequiredDynamicParams,
+  RequiredStaticParams,
+} from "@blocknote/core";
 import { EditorElementComponentWrapper } from "./EditorElementComponentWrapper";
 import { MantineThemeOverride } from "@mantine/core";
 
@@ -19,7 +23,7 @@ import { MantineThemeOverride } from "@mantine/core";
  * @param tippyProps Tippy props, which affect the elements' popup behaviour, e.g. popup position, animation, etc.
  */
 export const ReactElementFactory = <
-  ElementStaticParams extends Record<string, any>,
+  ElementStaticParams extends RequiredStaticParams,
   ElementDynamicParams extends RequiredDynamicParams
 >(
   staticParams: ElementStaticParams,
@@ -30,15 +34,35 @@ export const ReactElementFactory = <
   const rootElement = document.createElement("div");
   const root = createRoot(rootElement);
 
-  // Used when hiding the element. If we were to pass in undefined instead, the element would be immediately cleared, not
-  // leaving time for the fade out animation to complete.
+  // Used when hiding the element. If we were to pass in undefined instead, the
+  // element would be immediately cleared, not leaving time for the fade out
+  // animation to complete.
   let prevDynamicParams: ElementDynamicParams | undefined = undefined;
+  let isOpen = false;
 
   return {
     element: rootElement,
     render: (dynamicParams: ElementDynamicParams, _isHidden: boolean) => {
+      // Tippy should handle the reference bounding box changing positions
+      // itself, otherwise it's less responsive and isn't able to handle
+      // page overflows. Therefore, we want to avoid re-rendering the element
+      // when only its position changes.
+      const nextDynamicParamsCopy = { ...dynamicParams };
+      delete nextDynamicParamsCopy.referenceRect;
+      const prevDynamicParamsCopy = { ...prevDynamicParams };
+      delete prevDynamicParamsCopy.referenceRect;
+
       prevDynamicParams = dynamicParams;
 
+      if (
+        isOpen &&
+        JSON.stringify(nextDynamicParamsCopy) ===
+          JSON.stringify(prevDynamicParamsCopy)
+      ) {
+        return;
+      }
+
+      isOpen = true;
       root.render(
         <EditorElementComponentWrapper
           rootElement={rootElement}
@@ -52,6 +76,7 @@ export const ReactElementFactory = <
       );
     },
     hide: () => {
+      isOpen = false;
       root.render(
         <EditorElementComponentWrapper
           rootElement={rootElement}
@@ -63,6 +88,8 @@ export const ReactElementFactory = <
           tippyProps={tippyProps}
         />
       );
+
+      prevDynamicParams = undefined;
     },
   };
 };

--- a/packages/react/src/ElementFactory/components/ReactElementFactory.tsx
+++ b/packages/react/src/ElementFactory/components/ReactElementFactory.tsx
@@ -47,10 +47,18 @@ export const ReactElementFactory = <
       // itself, otherwise it's less responsive and isn't able to handle
       // page overflows. Therefore, we want to avoid re-rendering the element
       // when only its position changes.
-      const nextDynamicParamsCopy = { ...dynamicParams };
-      delete nextDynamicParamsCopy.referenceRect;
-      const prevDynamicParamsCopy = { ...prevDynamicParams };
-      delete prevDynamicParamsCopy.referenceRect;
+      const prevDynamicParamsCopy: Record<string, any> = {};
+      for (const key in prevDynamicParams) {
+        if (key !== "referenceRect") {
+          prevDynamicParamsCopy[key] = prevDynamicParams[key];
+        }
+      }
+      const nextDynamicParamsCopy: Record<string, any> = {};
+      for (const key in dynamicParams) {
+        if (key !== "referenceRect") {
+          nextDynamicParamsCopy[key] = dynamicParams[key];
+        }
+      }
 
       prevDynamicParams = dynamicParams;
 

--- a/packages/react/src/ElementFactory/components/ReactElementFactory.tsx
+++ b/packages/react/src/ElementFactory/components/ReactElementFactory.tsx
@@ -38,39 +38,12 @@ export const ReactElementFactory = <
   // element would be immediately cleared, not leaving time for the fade out
   // animation to complete.
   let prevDynamicParams: ElementDynamicParams | undefined = undefined;
-  let isOpen = false;
 
   return {
     element: rootElement,
     render: (dynamicParams: ElementDynamicParams, _isHidden: boolean) => {
-      // Tippy should handle the reference bounding box changing positions
-      // itself, otherwise it's less responsive and isn't able to handle
-      // page overflows. Therefore, we want to avoid re-rendering the element
-      // when only its position changes.
-      const prevDynamicParamsCopy: Record<string, any> = {};
-      for (const key in prevDynamicParams) {
-        if (key !== "referenceRect") {
-          prevDynamicParamsCopy[key] = prevDynamicParams[key];
-        }
-      }
-      const nextDynamicParamsCopy: Record<string, any> = {};
-      for (const key in dynamicParams) {
-        if (key !== "referenceRect") {
-          nextDynamicParamsCopy[key] = dynamicParams[key];
-        }
-      }
-
       prevDynamicParams = dynamicParams;
 
-      if (
-        isOpen &&
-        JSON.stringify(nextDynamicParamsCopy) ===
-          JSON.stringify(prevDynamicParamsCopy)
-      ) {
-        return;
-      }
-
-      isOpen = true;
       root.render(
         <EditorElementComponentWrapper
           rootElement={rootElement}
@@ -84,7 +57,6 @@ export const ReactElementFactory = <
       );
     },
     hide: () => {
-      isOpen = false;
       root.render(
         <EditorElementComponentWrapper
           rootElement={rootElement}

--- a/packages/react/src/ElementFactory/components/ReactElementFactory.tsx
+++ b/packages/react/src/ElementFactory/components/ReactElementFactory.tsx
@@ -34,9 +34,8 @@ export const ReactElementFactory = <
   const rootElement = document.createElement("div");
   const root = createRoot(rootElement);
 
-  // Used when hiding the element. If we were to pass in undefined instead, the
-  // element would be immediately cleared, not leaving time for the fade out
-  // animation to complete.
+  // Used when hiding the element. Without being passed a set of dynamic params,
+  // certain menus/toolbars will not render correctly.
   let prevDynamicParams: ElementDynamicParams | undefined = undefined;
 
   return {


### PR DESCRIPTION
Right now, every time we scroll, each `uiElement` is re-rendered. In general, I do think we want to leave the responsibility of figuring out when to render/hide `uiElement`s completely up to BlockNote, Tippy has it's own listeners to figure out when it should update its position. Trying to re-render the whole component on scroll instead of letting Tippy sort it out itself leads to some issues, namely overflow handling and bad responsiveness.

https://discord.com/channels/928190961455087667/1015169282444894219/1120228729600348181
https://discord.com/channels/928190961455087667/1015169282444894219/1120355999828680795