### PR TITLE
fix: Slash menu error when hitting enter with no items

### DIFF
--- a/packages/core/src/shared/plugins/suggestion/SuggestionPlugin.ts
+++ b/packages/core/src/shared/plugins/suggestion/SuggestionPlugin.ts
@@ -346,6 +346,10 @@ export const setupSuggestionsMenu = <
 
           // Selects an item and closes the menu.
           if (event.key === "Enter") {
+            if (items.length === 0) {
+              return true;
+            }
+
             deactivate(view);
             editor._tiptapEditor
               .chain()


### PR DESCRIPTION
Closes #269 