### PR TITLE
fix: Remove console logs while pasting

### DIFF
--- a/packages/core/src/api/parsers/pasteExtension.ts
+++ b/packages/core/src/api/parsers/pasteExtension.ts
@@ -44,7 +44,6 @@ export const createPasteFromClipboardExtension = <
                     );
 
                     data = htmlNode.innerHTML;
-                    console.log(data);
                   }
                   editor._tiptapEditor.view.pasteHTML(data);
                 }


### PR DESCRIPTION
This PR removes console.log generated while pasting content from clipboard

- closes #477 