### PR TITLE
Added editor option to disable nested blocks

### DIFF
--- a/packages/core/src/BlockNoteEditor.ts
+++ b/packages/core/src/BlockNoteEditor.ts
@@ -94,7 +94,7 @@ export type BlockNoteEditorOptions<BSchema extends BlockSchema> = {
   /**
    * Disables block nesting by the user if set to `false`.
    */
-  canNestBlock: boolean;
+  enableNestedBlocks: boolean;
   /**
    * The content that should be in the editor when it's created, represented as an array of partial block objects.
    */
@@ -287,13 +287,15 @@ export class BlockNoteEditor<BSchema extends BlockSchema = DefaultBlockSchema> {
 
         newOptions.onTextCursorPositionChange?.(this);
       },
-      canNestBlock:
-        options.canNestBlock !== undefined ? options.canNestBlock : true,
       editable:
         options.editable !== undefined
           ? options.editable
           : newOptions._tiptapOptions?.editable !== undefined
           ? newOptions._tiptapOptions?.editable
+          : true,
+      enableNestedBlocks:
+        options.enableNestedBlocks !== undefined
+          ? options.enableNestedBlocks
           : true,
       extensions:
         newOptions.enableBlockNoteExtensions === false
@@ -761,6 +763,13 @@ export class BlockNoteEditor<BSchema extends BlockSchema = DefaultBlockSchema> {
    * Checks if the block containing the text cursor can be nested.
    */
   public canNestBlock() {
+    if (
+      typeof this._tiptapEditor.options.enableNestedBlocks === "boolean" &&
+      !this._tiptapEditor.options.enableNestedBlocks
+    ) {
+      return false;
+    }
+
     const { startPos, depth } = getBlockInfoFromPos(
       this._tiptapEditor.state.doc,
       this._tiptapEditor.state.selection.from
@@ -780,6 +789,13 @@ export class BlockNoteEditor<BSchema extends BlockSchema = DefaultBlockSchema> {
    * Checks if the block containing the text cursor is nested.
    */
   public canUnnestBlock() {
+    if (
+      typeof this._tiptapEditor.options.enableNestedBlocks === "boolean" &&
+      !this._tiptapEditor.options.enableNestedBlocks
+    ) {
+      return false;
+    }
+
     const { depth } = getBlockInfoFromPos(
       this._tiptapEditor.state.doc,
       this._tiptapEditor.state.selection.from

--- a/packages/core/src/BlockNoteEditor.ts
+++ b/packages/core/src/BlockNoteEditor.ts
@@ -92,6 +92,10 @@ export type BlockNoteEditorOptions<BSchema extends BlockSchema> = {
    */
   editable: boolean;
   /**
+   * Disables block nesting by the user if set to `false`.
+   */
+  canNestBlock: boolean;
+  /**
    * The content that should be in the editor when it's created, represented as an array of partial block objects.
    */
   initialContent: PartialBlock<BSchema>[];
@@ -283,6 +287,8 @@ export class BlockNoteEditor<BSchema extends BlockSchema = DefaultBlockSchema> {
 
         newOptions.onTextCursorPositionChange?.(this);
       },
+      canNestBlock:
+        options.canNestBlock !== undefined ? options.canNestBlock : true,
       editable:
         options.editable !== undefined
           ? options.editable

--- a/packages/core/src/BlockNoteEditor.ts
+++ b/packages/core/src/BlockNoteEditor.ts
@@ -158,6 +158,7 @@ export class BlockNoteEditor<BSchema extends BlockSchema = DefaultBlockSchema> {
   public blockCache = new WeakMap<Node, Block<BSchema>>();
   public readonly schema: BSchema;
   public ready = false;
+  public enableNestedBlocks = true;
 
   public readonly sideMenu: SideMenuProsemirrorPlugin<BSchema>;
   public readonly formattingToolbar: FormattingToolbarProsemirrorPlugin<BSchema>;
@@ -194,6 +195,10 @@ export class BlockNoteEditor<BSchema extends BlockSchema = DefaultBlockSchema> {
     );
     this.hyperlinkToolbar = new HyperlinkToolbarProsemirrorPlugin(this);
     this.imageToolbar = new ImageToolbarProsemirrorPlugin(this);
+    this.enableNestedBlocks =
+      options.enableNestedBlocks !== undefined
+        ? options.enableNestedBlocks
+        : true;
 
     const extensions = getBlockNoteExtensions<BSchema>({
       editor: this,
@@ -292,10 +297,6 @@ export class BlockNoteEditor<BSchema extends BlockSchema = DefaultBlockSchema> {
           ? options.editable
           : newOptions._tiptapOptions?.editable !== undefined
           ? newOptions._tiptapOptions?.editable
-          : true,
-      enableNestedBlocks:
-        options.enableNestedBlocks !== undefined
-          ? options.enableNestedBlocks
           : true,
       extensions:
         newOptions.enableBlockNoteExtensions === false
@@ -763,10 +764,7 @@ export class BlockNoteEditor<BSchema extends BlockSchema = DefaultBlockSchema> {
    * Checks if the block containing the text cursor can be nested.
    */
   public canNestBlock() {
-    if (
-      typeof this._tiptapEditor.options.enableNestedBlocks === "boolean" &&
-      !this._tiptapEditor.options.enableNestedBlocks
-    ) {
+    if (!this.enableNestedBlocks) {
       return false;
     }
 
@@ -789,10 +787,7 @@ export class BlockNoteEditor<BSchema extends BlockSchema = DefaultBlockSchema> {
    * Checks if the block containing the text cursor is nested.
    */
   public canUnnestBlock() {
-    if (
-      typeof this._tiptapEditor.options.enableNestedBlocks === "boolean" &&
-      !this._tiptapEditor.options.enableNestedBlocks
-    ) {
+    if (!this.enableNestedBlocks) {
       return false;
     }
 

--- a/packages/core/src/BlockNoteExtensions.ts
+++ b/packages/core/src/BlockNoteExtensions.ts
@@ -94,6 +94,7 @@ export const getBlockNoteExtensions = <BSchema extends BlockSchema>(opts: {
     Doc,
     BlockContainer.configure({
       domAttributes: opts.domAttributes,
+      enableNestedBlocks: opts.editor.enableNestedBlocks,
     }),
     BlockGroup.configure({
       domAttributes: opts.domAttributes,

--- a/packages/core/src/extensions/Blocks/nodes/BlockContainer.ts
+++ b/packages/core/src/extensions/Blocks/nodes/BlockContainer.ts
@@ -632,23 +632,21 @@ export const BlockContainer = Node.create<{
       Tab: () => {
         if (
           typeof this.editor.options.enableNestedBlocks === "boolean" &&
-          !this.editor.options.enableNestedBlocks
+          this.editor.options.enableNestedBlocks
         ) {
-          return false;
+          this.editor.commands.sinkListItem("blockContainer");
         }
 
-        this.editor.commands.sinkListItem("blockContainer");
         return true;
       },
       "Shift-Tab": () => {
         if (
           typeof this.editor.options.enableNestedBlocks === "boolean" &&
-          !this.editor.options.enableNestedBlocks
+          this.editor.options.enableNestedBlocks
         ) {
-          return false;
+          this.editor.commands.liftListItem("blockContainer");
         }
 
-        this.editor.commands.liftListItem("blockContainer");
         return true;
       },
       "Mod-Alt-0": () =>

--- a/packages/core/src/extensions/Blocks/nodes/BlockContainer.ts
+++ b/packages/core/src/extensions/Blocks/nodes/BlockContainer.ts
@@ -621,11 +621,15 @@ export const BlockContainer = Node.create<{
       // Always returning true for tab key presses ensures they're not captured by the browser. Otherwise, they blur the
       // editor since the browser will try to use tab for keyboard navigation.
       Tab: () => {
-        this.editor.commands.sinkListItem("blockContainer");
+        if (this.editor.options.canNestBlock) {
+          this.editor.commands.sinkListItem("blockContainer");
+        }
         return true;
       },
       "Shift-Tab": () => {
-        this.editor.commands.liftListItem("blockContainer");
+        if (!this.editor.options.canNestBlock) {
+          this.editor.commands.liftListItem("blockContainer");
+        }
         return true;
       },
       "Mod-Alt-0": () =>

--- a/packages/core/src/extensions/Blocks/nodes/BlockContainer.ts
+++ b/packages/core/src/extensions/Blocks/nodes/BlockContainer.ts
@@ -42,15 +42,13 @@ declare module "@tiptap/core" {
  */
 export const BlockContainer = Node.create<{
   domAttributes?: BlockNoteDOMAttributes;
+  enableNestedBlocks?: boolean;
 }>({
   name: "blockContainer",
   group: "blockContainer",
   // A block always contains content, and optionally a blockGroup which contains nested blocks
   content() {
-    if (
-      typeof this.editor?.options.enableNestedBlocks === "boolean" &&
-      !this.editor?.options.enableNestedBlocks
-    ) {
+    if (!this.options.enableNestedBlocks) {
       return "blockContent";
     }
 
@@ -630,20 +628,14 @@ export const BlockContainer = Node.create<{
       // Always returning true for tab key presses ensures they're not captured by the browser. Otherwise, they blur the
       // editor since the browser will try to use tab for keyboard navigation.
       Tab: () => {
-        if (
-          typeof this.editor.options.enableNestedBlocks === "boolean" &&
-          this.editor.options.enableNestedBlocks
-        ) {
+        if (this.options.enableNestedBlocks) {
           this.editor.commands.sinkListItem("blockContainer");
         }
 
         return true;
       },
       "Shift-Tab": () => {
-        if (
-          typeof this.editor.options.enableNestedBlocks === "boolean" &&
-          this.editor.options.enableNestedBlocks
-        ) {
+        if (this.options.enableNestedBlocks) {
           this.editor.commands.liftListItem("blockContainer");
         }
 

--- a/packages/core/src/extensions/Blocks/nodes/BlockContainer.ts
+++ b/packages/core/src/extensions/Blocks/nodes/BlockContainer.ts
@@ -46,7 +46,16 @@ export const BlockContainer = Node.create<{
   name: "blockContainer",
   group: "blockContainer",
   // A block always contains content, and optionally a blockGroup which contains nested blocks
-  content: "blockContent blockGroup?",
+  content() {
+    if (
+      typeof this.editor?.options.enableNestedBlocks === "boolean" &&
+      !this.editor?.options.enableNestedBlocks
+    ) {
+      return "blockContent";
+    }
+
+    return "blockContent blockGroup?";
+  },
   // Ensures content-specific keyboard handlers trigger first.
   priority: 50,
   defining: true,
@@ -621,15 +630,25 @@ export const BlockContainer = Node.create<{
       // Always returning true for tab key presses ensures they're not captured by the browser. Otherwise, they blur the
       // editor since the browser will try to use tab for keyboard navigation.
       Tab: () => {
-        if (this.editor.options.canNestBlock) {
-          this.editor.commands.sinkListItem("blockContainer");
+        if (
+          typeof this.editor.options.enableNestedBlocks === "boolean" &&
+          !this.editor.options.enableNestedBlocks
+        ) {
+          return false;
         }
+
+        this.editor.commands.sinkListItem("blockContainer");
         return true;
       },
       "Shift-Tab": () => {
-        if (!this.editor.options.canNestBlock) {
-          this.editor.commands.liftListItem("blockContainer");
+        if (
+          typeof this.editor.options.enableNestedBlocks === "boolean" &&
+          !this.editor.options.enableNestedBlocks
+        ) {
+          return false;
         }
+
+        this.editor.commands.liftListItem("blockContainer");
         return true;
       },
       "Mod-Alt-0": () =>


### PR DESCRIPTION
This PR adds an option to the editor  to disable nested blocks. (on tab command or via formatting toolbar)

example configuration "canNestBlock":

`export type BlockNoteEditorOptions = Partial<{
  editable: boolean;
  canNestBlock: boolean;
  initialContent: PartialBlock[];
  editorDOMAttributes: Record<string, string>;
  onEditorReady: (editor: BlockNoteEditor) => void;
  onEditorContentChange: (editor: BlockNoteEditor) => void;
  onTextCursorPositionChange: (editor: BlockNoteEditor) => void;
  slashMenuItems: ReactSlashMenuItem[];
  defaultStyles: boolean;
  uploadFile: (file: File) => Promise<string>
}>;`
