### PR TITLE
fix: `_tiptapOptions` typing and fields getting overridden

### DIFF
--- a/packages/core/src/BlockNoteEditor.ts
+++ b/packages/core/src/BlockNoteEditor.ts
@@ -140,7 +140,7 @@ export type BlockNoteEditorOptions<BSchema extends BlockSchema> = {
   };
 
   // tiptap options, undocumented
-  _tiptapOptions: any;
+  _tiptapOptions: Partial<EditorOptions>;
 };
 
 const blockNoteTipTapOptions = {
@@ -228,10 +228,11 @@ export class BlockNoteEditor<BSchema extends BlockSchema = DefaultBlockSchema> {
             },
           ]);
 
-    const tiptapOptions: EditorOptions = {
+    const tiptapOptions: Partial<EditorOptions> = {
       ...blockNoteTipTapOptions,
       ...newOptions._tiptapOptions,
       onBeforeCreate(editor) {
+        newOptions._tiptapOptions?.onBeforeCreate?.(editor);
         if (!initialContent) {
           // when using collaboration
           return;
@@ -250,7 +251,8 @@ export class BlockNoteEditor<BSchema extends BlockSchema = DefaultBlockSchema> {
         );
         editor.editor.options.content = root.toJSON();
       },
-      onCreate: () => {
+      onCreate: (editor) => {
+        newOptions._tiptapOptions?.onCreate?.(editor);
         // We need to wait for the TipTap editor to init before we can set the
         // initial content, as the schema may contain custom blocks which need
         // it to render.
@@ -261,7 +263,8 @@ export class BlockNoteEditor<BSchema extends BlockSchema = DefaultBlockSchema> {
         newOptions.onEditorReady?.(this);
         this.ready = true;
       },
-      onUpdate: () => {
+      onUpdate: (editor) => {
+        newOptions._tiptapOptions?.onUpdate?.(editor);
         // This seems to be necessary due to a bug in TipTap:
         // https://github.com/ueberdosis/tiptap/issues/2583
         if (!this.ready) {
@@ -270,7 +273,8 @@ export class BlockNoteEditor<BSchema extends BlockSchema = DefaultBlockSchema> {
 
         newOptions.onEditorContentChange?.(this);
       },
-      onSelectionUpdate: () => {
+      onSelectionUpdate: (editor) => {
+        newOptions._tiptapOptions?.onSelectionUpdate?.(editor);
         // This seems to be necessary due to a bug in TipTap:
         // https://github.com/ueberdosis/tiptap/issues/2583
         if (!this.ready) {
@@ -279,17 +283,24 @@ export class BlockNoteEditor<BSchema extends BlockSchema = DefaultBlockSchema> {
 
         newOptions.onTextCursorPositionChange?.(this);
       },
-      editable: options.editable === undefined ? true : options.editable,
-      extensions:
-        newOptions.enableBlockNoteExtensions === false
-          ? newOptions._tiptapOptions?.extensions
-          : [...(newOptions._tiptapOptions?.extensions || []), ...extensions],
+      editable:
+        newOptions._tiptapOptions?.editable !== undefined
+          ? newOptions._tiptapOptions?.editable
+          : options.editable === undefined
+          ? true
+          : options.editable,
+      extensions: !newOptions.enableBlockNoteExtensions
+        ? newOptions._tiptapOptions?.extensions || []
+        : [...(newOptions._tiptapOptions?.extensions || []), ...extensions],
       editorProps: {
+        ...newOptions._tiptapOptions?.editorProps,
         attributes: {
+          ...newOptions._tiptapOptions?.editorProps?.attributes,
           ...newOptions.domAttributes?.editor,
           class: mergeCSSClasses(
             styles.bnEditor,
             styles.bnRoot,
+            newOptions.domAttributes?.editor?.class || "",
             newOptions.defaultStyles ? styles.defaultStyles : "",
             newOptions.domAttributes?.editor?.class || ""
           ),

--- a/packages/core/src/BlockNoteEditor.ts
+++ b/packages/core/src/BlockNoteEditor.ts
@@ -289,9 +289,10 @@ export class BlockNoteEditor<BSchema extends BlockSchema = DefaultBlockSchema> {
           : newOptions._tiptapOptions?.editable !== undefined
           ? newOptions._tiptapOptions?.editable
           : true,
-      extensions: !newOptions.enableBlockNoteExtensions
-        ? newOptions._tiptapOptions?.extensions || []
-        : [...(newOptions._tiptapOptions?.extensions || []), ...extensions],
+      extensions:
+        newOptions.enableBlockNoteExtensions === false
+          ? newOptions._tiptapOptions?.extensions || []
+          : [...(newOptions._tiptapOptions?.extensions || []), ...extensions],
       editorProps: {
         ...newOptions._tiptapOptions?.editorProps,
         attributes: {

--- a/packages/core/src/BlockNoteEditor.ts
+++ b/packages/core/src/BlockNoteEditor.ts
@@ -284,11 +284,11 @@ export class BlockNoteEditor<BSchema extends BlockSchema = DefaultBlockSchema> {
         newOptions.onTextCursorPositionChange?.(this);
       },
       editable:
-        newOptions._tiptapOptions?.editable !== undefined
+        options.editable !== undefined
+          ? options.editable
+          : newOptions._tiptapOptions?.editable !== undefined
           ? newOptions._tiptapOptions?.editable
-          : options.editable === undefined
-          ? true
-          : options.editable,
+          : true,
       extensions: !newOptions.enableBlockNoteExtensions
         ? newOptions._tiptapOptions?.extensions || []
         : [...(newOptions._tiptapOptions?.extensions || []), ...extensions],


### PR DESCRIPTION
Currently, some fields passed in the `_tiptapOptions` editor option are completely overwritten, such as `onCreate`, and `onUpdate`. This PR fixes this so that both options passed in `_tiptapOptions` and the remaining editor options are applied. BlockNote options take priority over TipTap options for fields that take primitive values. For fields that take objects/arrays, the options are merged. Closes #389 