### PR TITLE
docs: update the example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ function App() {
   const editor = useBlockNote({
     onEditorContentChange: (editor) => {
       // Log the document to console on every update
-      console.log(editor.getJSON());
+      console.log(editor._tiptapEditor.getJSON());
     },
   });
 


### PR DESCRIPTION
Hi, I just tried the tutorial and found the example code is not working.
I think `toJSON` is a method on the Tiptop Editor class, so I updated it to use `_tiptapEditor` instead.

If you have an alternative way to show the actual content, please let me know, Thank you!