### PR TITLE
several fixes for react rearchitecture

### DIFF
--- a/examples/editor/src/main.tsx
+++ b/examples/editor/src/main.tsx
@@ -6,6 +6,8 @@ import "./index.css";
 window.React = React;
 
 const root = createRoot(document.getElementById("root")!);
-root.render(<App />);
-
-// root.render(<App />);
+root.render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/packages/core/src/extensions/FormattingToolbar/FormattingToolbarPlugin.ts
+++ b/packages/core/src/extensions/FormattingToolbar/FormattingToolbarPlugin.ts
@@ -124,7 +124,7 @@ export class FormattingToolbarView<BSchema extends BlockSchema> {
   scrollHandler = () => {
     if (this.formattingToolbarState?.show) {
       this.formattingToolbarState.referencePos = this.getSelectionBoundingBox();
-      this.updateFormattingToolbar?.();
+      this.updateFormattingToolbar();
     }
   };
 
@@ -232,23 +232,21 @@ export const createFormattingToolbar = <BSchema extends BlockSchema>(
     formattingToolbarState: FormattingToolbarState
   ) => void
 ) => {
-  // TODO: Add a way to unregister the plugin.
-  const formattingToolbarView = new FormattingToolbarView(
-    editor,
-    editor._tiptapEditor.view,
-    updateFormattingToolbar
-  );
-  // For some reason, each time `registerPlugin` is called, the previous plugins
-  // which were added are either added again, or `view` is called again,
-  // resulting in duplicate views. This seems like a bug in TipTap?
   editor._tiptapEditor.registerPlugin(
     new Plugin({
       key: formattingToolbarPluginKey,
-      view: () => formattingToolbarView,
+      view: () =>
+        new FormattingToolbarView(
+          editor,
+          editor._tiptapEditor.view,
+          updateFormattingToolbar
+        ),
     }),
     (formattingToolbarPlugin, plugins) => {
       plugins.unshift(formattingToolbarPlugin);
       return plugins;
     }
   );
+  return () =>
+    editor._tiptapEditor.unregisterPlugin(formattingToolbarPluginKey);
 };

--- a/packages/core/src/extensions/HyperlinkToolbar/HyperlinkToolbarPlugin.ts
+++ b/packages/core/src/extensions/HyperlinkToolbar/HyperlinkToolbarPlugin.ts
@@ -1,8 +1,8 @@
 import { getMarkRange, posToDOMRect, Range } from "@tiptap/core";
 import { Mark } from "prosemirror-model";
 import { Plugin, PluginKey } from "prosemirror-state";
-import { BaseUiElementState } from "../../shared/EditorElement";
 import { BlockNoteEditor } from "../../BlockNoteEditor";
+import { BaseUiElementState } from "../../shared/EditorElement";
 import { BlockSchema } from "../Blocks/api/blockTypes";
 
 export type HyperlinkToolbarState = BaseUiElementState & {
@@ -298,6 +298,7 @@ class HyperlinkToolbarView<BSchema extends BlockSchema> {
       this.mouseOverHandler
     );
     document.removeEventListener("scroll", this.scrollHandler);
+    document.removeEventListener("click", this.clickHandler, true);
   }
 }
 
@@ -308,22 +309,15 @@ export const createHyperlinkToolbar = <BSchema extends BlockSchema>(
   editor: BlockNoteEditor<BSchema>,
   updateHyperlinkToolbar: (hyperlinkToolbarState: HyperlinkToolbarState) => void
 ) => {
-  // TODO: Add a way to unregister the plugin.
-  const hyperlinkToolbarView = new HyperlinkToolbarView(
-    editor,
-    updateHyperlinkToolbar
-  );
-  // For some reason, each time `registerPlugin` is called, the previous plugins
-  // which were added are either added again, or `view` is called again,
-  // resulting in duplicate views. This seems like a bug in TipTap?
   editor._tiptapEditor.registerPlugin(
     new Plugin({
       key: hyperlinkToolbarPluginKey,
-      view: () => hyperlinkToolbarView,
+      view: () => new HyperlinkToolbarView(editor, updateHyperlinkToolbar),
     }),
     (hyperlinkToolbarPlugin, plugins) => {
       plugins.unshift(hyperlinkToolbarPlugin);
       return plugins;
     }
   );
+  return () => editor._tiptapEditor.unregisterPlugin(hyperlinkToolbarPluginKey);
 };

--- a/packages/core/src/extensions/SlashMenu/SlashMenuPlugin.ts
+++ b/packages/core/src/extensions/SlashMenu/SlashMenuPlugin.ts
@@ -1,11 +1,11 @@
-import { BaseSlashMenuItem } from "./BaseSlashMenuItem";
-import { DefaultBlockSchema } from "../Blocks/api/defaultBlocks";
+import { PluginKey } from "prosemirror-state";
 import { BlockNoteEditor } from "../../BlockNoteEditor";
 import {
   createSuggestionPlugin,
   SuggestionsMenuState,
 } from "../../shared/plugins/suggestion/SuggestionPlugin";
-import { PluginKey } from "prosemirror-state";
+import { DefaultBlockSchema } from "../Blocks/api/defaultBlocks";
+import { BaseSlashMenuItem } from "./BaseSlashMenuItem";
 
 export const slashMenuPluginKey = new PluginKey("SlashMenuPlugin");
 export const createSlashMenu = <
@@ -25,4 +25,5 @@ export const createSlashMenu = <
     ({ item, editor }) => item.execute(editor),
     items
   );
+  return () => editor._tiptapEditor.unregisterPlugin(slashMenuPluginKey);
 };

--- a/packages/core/src/shared/plugins/suggestion/SuggestionPlugin.ts
+++ b/packages/core/src/shared/plugins/suggestion/SuggestionPlugin.ts
@@ -3,8 +3,8 @@ import { Decoration, DecorationSet, EditorView } from "prosemirror-view";
 import { BlockNoteEditor } from "../../../BlockNoteEditor";
 import { BlockSchema } from "../../../extensions/Blocks/api/blockTypes";
 import { findBlock } from "../../../extensions/Blocks/helpers/findBlock";
-import { SuggestionItem } from "./SuggestionItem";
 import { BaseUiElementState } from "../../EditorElement";
+import { SuggestionItem } from "./SuggestionItem";
 
 export type SuggestionsMenuState<T extends SuggestionItem> =
   BaseUiElementState & {
@@ -193,7 +193,6 @@ export function createSuggestionPlugin<
   }) => void = () => {},
   items: (query: string) => T[] = () => []
 ) {
-  // TODO: Add a way to unregister the plugin.
   // Assertions
   if (defaultTriggerCharacter.length !== 1) {
     throw new Error("'char' should be a single character");
@@ -203,24 +202,20 @@ export function createSuggestionPlugin<
     view.dispatch(view.state.tr.setMeta(pluginKey, { deactivate: true }));
   };
 
-  const suggestionPluginView = new SuggestionPluginView<T, BSchema>(
-    editor,
-    pluginKey,
-    (props: { item: T; editor: BlockNoteEditor<BSchema> }) => {
-      deactivate(editor._tiptapEditor.view);
-      onSelectItem(props);
-    },
-    updateSuggestionsMenu
-  );
-
-  // For some reason, each time `registerPlugin` is called, the previous plugins
-  // which were added are either added again, or `view` is called again,
-  // resulting in duplicate views. This seems like a bug in TipTap?
   editor._tiptapEditor.registerPlugin(
     new Plugin({
       key: pluginKey,
 
-      view: () => suggestionPluginView,
+      view: () =>
+        new SuggestionPluginView<T, BSchema>(
+          editor,
+          pluginKey,
+          (props: { item: T; editor: BlockNoteEditor<BSchema> }) => {
+            deactivate(editor._tiptapEditor.view);
+            onSelectItem(props);
+          },
+          updateSuggestionsMenu
+        ),
 
       state: {
         // Initialize the plugin's internal state.

--- a/packages/react/src/BlockNoteView.tsx
+++ b/packages/react/src/BlockNoteView.tsx
@@ -1,22 +1,24 @@
 import { BlockNoteEditor, BlockSchema } from "@blocknote/core";
-import { EditorContent } from "@tiptap/react";
-import { FormattingToolbar } from "./FormattingToolbar/components/FormattingToolbar";
-import { SlashMenu } from "./SlashMenu/components/SlashMenu";
-import { HyperlinkToolbar } from "./HyperlinkToolbar/components/HyperlinkToolbar";
-import { SideMenu } from "./BlockSideMenu/components/BlockSideMenu";
-import { getBlockNoteTheme } from "./BlockNoteTheme";
 import { MantineProvider } from "@mantine/core";
+import { EditorContent } from "@tiptap/react";
+import { getBlockNoteTheme } from "./BlockNoteTheme";
+import { SideMenu } from "./BlockSideMenu/components/BlockSideMenu";
+import { FormattingToolbar } from "./FormattingToolbar/components/FormattingToolbar";
+import { HyperlinkToolbar } from "./HyperlinkToolbar/components/HyperlinkToolbar";
+import { SlashMenu } from "./SlashMenu/components/SlashMenu";
 
 export function BlockNoteView<BSchema extends BlockSchema>(props: {
   editor: BlockNoteEditor<BSchema>;
 }) {
   return (
     <MantineProvider theme={getBlockNoteTheme()}>
-      <EditorContent editor={props.editor?._tiptapEditor || null} />
-      <FormattingToolbar editor={props.editor!} />
-      <HyperlinkToolbar editor={props.editor!} />
-      <SideMenu editor={props.editor!} />
-      <SlashMenu editor={props.editor!} />
+      <EditorContent editor={props.editor?._tiptapEditor || null}>
+        <SideMenu editor={props.editor!} />
+        <FormattingToolbar editor={props.editor!} />
+        <HyperlinkToolbar editor={props.editor!} />
+
+        <SlashMenu editor={props.editor!} />
+      </EditorContent>
     </MantineProvider>
   );
 }

--- a/packages/react/src/FormattingToolbar/components/FormattingToolbar.tsx
+++ b/packages/react/src/FormattingToolbar/components/FormattingToolbar.tsx
@@ -1,11 +1,12 @@
 import {
   BlockNoteEditor,
   BlockSchema,
-  createFormattingToolbar,
   FormattingToolbarState,
+  createFormattingToolbar,
 } from "@blocknote/core";
 
-import { useCallback, useEffect, useRef, useState } from "react";
+import Tippy from "@tippyjs/react";
+import { useEffect, useMemo, useState } from "react";
 import { Toolbar } from "../../SharedComponents/Toolbar/components/Toolbar";
 import { ColorStyleButton } from "./DefaultButtons/ColorStyleButton";
 import { CreateLinkButton } from "./DefaultButtons/CreateLinkButton";
@@ -16,7 +17,6 @@ import {
 import { TextAlignButton } from "./DefaultButtons/TextAlignButton";
 import { ToggledStyleButton } from "./DefaultButtons/ToggledStyleButton";
 import { BlockTypeDropdown } from "./DefaultDropdowns/BlockTypeDropdown";
-import Tippy from "@tippyjs/react";
 
 export const FormattingToolbarOld = <BSchema extends BlockSchema>(props: {
   editor: BlockNoteEditor<BSchema>;
@@ -47,36 +47,33 @@ export const FormattingToolbarOld = <BSchema extends BlockSchema>(props: {
 export const FormattingToolbar = <BSchema extends BlockSchema>(props: {
   editor: BlockNoteEditor<BSchema>;
 }) => {
-  const [state, setState] = useState<
-    Omit<FormattingToolbarState, "referencePos"> | undefined
-  >();
-  // Since we're using Tippy, we don't want to trigger re-renders when only the
-  // reference position changes. So we store it in a ref instead of state.
-  const referenceClientRect = useRef<DOMRect | undefined>();
-
+  const [state, setState] = useState<FormattingToolbarState>();
   useEffect(() => {
-    createFormattingToolbar(props.editor, ({ referencePos, ...state }) => {
-      setState(state);
-      referenceClientRect.current = referencePos;
+    return createFormattingToolbar(props.editor, (state) => {
+      setState({ ...state });
     });
   }, [props.editor]);
 
-  const getReferenceClientRect = useCallback(
-    () => referenceClientRect.current!,
-    [referenceClientRect]
-  );
+  const getReferenceClientRect = useMemo(() => {
+    // TODO: test
+    console.log(
+      "new reference pos TOOLBAR, this should only be triggered when selection changes"
+    );
+    if (!state?.referencePos) {
+      return undefined;
+    }
+    return () => state.referencePos;
+  }, [state?.referencePos]);
 
   return (
     <Tippy
-      appendTo={props.editor._tiptapEditor.view.dom.parentElement!}
       content={<FormattingToolbarOld editor={props.editor} />}
-      getReferenceClientRect={
-        referenceClientRect.current && getReferenceClientRect
-      }
+      getReferenceClientRect={getReferenceClientRect}
       interactive={true}
       visible={state?.show || false}
       animation={"fade"}
-      placement={"top-start"}
-    />
+      placement={"top-start"}>
+      <div />
+    </Tippy>
   );
 };

--- a/packages/react/src/HyperlinkToolbar/components/HyperlinkToolbar.tsx
+++ b/packages/react/src/HyperlinkToolbar/components/HyperlinkToolbar.tsx
@@ -1,15 +1,15 @@
-import { useCallback, useEffect, useRef, useState } from "react";
-import { EditHyperlinkMenu } from "../EditHyperlinkMenu/components/EditHyperlinkMenu";
-import { Toolbar } from "../../SharedComponents/Toolbar/components/Toolbar";
-import { ToolbarButton } from "../../SharedComponents/Toolbar/components/ToolbarButton";
-import { RiExternalLinkFill, RiLinkUnlink } from "react-icons/ri";
 import {
   BlockNoteEditor,
   BlockSchema,
-  createHyperlinkToolbar,
   HyperlinkToolbarState,
+  createHyperlinkToolbar,
 } from "@blocknote/core";
 import Tippy from "@tippyjs/react";
+import { useEffect, useMemo, useState } from "react";
+import { RiExternalLinkFill, RiLinkUnlink } from "react-icons/ri";
+import { Toolbar } from "../../SharedComponents/Toolbar/components/Toolbar";
+import { ToolbarButton } from "../../SharedComponents/Toolbar/components/ToolbarButton";
+import { EditHyperlinkMenu } from "../EditHyperlinkMenu/components/EditHyperlinkMenu";
 // import rootStyles from "../../../root.module.css";
 
 /**
@@ -60,37 +60,33 @@ export const HyperlinkToolbarOld = (
 export const HyperlinkToolbar = <BSchema extends BlockSchema>(props: {
   editor: BlockNoteEditor<BSchema>;
 }) => {
-  const [state, setState] = useState<
-    Omit<HyperlinkToolbarState, "referencePos"> | undefined
-  >();
-  // Since we're using Tippy, we don't want to trigger re-renders when only the
-  // reference position changes. So we store it in a ref instead of state.
-  const referenceClientRect = useRef<DOMRect | undefined>();
+  const [state, setState] = useState<HyperlinkToolbarState>();
 
   useEffect(() => {
-    createHyperlinkToolbar(props.editor, ({ referencePos, ...state }) => {
+    return createHyperlinkToolbar(props.editor, ({ ...state }) => {
       setState(state);
-      referenceClientRect.current = referencePos;
     });
   }, [props.editor]);
 
-  const getReferenceClientRect = useCallback(
-    () => referenceClientRect.current!,
-    [referenceClientRect]
-  );
+  const getReferenceClientRect = useMemo(() => {
+    // TODO: test and remove
+    console.log("new reference pos for HYPERLINKTOOLBAR");
+    if (!state?.referencePos) {
+      return undefined;
+    }
+    return () => state.referencePos;
+  }, [state?.referencePos]);
 
   return (
     <Tippy
-      appendTo={props.editor._tiptapEditor.view.dom.parentElement!}
       // TODO: Add onMouseEnter and onMouseLeave handlers from state
       content={<HyperlinkToolbarOld {...state!} />}
-      getReferenceClientRect={
-        referenceClientRect.current && getReferenceClientRect
-      }
+      getReferenceClientRect={getReferenceClientRect}
       interactive={true}
       visible={state?.show || false}
       animation={"fade"}
-      placement={"top-start"}
-    />
+      placement={"top-start"}>
+      <div />
+    </Tippy>
   );
 };

--- a/packages/react/src/SharedComponents/Toolbar/components/ToolbarDropdown.tsx
+++ b/packages/react/src/SharedComponents/Toolbar/components/ToolbarDropdown.tsx
@@ -16,7 +16,9 @@ export type ToolbarDropdownProps = {
 };
 
 export function ToolbarDropdown(props: ToolbarDropdownProps) {
-  const activeItem = props.items.filter((p) => p.isSelected)[0];
+  const { isSelected, ...activeItem } = props.items.filter(
+    (p) => p.isSelected
+  )[0];
 
   if (!activeItem) {
     return null;

--- a/packages/website/partykitserver.ts
+++ b/packages/website/partykitserver.ts
@@ -5,6 +5,6 @@ import { onConnect } from "y-partykit";
 // preview with npx partykit@beta dev partykitserver.ts
 export default {
   onConnect(ws, room) {
-    return onConnect(ws, room, { persist: true });
+    return onConnect(ws, room, { persist: false, gc: true });
   },
 } satisfies PartyKitServer;


### PR DESCRIPTION
This addresses several issues in #270"

- call unregisterPlugin as useEffect disposer
- fixed event listener removal + reverted the plugin view instantation
- now, strict mode works again
- remove tippy `appendTo`, this is possible because I made the elements children of EditorView, and included a <div/> within the <Tippy> components
- cleaned up the referenceRect logic a bit
