### PR TITLE
fix: Enter preserves block type when text cursor is at the start of a block

### DIFF
--- a/packages/core/src/extensions/Blocks/nodes/BlockContainer.ts
+++ b/packages/core/src/extensions/Blocks/nodes/BlockContainer.ts
@@ -552,12 +552,14 @@ export const BlockContainer = Node.create<{
               state.selection.from
             )!;
 
+            const selectionAtBlockStart =
+              state.selection.$anchor.parentOffset === 0;
             const blockEmpty = node.textContent.length === 0;
 
             if (!blockEmpty) {
               chain()
                 .deleteSelection()
-                .BNSplitBlock(state.selection.from, false)
+                .BNSplitBlock(state.selection.from, selectionAtBlockStart)
                 .run();
 
               return true;


### PR DESCRIPTION
This PR brings the UX slightly more inline with Notion by changing the behaviour when pressing Enter at the start of a block. Before, it would copy the content to a new block below but the new block would always be a paragraph. Now, the block's type is also copied over.