### PR TITLE
fix: block type dropdown cannot update to different levels of heading

### DIFF
--- a/packages/react/src/FormattingToolbar/components/DefaultDropdowns/BlockTypeDropdown.tsx
+++ b/packages/react/src/FormattingToolbar/components/DefaultDropdowns/BlockTypeDropdown.tsx
@@ -112,7 +112,11 @@ export const BlockTypeDropdown = <BSchema extends BlockSchema>(props: {
             props: {},
           });
         },
-        isSelected: block.type === item.type,
+        isSelected:
+          block.type === item.type &&
+          (block.type === "heading"
+            ? block.props.level === item.props?.level
+            : true),
       })),
     [block, filteredItems, props.editor]
   );

--- a/packages/react/src/FormattingToolbar/components/DefaultDropdowns/BlockTypeDropdown.tsx
+++ b/packages/react/src/FormattingToolbar/components/DefaultDropdowns/BlockTypeDropdown.tsx
@@ -9,6 +9,7 @@ import {
   RiListUnordered,
   RiText,
 } from "react-icons/ri";
+import { PartialBlock } from "../../../../../core/src/extensions/Blocks/api/blockTypes";
 
 import { ToolbarDropdown } from "../../../SharedComponents/Toolbar/components/ToolbarDropdown";
 import { useEditorSelectionChange } from "../../../hooks/useEditorSelectionChange";
@@ -109,8 +110,8 @@ export const BlockTypeDropdown = <BSchema extends BlockSchema>(props: {
           props.editor.focus();
           props.editor.updateBlock(block, {
             type: item.type,
-            props: {},
-          });
+            props: item.type === "heading" ? { level: item.props?.level } : {},
+          } as PartialBlock<BSchema>);
         },
         isSelected:
           block.type === item.type &&


### PR DESCRIPTION
BlockTypeDropdown can now able to update different levels of heading.

fixes: #333

Changes:

- Changed the updateBlock function to check the block type as 'heading'
- If it is heading then, it will pass the level of heading as props instead of empty object {}.


https://github.com/TypeCellOS/BlockNote/assets/74180320/54303bc9-4e7d-4036-bc20-647bbb189187

