### PR TITLE
fix: block id null when using collaboration

### DIFF
--- a/examples/editor/src/main.tsx
+++ b/examples/editor/src/main.tsx
@@ -6,7 +6,8 @@ window.React = React;
 
 const root = createRoot(document.getElementById("root")!);
 root.render(
-  <React.StrictMode>
-    <App />
-  </React.StrictMode>
+  // TODO: StrictMode is causing duplicate mounts and conflicts with collaboration
+  // <React.StrictMode>
+  <App />
+  // </React.StrictMode>
 );

--- a/packages/core/src/BlockNoteEditor.ts
+++ b/packages/core/src/BlockNoteEditor.ts
@@ -29,7 +29,6 @@ import {
   BlockSchema,
   PartialBlock,
 } from "./extensions/Blocks/api/blockTypes";
-import { TextCursorPosition } from "./extensions/Blocks/api/cursorPositionTypes";
 import {
   DefaultBlockSchema,
   defaultBlockSchema,
@@ -42,6 +41,7 @@ import {
 import { Selection } from "./extensions/Blocks/api/selectionTypes";
 import { getBlockInfoFromPos } from "./extensions/Blocks/helpers/getBlockInfoFromPos";
 
+import { TextCursorPosition } from "./extensions/Blocks/api/cursorPositionTypes";
 import { FormattingToolbarProsemirrorPlugin } from "./extensions/FormattingToolbar/FormattingToolbarPlugin";
 import { HyperlinkToolbarProsemirrorPlugin } from "./extensions/HyperlinkToolbar/HyperlinkToolbarPlugin";
 import { ImageToolbarProsemirrorPlugin } from "./extensions/ImageToolbar/ImageToolbarPlugin";
@@ -217,6 +217,12 @@ export class BlockNoteEditor<BSchema extends BlockSchema = DefaultBlockSchema> {
 
     this.uploadFile = newOptions.uploadFile;
 
+    if (newOptions.collaboration && newOptions.initialContent) {
+      console.warn(
+        "When using Collaboration, initialContent might cause conflicts, because changes should come from the collaboration provider"
+      );
+    }
+
     const initialContent =
       newOptions.initialContent ||
       (options.collaboration
@@ -233,20 +239,28 @@ export class BlockNoteEditor<BSchema extends BlockSchema = DefaultBlockSchema> {
       ...newOptions._tiptapOptions,
       onBeforeCreate(editor) {
         newOptions._tiptapOptions?.onBeforeCreate?.(editor);
-        if (!initialContent) {
-          // when using collaboration
-          return;
-        }
-
         // We always set the initial content to a single paragraph block. This
         // allows us to easily replace it with the actual initial content once
         // the TipTap editor is initialized.
         const schema = editor.editor.schema;
+
+        // This is a hack to make "initial content detection" by y-prosemirror (and also tiptap isEmpty)
+        // properly detect whether or not the document has changed.
+        // We change the doc.createAndFill function to make sure the initial block id is set, instead of null
+        const oldCreateAndFill = schema.nodes.doc.createAndFill;
+        (schema.nodes.doc as any).createAndFill = (...args: any) => {
+          const ret = oldCreateAndFill.apply(schema.nodes.doc, args);
+          const jsonNode = ret!.toJSON();
+          jsonNode.content[0].content[0].attrs.id = "initialBlockId";
+
+          return Node.fromJSON(schema, jsonNode);
+        };
+
         const root = schema.node(
           "doc",
           undefined,
           schema.node("blockGroup", undefined, [
-            blockToNode({ id: "initialBlock", type: "paragraph" }, schema),
+            blockToNode({ id: "initialBlockId", type: "paragraph" }, schema),
           ])
         );
         editor.editor.options.content = root.toJSON();

--- a/packages/core/src/extensions/SideMenu/SideMenuPlugin.ts
+++ b/packages/core/src/extensions/SideMenu/SideMenuPlugin.ts
@@ -411,12 +411,6 @@ export class SideMenuView<BSchema extends BlockSchema> implements PluginView {
     };
     const block = getDraggableBlockFromCoords(coords, this.pmView);
 
-    if (!block?.id) {
-      // temporary fix for a blank document using collaboration,
-      // in this case it can happen there's a block with no id
-      // TODO: fix root cause
-      return;
-    }
     // Closes the menu if the mouse cursor is beyond the editor vertically.
     if (!block || !this.editor.isEditable) {
       if (this.sideMenuState?.show) {

--- a/packages/core/src/extensions/SideMenu/SideMenuPlugin.ts
+++ b/packages/core/src/extensions/SideMenu/SideMenuPlugin.ts
@@ -411,6 +411,12 @@ export class SideMenuView<BSchema extends BlockSchema> implements PluginView {
     };
     const block = getDraggableBlockFromCoords(coords, this.pmView);
 
+    if (!block?.id) {
+      // temporary fix for a blank document using collaboration,
+      // in this case it can happen there's a block with no id
+      // TODO: fix root cause
+      return;
+    }
     // Closes the menu if the mouse cursor is beyond the editor vertically.
     if (!block || !this.editor.isEditable) {
       if (this.sideMenuState?.show) {


### PR DESCRIPTION
fixes https://github.com/TypeCellOS/BlockNote/issues/366

and `Uncaught TypeError: Cannot read properties of null (reading 'id')` when hovering over an empty block when using collaboration (reported via discord)


yjs calls `createAndFill` here: https://github.com/yjs/y-prosemirror/blob/e0e5e951614abe1be2295e5ab8987ab5916bcaec/src/plugins/sync-plugin.js#L194