### PR TITLE
Fix: CreateLinkButton does not work when click event propagation prevented

### DIFF
--- a/packages/react/src/FormattingToolbar/components/LinkToolbarButton.tsx
+++ b/packages/react/src/FormattingToolbar/components/LinkToolbarButton.tsx
@@ -1,5 +1,5 @@
 import Tippy from "@tippyjs/react";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useRef, useState } from "react";
 import {
   ToolbarButton,
   ToolbarButtonProps,
@@ -38,27 +38,9 @@ export const LinkToolbarButton = (props: HyperlinkButtonProps) => {
       />
     );
   }, [props]);
-
-  const handleClick = useCallback(
-    (event: MouseEvent) => {
-      if (buttonRef.current?.contains(event.target as HTMLElement)) {
-        setCreationMenuOpen(!creationMenuOpen);
-        return;
-      }
-
-      if (menuRef.current?.contains(event.target as HTMLElement)) {
-        return;
-      }
-
-      setCreationMenuOpen(false);
-    },
-    [creationMenuOpen]
-  );
-
-  useEffect(() => {
-    document.body.addEventListener("click", handleClick);
-    return () => document.body.removeEventListener("click", handleClick);
-  }, [handleClick]);
+  const handleClick = () => {
+    setCreationMenuOpen(!creationMenuOpen);
+  };
 
   return (
     <Tippy
@@ -68,6 +50,7 @@ export const LinkToolbarButton = (props: HyperlinkButtonProps) => {
       maxWidth={500}
       visible={creationMenuOpen}>
       <ToolbarButton
+        onClick={handleClick}
         isSelected={props.isSelected}
         mainTooltip={props.mainTooltip}
         secondaryTooltip={props.secondaryTooltip}

--- a/packages/react/src/FormattingToolbar/components/LinkToolbarButton.tsx
+++ b/packages/react/src/FormattingToolbar/components/LinkToolbarButton.tsx
@@ -1,5 +1,5 @@
 import Tippy from "@tippyjs/react";
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useState } from "react";
 import {
   ToolbarButton,
   ToolbarButtonProps,
@@ -20,9 +20,6 @@ export const LinkToolbarButton = (props: HyperlinkButtonProps) => {
   const [creationMenu, setCreationMenu] = useState<any>();
   const [creationMenuOpen, setCreationMenuOpen] = useState(false);
 
-  const buttonRef = useRef<HTMLButtonElement>(null);
-  const menuRef = useRef<HTMLDivElement>(null);
-
   // TODO: review code; does this pattern still make sense?
   const updateCreationMenu = useCallback(() => {
     setCreationMenu(
@@ -34,10 +31,12 @@ export const LinkToolbarButton = (props: HyperlinkButtonProps) => {
           props.setHyperlink(url, text);
           setCreationMenuOpen(false);
         }}
-        ref={menuRef}
       />
     );
   }, [props]);
+  const handleHide = () => {
+    setCreationMenuOpen(false);
+  };
   const handleClick = () => {
     setCreationMenuOpen(!creationMenuOpen);
   };
@@ -46,6 +45,7 @@ export const LinkToolbarButton = (props: HyperlinkButtonProps) => {
     <Tippy
       content={creationMenu}
       onShow={updateCreationMenu}
+      onHide={handleHide}
       interactive={true}
       maxWidth={500}
       visible={creationMenuOpen}>
@@ -55,7 +55,6 @@ export const LinkToolbarButton = (props: HyperlinkButtonProps) => {
         mainTooltip={props.mainTooltip}
         secondaryTooltip={props.secondaryTooltip}
         icon={props.icon}
-        ref={buttonRef}
       />
     </Tippy>
   );


### PR DESCRIPTION
Hi, thank you for providing great library!

I found a case that `CreateLinkButton` does not work when `BlockNoteView` wrapped by a component with stoping click event propagation, such as modal component, like following:

```tsx
...
<div onClick={(e) => { e.stopPropagation();}}>
  <BlockNoteView editor={editor} />
</div>
...
```

This is because, currently `LinkToolbarButton` captures click event via event listener of `document.body`.
So, this PR fix the problem by changing the way to capture click event of the button as setting `onClick` handler to the button directly.