### PR TITLE
fix: Homepage dark theme

### DIFF
--- a/packages/website/docs/.vitepress/theme/components/Examples/BlockNote/ReactBlockNote.module.css
+++ b/packages/website/docs/.vitepress/theme/components/Examples/BlockNote/ReactBlockNote.module.css
@@ -1,4 +1,4 @@
 .editor {
-  background: transparent;
+  background: transparent !important;
   height: 500px;
 }

--- a/packages/website/docs/.vitepress/theme/components/Examples/BlockNote/ReactBlockNote.tsx
+++ b/packages/website/docs/.vitepress/theme/components/Examples/BlockNote/ReactBlockNote.tsx
@@ -52,10 +52,11 @@ export function ReactBlockNote(props: { theme: "light" | "dark" }) {
 
   const editor = useBlockNote(
     {
-      editorDOMAttributes: {
-        class: styles.editor,
+      domAttributes: {
+        editor: {
+          class: styles.editor,
+        },
       },
-      theme: props.theme,
       collaboration: {
         provider,
         fragment: doc.getXmlFragment("blocknote"),
@@ -84,5 +85,5 @@ export function ReactBlockNote(props: { theme: "light" | "dark" }) {
     };
   }, [editor?.domElement]);
 
-  return <BlockNoteView editor={editor} />;
+  return <BlockNoteView editor={editor} theme={props.theme} />;
 }


### PR DESCRIPTION
After improving the theming and styling of BlockNote, I forgot to update the home page demo to work with the new theme API, so this PR fixes that.