### PR TITLE
fix: Removed warning when node attribute does not correspond to a prop

### DIFF
--- a/packages/core/src/api/nodeConversions/nodeConversions.ts
+++ b/packages/core/src/api/nodeConversions/nodeConversions.ts
@@ -5,7 +5,6 @@ import {
   BlockSchema,
   PartialBlock,
 } from "../../extensions/Blocks/api/blockTypes";
-import { defaultProps } from "../../extensions/Blocks/api/defaultProps";
 import {
   ColorStyle,
   InlineContent,
@@ -393,18 +392,6 @@ export function nodeToBlock<BSchema extends BlockSchema>(
 
     if (attr in propSchema) {
       props[attr] = value;
-    }
-    // Block ids are stored as node attributes the same way props are, so we
-    // need to ensure we don't attempt to read block ids as props.
-
-    // the second check is for the backgroundColor & textColor props.
-    // Since we want them to be inherited by child blocks, we can't put them on the blockContent node,
-    // and instead have to put them on the blockContainer node.
-    // The blockContainer node is the same for all block types, but some custom blocks might not use backgroundColor & textColor,
-    // so these 2 props are technically unexpected but we shouldn't log a warning.
-    // (this is a bit hacky)
-    else if (attr !== "id" && !(attr in defaultProps)) {
-      console.warn("Block has an unrecognized attribute: " + attr);
     }
   }
 


### PR DESCRIPTION
The warning we log when converting a TipTap node to BlockNote block, which triggers when a node attribute doesn't correspond to a block prop, triggers false positives on the list item block's `index` attribute. The warning isn't actually useful for diagnosing bugs since custom blocks are made using the API anyway where the warning won't trigger, so it's only useful when converting an existing TipTap node to a block, which isn't recommended and is an advanced (not even documented) use case. Therefore, this PR removes that warning altogether. Closes #308 