### PR TITLE
fix: Multiline list indentation

### DIFF
--- a/packages/core/src/editor/Block.css
+++ b/packages/core/src/editor/Block.css
@@ -48,7 +48,8 @@ NESTED BLOCKS
   position: relative;
 }
 
-.bn-block-group .bn-block-group
+.bn-block-group
+  .bn-block-group
   > .bn-block-outer:not([data-prev-depth-changed])::before {
   content: " ";
   display: inline;
@@ -58,7 +59,8 @@ NESTED BLOCKS
   transition: all 0.2s 0.1s;
 }
 
-.bn-block-group .bn-block-group
+.bn-block-group
+  .bn-block-group
   > .bn-block-outer[data-prev-depth-change="-2"]::before {
   height: 0;
 }
@@ -147,6 +149,11 @@ NESTED BLOCKS
 }
 
 /* Ordered */
+.bn-block-content[data-content-type="numberedListItem"] {
+  display: flex;
+  gap: 1.2em;
+}
+
 [data-content-type="numberedListItem"] {
   --index: attr(data-index);
 }
@@ -158,30 +165,31 @@ NESTED BLOCKS
 .bn-block-outer[data-prev-type="numberedListItem"]:not([data-prev-index="none"])
   > .bn-block
   > .bn-block-content::before {
-  margin-right: 1.2em;
   content: var(--prev-index) ".";
 }
 
 .bn-block-outer:not([data-prev-type])
   > .bn-block
   > .bn-block-content[data-content-type="numberedListItem"]::before {
-  margin-right: 1.2em;
   content: var(--index) ".";
 }
 
 /* Unordered */
+.bn-block-content[data-content-type="bulletListItem"] {
+  display: flex;
+  gap: 1.2em;
+}
+
 /* No list nesting */
 .bn-block-outer[data-prev-type="bulletListItem"]
   > .bn-block
   > .bn-block-content::before {
-  margin-right: 1.2em;
   content: "•";
 }
 
 .bn-block-outer:not([data-prev-type])
   > .bn-block
   > .bn-block-content[data-content-type="bulletListItem"]::before {
-  margin-right: 1.2em;
   content: "•";
 }
 
@@ -191,7 +199,6 @@ NESTED BLOCKS
   > .bn-block-outer[data-prev-type="bulletListItem"]
   > .bn-block
   > .bn-block-content::before {
-  margin-right: 1.2em;
   content: "◦";
 }
 
@@ -200,7 +207,6 @@ NESTED BLOCKS
   > .bn-block-outer:not([data-prev-type])
   > .bn-block
   > .bn-block-content[data-content-type="bulletListItem"]::before {
-  margin-right: 1.2em;
   content: "◦";
 }
 
@@ -212,7 +218,6 @@ NESTED BLOCKS
   > .bn-block-outer[data-prev-type="bulletListItem"]
   > .bn-block
   > .bn-block-content::before {
-  margin-right: 1.2em;
   content: "▪";
 }
 
@@ -223,7 +228,6 @@ NESTED BLOCKS
   > .bn-block-outer:not([data-prev-type])
   > .bn-block
   > .bn-block-content[data-content-type="bulletListItem"]::before {
-  margin-right: 1.2em;
   content: "▪";
 }
 
@@ -294,7 +298,7 @@ NESTED BLOCKS
 }
 
 [data-content-type="image"] .caption {
-  font-size: 0.8em
+  font-size: 0.8em;
 }
 
 /* PLACEHOLDERS*/
@@ -327,12 +331,14 @@ NESTED BLOCKS
 
 .bn-block-content[data-content-type="bulletListItem"].bn-is-empty
   .bn-inline-content:before,
-  .bn-block-content[data-content-type="numberedListItem"].bn-is-empty
+.bn-block-content[data-content-type="numberedListItem"].bn-is-empty
   .bn-inline-content:before {
   content: "List";
 }
 
-.bn-is-empty .bn-block-content[data-content-type="captionedImage"] .bn-inline-content:before {
+.bn-is-empty
+  .bn-block-content[data-content-type="captionedImage"]
+  .bn-inline-content:before {
   content: "Caption";
 }
 


### PR DESCRIPTION
## Description
This PR fixes the lists indentation in case of multi-line content.

### Issue
- Closes #463 

### Note
There are some formatting changes which were popping on saving the CSS file. Tried avoid them, but were overwritten.

### Screenshots

**Previously**

<img width="749" alt="image" src="https://github.com/TypeCellOS/BlockNote/assets/60139930/7160709a-0a48-40dc-94fa-e440b9551cb2">


**Updated**
<img width="738" alt="image" src="https://github.com/TypeCellOS/BlockNote/assets/60139930/b084c4e2-1cdb-4c3a-a414-94d9b7908f4e">

