### PR TITLE
fix: BlockTypeDropdown can not select Heading

### DIFF
--- a/packages/react/src/FormattingToolbar/components/DefaultDropdowns/BlockTypeDropdown.tsx
+++ b/packages/react/src/FormattingToolbar/components/DefaultDropdowns/BlockTypeDropdown.tsx
@@ -112,7 +112,11 @@ export const BlockTypeDropdown = <BSchema extends BlockSchema>(props: {
             props: {},
           });
         },
-        isSelected: block.type === item.type,
+        isSelected:
+          block.type === item.type &&
+          (block.type === "heading"
+            ? block.props.level === item.props?.level
+            : true),
       })),
     [block, filteredItems, props.editor]
   );


### PR DESCRIPTION
BlockTypeDropdown can now able to select the appropriate heading as per the level of the heading.

fixes: #328

Changes:
- Changed the logic for isSelected prop
- If the block.type is 'heading', it will also check for the level of heading in block.props.level

https://github.com/TypeCellOS/BlockNote/assets/74180320/8eccfe54-8502-4219-955c-46d303f7bf95

