### PR TITLE
fix initialcontent and uniqueid

### DIFF
--- a/packages/core/src/extensions/UniqueID/UniqueID.ts
+++ b/packages/core/src/extensions/UniqueID/UniqueID.ts
@@ -86,36 +86,35 @@ const UniqueID = Extension.create({
     ];
   },
   // check initial content for missing ids
-  onCreate() {
-    return;
-    // Don’t do this when the collaboration extension is active
-    // because this may update the content, so Y.js tries to merge these changes.
-    // This leads to empty block nodes.
-    // See: https://github.com/ueberdosis/tiptap/issues/2400
-    // if (
-    //   this.editor.extensionManager.extensions.find(
-    //     (extension) => extension.name === "collaboration"
-    //   )
-    // ) {
-    //   return;
-    // }
-    // const { view, state } = this.editor;
-    // const { tr, doc } = state;
-    // const { types, attributeName, generateID } = this.options;
-    // const nodesWithoutId = findChildren(doc, (node) => {
-    //   return (
-    //     types.includes(node.type.name) && node.attrs[attributeName] === null
-    //   );
-    // });
-    // nodesWithoutId.forEach(({ node, pos }) => {
-    //   tr.setNodeMarkup(pos, undefined, {
-    //     ...node.attrs,
-    //     [attributeName]: generateID(),
-    //   });
-    // });
-    // tr.setMeta("addToHistory", false);
-    // view.dispatch(tr);
-  },
+  // onCreate() {
+  //   // Don’t do this when the collaboration extension is active
+  //   // because this may update the content, so Y.js tries to merge these changes.
+  //   // This leads to empty block nodes.
+  //   // See: https://github.com/ueberdosis/tiptap/issues/2400
+  //   if (
+  //     this.editor.extensionManager.extensions.find(
+  //       (extension) => extension.name === "collaboration"
+  //     )
+  //   ) {
+  //     return;
+  //   }
+  //   const { view, state } = this.editor;
+  //   const { tr, doc } = state;
+  //   const { types, attributeName, generateID } = this.options;
+  //   const nodesWithoutId = findChildren(doc, (node) => {
+  //     return (
+  //       types.includes(node.type.name) && node.attrs[attributeName] === null
+  //     );
+  //   });
+  //   nodesWithoutId.forEach(({ node, pos }) => {
+  //     tr.setNodeMarkup(pos, undefined, {
+  //       ...node.attrs,
+  //       [attributeName]: generateID(),
+  //     });
+  //   });
+  //   tr.setMeta("addToHistory", false);
+  //   view.dispatch(tr);
+  // },
   addProseMirrorPlugins() {
     let dragSourceElement: any = null;
     let transformPasted = false;

--- a/packages/core/src/extensions/UniqueID/UniqueID.ts
+++ b/packages/core/src/extensions/UniqueID/UniqueID.ts
@@ -1,7 +1,6 @@
 import {
   combineTransactionSteps,
   Extension,
-  findChildren,
   findChildrenInRange,
   getChangedRanges,
 } from "@tiptap/core";
@@ -88,33 +87,34 @@ const UniqueID = Extension.create({
   },
   // check initial content for missing ids
   onCreate() {
+    return;
     // Don’t do this when the collaboration extension is active
     // because this may update the content, so Y.js tries to merge these changes.
     // This leads to empty block nodes.
     // See: https://github.com/ueberdosis/tiptap/issues/2400
-    if (
-      this.editor.extensionManager.extensions.find(
-        (extension) => extension.name === "collaboration"
-      )
-    ) {
-      return;
-    }
-    const { view, state } = this.editor;
-    const { tr, doc } = state;
-    const { types, attributeName, generateID } = this.options;
-    const nodesWithoutId = findChildren(doc, (node) => {
-      return (
-        types.includes(node.type.name) && node.attrs[attributeName] === null
-      );
-    });
-    nodesWithoutId.forEach(({ node, pos }) => {
-      tr.setNodeMarkup(pos, undefined, {
-        ...node.attrs,
-        [attributeName]: generateID(),
-      });
-    });
-    tr.setMeta("addToHistory", false);
-    view.dispatch(tr);
+    // if (
+    //   this.editor.extensionManager.extensions.find(
+    //     (extension) => extension.name === "collaboration"
+    //   )
+    // ) {
+    //   return;
+    // }
+    // const { view, state } = this.editor;
+    // const { tr, doc } = state;
+    // const { types, attributeName, generateID } = this.options;
+    // const nodesWithoutId = findChildren(doc, (node) => {
+    //   return (
+    //     types.includes(node.type.name) && node.attrs[attributeName] === null
+    //   );
+    // });
+    // nodesWithoutId.forEach(({ node, pos }) => {
+    //   tr.setNodeMarkup(pos, undefined, {
+    //     ...node.attrs,
+    //     [attributeName]: generateID(),
+    //   });
+    // });
+    // tr.setMeta("addToHistory", false);
+    // view.dispatch(tr);
   },
   addProseMirrorPlugins() {
     let dragSourceElement: any = null;

--- a/packages/react/src/BlockNoteView.tsx
+++ b/packages/react/src/BlockNoteView.tsx
@@ -1,7 +1,7 @@
 import { BlockNoteEditor, BlockSchema } from "@blocknote/core";
 import { MantineProvider } from "@mantine/core";
 import { EditorContent } from "@tiptap/react";
-import { ReactNode, useEffect, useState } from "react";
+import { HTMLAttributes, ReactNode } from "react";
 import { getBlockNoteTheme } from "./BlockNoteTheme";
 import { FormattingToolbarPositioner } from "./FormattingToolbar/components/FormattingToolbarPositioner";
 import { HyperlinkToolbarPositioner } from "./HyperlinkToolbar/components/HyperlinkToolbarPositioner";
@@ -12,40 +12,21 @@ export function BlockNoteView<BSchema extends BlockSchema>(
   props: {
     editor: BlockNoteEditor<BSchema>;
     children?: ReactNode;
-  } & React.HTMLAttributes<HTMLDivElement>
+  } & HTMLAttributes<HTMLDivElement>
 ) {
   const { editor, children, ...rest } = props;
-  const [ready, setReady] = useState(false);
-
-  useEffect(() => {
-    function checkReady() {
-      if (!props.editor.ready) {
-        window.setTimeout(checkReady, 100);
-      } else {
-        setReady(true);
-      }
-    }
-    checkReady();
-
-    // TODO: Shouldn't this work with props.editor.ready in deps? It fails in
-    //  tests so it doesn't seem to.
-    // if (props.editor.ready) {
-    //   setReady(true);
-    // }
-  }, [props.editor.ready]);
 
   return (
     <MantineProvider theme={getBlockNoteTheme()}>
       <EditorContent editor={props.editor?._tiptapEditor} {...rest}>
-        {ready &&
-          (props.children || (
-            <>
-              <FormattingToolbarPositioner editor={props.editor} />
-              <HyperlinkToolbarPositioner editor={props.editor} />
-              <SlashMenuPositioner editor={props.editor} />
-              <SideMenuPositioner editor={props.editor} />
-            </>
-          ))}
+        {props.children || (
+          <>
+            <FormattingToolbarPositioner editor={props.editor} />
+            <HyperlinkToolbarPositioner editor={props.editor} />
+            <SlashMenuPositioner editor={props.editor} />
+            <SideMenuPositioner editor={props.editor} />
+          </>
+        )}
       </EditorContent>
     </MantineProvider>
   );

--- a/packages/react/src/hooks/useBlockNote.ts
+++ b/packages/react/src/hooks/useBlockNote.ts
@@ -25,15 +25,16 @@ export const useBlockNote = <BSchema extends BlockSchema = DefaultBlockSchema>(
   options: Partial<BlockNoteEditorOptions<BSchema>> = {},
   deps: DependencyList = []
 ): BlockNoteEditor<BSchema> => {
-  const editorRef = useRef<BlockNoteEditor<BSchema>>(initEditor(options));
+  const editorRef = useRef<BlockNoteEditor<BSchema>>();
 
-  useMemo(() => {
+  const ret = useMemo(() => {
     if (editorRef.current) {
       editorRef.current._tiptapEditor.destroy();
     }
 
     editorRef.current = initEditor(options);
+    return editorRef.current;
   }, [deps, options]); //eslint-disable-line react-hooks/exhaustive-deps
 
-  return editorRef.current;
+  return ret;
 };


### PR DESCRIPTION
with this change we:
- explicitly pass initial content of the editor, so that we can make sure the default paragraph has an `id`
- disable uniqueId onCreate(). As this is disabled for collab anyway, I think it's cleaner to clear this. It also was causing issues with unit tests.
- we don't need to call `replaceBlocks` in onCreate anymore 🎉