### PR TITLE
fix: inline content type definitions for `TableContent`

### DIFF
--- a/packages/website/docs/docs/block-types.md
+++ b/packages/website/docs/docs/block-types.md
@@ -137,7 +137,7 @@ type TableBlock = {
   id: string;
   type: "table";
   props: DefaultProps;
-  content: TableContent[];
+  content: TableContent;
   children: Block[];
 };
 ```


### PR DESCRIPTION
Previously the documentation stated that the TableContent must be an array which is not the case.
Updated the Type Definition in Documentation to reflect the same