### PR TITLE
fix: collaboration initial content bug

### DIFF
--- a/packages/core/src/BlockNoteEditor.ts
+++ b/packages/core/src/BlockNoteEditor.ts
@@ -205,12 +205,15 @@ export class BlockNoteEditor<BSchema extends BlockSchema = DefaultBlockSchema> {
 
     this.schema = newOptions.blockSchema;
 
-    const initialContent = newOptions.initialContent || [
-      {
-        type: "paragraph",
-        id: UniqueID.options.generateID(),
-      },
-    ];
+    const initialContent =
+      newOptions.initialContent || options.collaboration
+        ? undefined
+        : [
+            {
+              type: "paragraph",
+              id: UniqueID.options.generateID(),
+            },
+          ];
 
     const tiptapOptions: EditorOptions = {
       ...blockNoteTipTapOptions,
@@ -220,6 +223,10 @@ export class BlockNoteEditor<BSchema extends BlockSchema = DefaultBlockSchema> {
         this.ready = true;
       },
       onBeforeCreate(editor) {
+        if (!initialContent) {
+          // when using collaboration
+          return;
+        }
         // we have to set the initial content here, because now we can use the editor schema
         // which has been created at this point
         const schema = editor.editor.schema;


### PR DESCRIPTION
https://github.com/TypeCellOS/BlockNote/pull/289 introduced a bug for collaboration.

This line https://github.com/yjs/y-prosemirror/blob/6349748b44859eacb8e54ef94757e2f59bb89113/src/plugins/sync-plugin.js#L193C20-L193C20 would evaluate to true, making y-prosemirror think the user changed the initialcontent intentionally.

This basically always reset the editor to an empty state