### PR TITLE
fix: saving-loading meta info

### DIFF
--- a/packages/website/docs/examples/saving-loading.md
+++ b/packages/website/docs/examples/saving-loading.md
@@ -1,8 +1,8 @@
 ---
-title: Alert Block
-description: In this example, we create a custom Alert block which is used to emphasize text.
-imageTitle: Alert Block
-path: /examples/alert-block
+title: Saving & Loading
+description: In this example, we save the editor contents to local storage whenever a change is made, and load the saved contents when the editor is created.
+imageTitle: Saving & Loading
+path: /examples/saving-loading
 ---
 
 <script setup>


### PR DESCRIPTION
The current saving-loading page info is not the correct

<img width="923" alt="image" src="https://github.com/TypeCellOS/BlockNote/assets/26347085/a12c419c-0aa1-4e71-b58e-7343420190d2">
