### PR TITLE
fix: Custom blocks without inline content

### DIFF
--- a/packages/core/src/api/nodeConversions/nodeConversions.ts
+++ b/packages/core/src/api/nodeConversions/nodeConversions.ts
@@ -369,7 +369,9 @@ export function nodeToBlock<BSchema extends BlockSchema>(
     return cachedBlock;
   }
 
-  let { id, contentNode, contentType, numChildBlocks } = getBlockInfo(node);
+  const blockInfo = getBlockInfo(node);
+
+  let id = blockInfo.id;
 
   // Only used for blocks converted from other formats.
   if (id === null) {
@@ -379,11 +381,13 @@ export function nodeToBlock<BSchema extends BlockSchema>(
   const props: any = {};
   for (const [attr, value] of Object.entries({
     ...node.attrs,
-    ...contentNode.attrs,
+    ...blockInfo.contentNode.attrs,
   })) {
-    const blockSpec = blockSchema[contentType.name];
+    const blockSpec = blockSchema[blockInfo.contentType.name];
     if (!blockSpec) {
-      throw Error("Block is of an unrecognized type: " + contentType.name);
+      throw Error(
+        "Block is of an unrecognized type: " + blockInfo.contentType.name
+      );
     }
 
     const propSchema = blockSpec.propSchema;
@@ -405,10 +409,10 @@ export function nodeToBlock<BSchema extends BlockSchema>(
     }
   }
 
-  const content = contentNodeToInlineContent(contentNode);
+  const content = contentNodeToInlineContent(blockInfo.contentNode);
 
   const children: Block<BSchema>[] = [];
-  for (let i = 0; i < numChildBlocks; i++) {
+  for (let i = 0; i < blockInfo.numChildBlocks; i++) {
     children.push(
       nodeToBlock(node.lastChild!.child(i), blockSchema, blockCache)
     );
@@ -416,7 +420,7 @@ export function nodeToBlock<BSchema extends BlockSchema>(
 
   const block: Block<BSchema> = {
     id,
-    type: contentType.name,
+    type: blockInfo.contentType.name,
     props,
     content,
     children,

--- a/packages/core/src/api/nodeConversions/nodeConversions.ts
+++ b/packages/core/src/api/nodeConversions/nodeConversions.ts
@@ -18,6 +18,7 @@ import {
 } from "../../extensions/Blocks/api/inlineContentTypes";
 import UniqueID from "../../extensions/UniqueID/UniqueID";
 import { UnreachableCaseError } from "../../shared/utils";
+import { getBlockInfo } from "../../extensions/Blocks/helpers/getBlockInfoFromPos";
 
 const toggleStyles = new Set<ToggledStyle>([
   "bold",
@@ -368,10 +369,7 @@ export function nodeToBlock<BSchema extends BlockSchema>(
     return cachedBlock;
   }
 
-  let id = node.attrs["id"];
-  const contentNode = node.firstChild!;
-  const contentType = contentNode.type;
-  const numChildBlocks = node.childCount === 2 ? node.lastChild!.childCount : 0;
+  let { id, contentNode, contentType, numChildBlocks } = getBlockInfo(node);
 
   // Only used for blocks converted from other formats.
   if (id === null) {

--- a/packages/core/src/extensions/Blocks/helpers/getBlockInfoFromPos.ts
+++ b/packages/core/src/extensions/Blocks/helpers/getBlockInfoFromPos.ts
@@ -1,15 +1,39 @@
 import { Node, NodeType } from "prosemirror-model";
 
-export type BlockInfo = {
+export type BlockInfoWithoutPositions = {
   id: string;
   node: Node;
   contentNode: Node;
   contentType: NodeType;
   numChildBlocks: number;
+};
+
+export type BlockInfo = BlockInfoWithoutPositions & {
   startPos: number;
   endPos: number;
   depth: number;
 };
+
+/**
+ * Helper function for `getBlockInfoFromPos`, returns information regarding
+ * provided blockContainer node.
+ * @param blockContainer The blockContainer node to retrieve info for.
+ */
+export function getBlockInfo(blockContainer: Node): BlockInfoWithoutPositions {
+  const id = blockContainer.attrs["id"];
+  const contentNode = blockContainer.firstChild!;
+  const contentType = contentNode.type;
+  const numChildBlocks =
+    blockContainer.childCount === 2 ? blockContainer.lastChild!.childCount : 0;
+
+  return {
+    id,
+    node: blockContainer,
+    contentNode,
+    contentType,
+    numChildBlocks,
+  };
+}
 
 /**
  * Retrieves information regarding the nearest blockContainer node in a
@@ -71,10 +95,7 @@ export function getBlockInfoFromPos(doc: Node, pos: number): BlockInfo {
     node = $pos.node(depth);
   }
 
-  const id = node.attrs["id"];
-  const contentNode = node.firstChild!;
-  const contentType = contentNode.type;
-  const numChildBlocks = node.childCount === 2 ? node.lastChild!.childCount : 0;
+  const { id, contentNode, contentType, numChildBlocks } = getBlockInfo(node);
 
   const startPos = $pos.start(depth);
   const endPos = $pos.end(depth);


### PR DESCRIPTION
A recent change has broken custom blocks which don't contain inline content. This is because we added edge case handling in `getBlockInfoFromPos`, for situations where the selection is outside of any blocks. However, `nodeToBlock` was unnecessarily and incorrectly calling `getBlockInfoFromPos` with the `blockContainer` node instead of the `doc`, and was causing errors when inserting custom blocks without inline content.

Closes #300 