### PR TITLE
fix: custom blocks may error when it is re-created

### DIFF
--- a/packages/react/src/ReactBlockSpec.tsx
+++ b/packages/react/src/ReactBlockSpec.tsx
@@ -127,6 +127,14 @@ export function createReactBlockSpec<
         // Gets position of the node
         const pos =
           typeof props.getPos === "function" ? props.getPos() : undefined;
+
+        // workaround race condition when re-creating BlockNote from database:
+        // if the position of a node could not be found in a tiptap block, then
+        // the node isn't ready to be rendered
+        if (!pos) {
+          return <></>
+        }
+
         // Gets TipTap editor instance
         const tipTapEditor = editor._tiptapEditor;
         // Gets parent blockContainer node


### PR DESCRIPTION
The custom block wrapper attempts to read the block id of the inner block using getPos(), but the inner block has not been initialized by tiptap yet. Do not attempt to render this block until it is ready