### PR TITLE
fix: add check to display or hide sidemenu

### DIFF
--- a/packages/core/src/extensions/SideMenu/SideMenuPlugin.ts
+++ b/packages/core/src/extensions/SideMenu/SideMenuPlugin.ts
@@ -429,6 +429,12 @@ export class SideMenuView<
       return;
     }
 
+    // hide sidemenu when hover from editor to outside
+    if (!cursorWithinEditor && this.sideMenuState) {
+      this.sideMenuState.show = false;
+      this.updateSideMenu(this.sideMenuState);
+    }
+
     this.horizontalPosAnchor = editorBoundingBox.x;
 
     // Gets block at mouse cursor's vertical position.
@@ -471,7 +477,7 @@ export class SideMenuView<
       const blockContentBoundingBox = blockContent.getBoundingClientRect();
 
       this.sideMenuState = {
-        show: true,
+        show: cursorWithinEditor,
         referencePos: new DOMRect(
           this.horizontalPosAnchoredAtRoot
             ? this.horizontalPosAnchor


### PR DESCRIPTION
The side menu still displays when hover outside of the editor

Before:

https://github.com/TypeCellOS/BlockNote/assets/48788462/fab726ef-b78e-4525-8494-ba5eda66080d

After:

https://github.com/TypeCellOS/BlockNote/assets/48788462/72dd8344-fca1-4d53-85d8-e51ea2b0a245

