### PR TITLE
Standardize shortcuts

### DIFF
--- a/packages/core/src/extensions/Blocks/nodes/BlockContent/ListItemBlockContent/BulletListItemBlockContent/BulletListItemBlockContent.ts
+++ b/packages/core/src/extensions/Blocks/nodes/BlockContent/ListItemBlockContent/BulletListItemBlockContent/BulletListItemBlockContent.ts
@@ -35,7 +35,7 @@ const BulletListItemBlockContent = createTipTapBlock<"bulletListItem", true>({
   addKeyboardShortcuts() {
     return {
       Enter: () => handleEnter(this.editor),
-      "Mod-Shift-7": () =>
+      "Mod-Shift-8": () =>
         this.editor.commands.BNUpdateBlock<{
           bulletListItem: BlockSpec<
             "bulletListItem",

--- a/packages/core/src/extensions/Blocks/nodes/BlockContent/ListItemBlockContent/NumberedListItemBlockContent/NumberedListItemBlockContent.ts
+++ b/packages/core/src/extensions/Blocks/nodes/BlockContent/ListItemBlockContent/NumberedListItemBlockContent/NumberedListItemBlockContent.ts
@@ -53,7 +53,7 @@ const NumberedListItemBlockContent = createTipTapBlock<
   addKeyboardShortcuts() {
     return {
       Enter: () => handleEnter(this.editor),
-      "Mod-Shift-8": () =>
+      "Mod-Shift-7": () =>
         this.editor.commands.BNUpdateBlock<{
           numberedListItem: BlockSpec<
             "numberedListItem",

--- a/packages/react/src/SlashMenu/defaultReactSlashMenuItems.tsx
+++ b/packages/react/src/SlashMenu/defaultReactSlashMenuItems.tsx
@@ -46,13 +46,13 @@ const extraFields: Record<
     group: "Basic blocks",
     icon: <RiListOrdered size={18} />,
     hint: "Used to display a numbered list",
-    shortcut: formatKeyboardShortcut("Mod-Alt-7"),
+    shortcut: formatKeyboardShortcut("Mod-Shift-7"),
   },
   "Bullet List": {
     group: "Basic blocks",
     icon: <RiListUnordered size={18} />,
     hint: "Used to display an unordered list",
-    shortcut: formatKeyboardShortcut("Mod-Alt-9"),
+    shortcut: formatKeyboardShortcut("Mod-Shift-8"),
   },
   Paragraph: {
     group: "Basic blocks",


### PR DESCRIPTION
There was confusion between the keyboard shortcuts specified in ﻿defaultReactSlashMenuItems.tsx and the actual keyboard shortcuts. To resolve this, I decided to align them and set the default shortcuts to match those of Google Docs.