### PR TITLE
feat: Return values for block manipulation methods

### DIFF
--- a/packages/core/src/api/blockManipulation/blockManipulation.ts
+++ b/packages/core/src/api/blockManipulation/blockManipulation.ts
@@ -130,7 +130,6 @@ function removeBlocksWithCallback<
   ) => number
 ): Block<BSchema, I, S>[] {
   const ttEditor = editor._tiptapEditor;
-
   const tr = ttEditor.state.tr;
 
   const idsOfBlocksToRemove = new Set<string>(
@@ -155,6 +154,7 @@ function removeBlocksWithCallback<
       return true;
     }
 
+    // Saves the block that is being deleted.
     removedBlocks.push(
       nodeToBlock(
         node,
@@ -166,6 +166,7 @@ function removeBlocksWithCallback<
     );
     idsOfBlocksToRemove.delete(node.attrs.id);
 
+    // Removes the block and calculates the change in document size.
     removedSize = callback?.(node, pos, tr, removedSize) || removedSize;
     const oldDocSize = tr.doc.nodeSize;
     tr.delete(pos - removedSize - 1, pos - removedSize + node.nodeSize + 1);
@@ -175,12 +176,13 @@ function removeBlocksWithCallback<
     return false;
   });
 
+  // Throws an error if now all blocks could be found.
   if (idsOfBlocksToRemove.size > 0) {
     const notFoundIds = [...idsOfBlocksToRemove].join("\n");
 
     throw Error(
       "Blocks with the following IDs could not be found in the editor: " +
-      notFoundIds
+        notFoundIds
     );
   }
 
@@ -215,10 +217,8 @@ export function replaceBlocks<
   const ttEditor = editor._tiptapEditor;
 
   const nodesToInsert: Node[] = [];
-  for (const blockSpec of blocksToInsert) {
-    nodesToInsert.push(
-      blockToNode(blockSpec, ttEditor.schema, editor.styleSchema)
-    );
+  for (const block of blocksToInsert) {
+    nodesToInsert.push(blockToNode(block, ttEditor.schema, editor.styleSchema));
   }
 
   const idOfFirstBlock =
@@ -256,5 +256,5 @@ export function replaceBlocks<
     );
   }
 
-  return { insertedBlocks, removedBlocks }
+  return { insertedBlocks, removedBlocks };
 }

--- a/packages/core/src/editor/BlockNoteEditor.ts
+++ b/packages/core/src/editor/BlockNoteEditor.ts
@@ -21,11 +21,11 @@ import { HTMLToBlocks } from "../api/parsers/html/parseHTML";
 import { markdownToBlocks } from "../api/parsers/markdown/parseMarkdown";
 import {
   DefaultBlockSchema,
-  DefaultInlineContentSchema,
-  DefaultStyleSchema,
   defaultBlockSchema,
   defaultBlockSpecs,
+  DefaultInlineContentSchema,
   defaultInlineContentSpecs,
+  DefaultStyleSchema,
   defaultStyleSpecs,
 } from "../blocks/defaultBlocks";
 import { FormattingToolbarProsemirrorPlugin } from "../extensions/FormattingToolbar/FormattingToolbarPlugin";
@@ -45,17 +45,17 @@ import {
   BlockSchemaFromSpecs,
   BlockSchemaWithBlock,
   BlockSpecs,
+  getBlockSchemaFromSpecs,
+  getInlineContentSchemaFromSpecs,
+  getStyleSchemaFromSpecs,
   InlineContentSchema,
   InlineContentSchemaFromSpecs,
   InlineContentSpecs,
   PartialBlock,
+  Styles,
   StyleSchema,
   StyleSchemaFromSpecs,
   StyleSpecs,
-  Styles,
-  getBlockSchemaFromSpecs,
-  getInlineContentSchemaFromSpecs,
-  getStyleSchemaFromSpecs,
 } from "../schema";
 import { mergeCSSClasses } from "../util/browser";
 import { UnreachableCaseError } from "../util/typescript";
@@ -776,8 +776,8 @@ export class BlockNoteEditor<
     blocksToInsert: PartialBlock<BSchema, ISchema, SSchema>[],
     referenceBlock: BlockIdentifier,
     placement: "before" | "after" | "nested" = "before"
-  ): void {
-    insertBlocks(blocksToInsert, referenceBlock, placement, this);
+  ) {
+    return insertBlocks(blocksToInsert, referenceBlock, placement, this);
   }
 
   /**
@@ -791,7 +791,7 @@ export class BlockNoteEditor<
     blockToUpdate: BlockIdentifier,
     update: PartialBlock<BSchema, ISchema, SSchema>
   ) {
-    updateBlock(blockToUpdate, update, this._tiptapEditor);
+    return updateBlock(blockToUpdate, update, this);
   }
 
   /**
@@ -799,7 +799,7 @@ export class BlockNoteEditor<
    * @param blocksToRemove An array of identifiers for existing blocks that should be removed.
    */
   public removeBlocks(blocksToRemove: BlockIdentifier[]) {
-    removeBlocks(blocksToRemove, this._tiptapEditor);
+    return removeBlocks(blocksToRemove, this);
   }
 
   /**
@@ -813,7 +813,7 @@ export class BlockNoteEditor<
     blocksToRemove: BlockIdentifier[],
     blocksToInsert: PartialBlock<BSchema, ISchema, SSchema>[]
   ) {
-    replaceBlocks(blocksToRemove, blocksToInsert, this);
+    return replaceBlocks(blocksToRemove, blocksToInsert, this);
   }
 
   /**


### PR DESCRIPTION
This PR adds return values for the following `BlockNoteEditor` methods:
```
// Returns the blocks after being inserted
insertBlocks(...): Block[]

// Returns the updated block
updateBlock(...): Block

// Returns the blocks that were removed
removeBlocks(...): Block[]

// Returns both the blocks that were removed and the blocks after being inserted
replaceBlocks(...): {
  insertedBlocks: Block[];
  removedBlocks: Block[];
}
```

Closes #410 