### PR TITLE
feat: Asynchronous slash menu item fetching

### DIFF
--- a/examples/vanilla/src/ui/addSlashMenu.ts
+++ b/examples/vanilla/src/ui/addSlashMenu.ts
@@ -13,10 +13,7 @@ export const addSlashMenu = async (editor: BlockNoteEditor) => {
   async function updateItems(
     query: string,
     getItems: (
-      query: string,
-      token: {
-        cancel: (() => void) | undefined;
-      }
+      query: string
     ) => Promise<
       BaseSlashMenuItem<
         DefaultBlockSchema,
@@ -33,11 +30,7 @@ export const addSlashMenu = async (editor: BlockNoteEditor) => {
     ) => void
   ) {
     element.innerHTML = "";
-    const items = await getItems(query, {
-      cancel: () => {
-        return;
-      },
-    });
+    const items = await getItems(query);
     const domItems = items.map((val, i) => {
       const element = createButton(val.name, () => {
         onClick(val);

--- a/examples/vanilla/src/ui/addSlashMenu.ts
+++ b/examples/vanilla/src/ui/addSlashMenu.ts
@@ -5,13 +5,12 @@ import {
 } from "@blocknote/core";
 import { createButton } from "./util";
 
-export const addSlashMenu = (editor: BlockNoteEditor) => {
+export const addSlashMenu = async (editor: BlockNoteEditor) => {
   let element: HTMLElement;
 
   function updateItems(
     items: BaseSlashMenuItem<DefaultBlockSchema, any, any>[],
-    onClick: (item: BaseSlashMenuItem<DefaultBlockSchema, any, any>) => void,
-    selected: number
+    onClick: (item: BaseSlashMenuItem<DefaultBlockSchema, any, any>) => void
   ) {
     element.innerHTML = "";
     const domItems = items.map((val, i) => {
@@ -19,16 +18,13 @@ export const addSlashMenu = (editor: BlockNoteEditor) => {
         onClick(val);
       });
       element.style.display = "block";
-      if (selected === i) {
-        element.style.fontWeight = "bold";
-      }
       return element;
     });
     element.append(...domItems);
     return domItems;
   }
 
-  editor.slashMenu.onUpdate((slashMenuState) => {
+  editor.slashMenu.onUpdate(async (slashMenuState) => {
     if (!element) {
       element = document.createElement("div");
       element.style.background = "gray";
@@ -41,11 +37,7 @@ export const addSlashMenu = (editor: BlockNoteEditor) => {
     }
 
     if (slashMenuState.show) {
-      updateItems(
-        slashMenuState.filteredItems,
-        editor.slashMenu.itemCallback,
-        slashMenuState.keyboardHoveredItemIndex
-      );
+      updateItems(await slashMenuState.items, editor.slashMenu.executeItem);
 
       element.style.display = "block";
 

--- a/examples/vanilla/src/ui/addSlashMenu.ts
+++ b/examples/vanilla/src/ui/addSlashMenu.ts
@@ -2,17 +2,42 @@ import {
   BaseSlashMenuItem,
   BlockNoteEditor,
   DefaultBlockSchema,
+  DefaultInlineContentSchema,
+  DefaultStyleSchema,
 } from "@blocknote/core";
 import { createButton } from "./util";
 
 export const addSlashMenu = async (editor: BlockNoteEditor) => {
   let element: HTMLElement;
 
-  function updateItems(
-    items: BaseSlashMenuItem<DefaultBlockSchema, any, any>[],
-    onClick: (item: BaseSlashMenuItem<DefaultBlockSchema, any, any>) => void
+  async function updateItems(
+    query: string,
+    getItems: (
+      query: string,
+      token: {
+        cancel: (() => void) | undefined;
+      }
+    ) => Promise<
+      BaseSlashMenuItem<
+        DefaultBlockSchema,
+        DefaultInlineContentSchema,
+        DefaultStyleSchema
+      >[]
+    >,
+    onClick: (
+      item: BaseSlashMenuItem<
+        DefaultBlockSchema,
+        DefaultInlineContentSchema,
+        DefaultStyleSchema
+      >
+    ) => void
   ) {
     element.innerHTML = "";
+    const items = await getItems(query, {
+      cancel: () => {
+        return;
+      },
+    });
     const domItems = items.map((val, i) => {
       const element = createButton(val.name, () => {
         onClick(val);
@@ -37,7 +62,11 @@ export const addSlashMenu = async (editor: BlockNoteEditor) => {
     }
 
     if (slashMenuState.show) {
-      updateItems(await slashMenuState.items, editor.slashMenu.executeItem);
+      await updateItems(
+        slashMenuState.query,
+        editor.slashMenu.getItems,
+        editor.slashMenu.executeItem
+      );
 
       element.style.display = "block";
 

--- a/packages/core/src/editor/BlockNoteEditor.ts
+++ b/packages/core/src/editor/BlockNoteEditor.ts
@@ -83,7 +83,9 @@ export type BlockNoteEditorOptions<
    *
    * @default defaultSlashMenuItems from `./extensions/SlashMenu`
    */
-  slashMenuItems: BaseSlashMenuItem<any, any, any>[];
+  slashMenuItems: (
+    query: string
+  ) => Promise<BaseSlashMenuItem<any, any, any>[]>;
 
   /**
    * The HTML element that should be used as the parent element for the editor.
@@ -290,7 +292,7 @@ export class BlockNoteEditor<
     this.slashMenu = new SlashMenuProsemirrorPlugin(
       this,
       newOptions.slashMenuItems ||
-        (getDefaultSlashMenuItems(this.blockSchema) as any)
+        ((query) => getDefaultSlashMenuItems(query, this.blockSchema) as any)
     );
     this.hyperlinkToolbar = new HyperlinkToolbarProsemirrorPlugin(this);
     this.imageToolbar = new ImageToolbarProsemirrorPlugin(this);

--- a/packages/core/src/editor/BlockNoteEditor.ts
+++ b/packages/core/src/editor/BlockNoteEditor.ts
@@ -84,10 +84,7 @@ export type BlockNoteEditorOptions<
    * @default defaultSlashMenuItems from `./extensions/SlashMenu`
    */
   slashMenuItems: (
-    query: string,
-    token: {
-      cancel: (() => void) | undefined;
-    }
+    query: string
   ) => Promise<BaseSlashMenuItem<any, any, any>[]>;
 
   /**

--- a/packages/core/src/editor/BlockNoteEditor.ts
+++ b/packages/core/src/editor/BlockNoteEditor.ts
@@ -84,7 +84,10 @@ export type BlockNoteEditorOptions<
    * @default defaultSlashMenuItems from `./extensions/SlashMenu`
    */
   slashMenuItems: (
-    query: string
+    query: string,
+    token: {
+      cancel: (() => void) | undefined;
+    }
   ) => Promise<BaseSlashMenuItem<any, any, any>[]>;
 
   /**

--- a/packages/core/src/extensions-shared/suggestion/SuggestionPlugin.ts
+++ b/packages/core/src/extensions-shared/suggestion/SuggestionPlugin.ts
@@ -144,12 +144,8 @@ export const setupSuggestionsMenu = <
 
   pluginKey: PluginKey,
   defaultTriggerCharacter: string,
-  getItems: (
-    query: string,
-    token: {
-      cancel: (() => void) | undefined;
-    }
-  ) => Promise<T[]> = () => new Promise((resolve) => resolve([])),
+  getItems: (query: string) => Promise<T[]> = () =>
+    new Promise((resolve) => resolve([])),
   onSelectItem: (props: {
     item: T;
     editor: BlockNoteEditor<BSchema, I, S>;

--- a/packages/core/src/extensions/SlashMenu/SlashMenuPlugin.ts
+++ b/packages/core/src/extensions/SlashMenu/SlashMenuPlugin.ts
@@ -18,13 +18,24 @@ export class SlashMenuProsemirrorPlugin<
   SlashMenuItem extends BaseSlashMenuItem<BSchema, I, S>
 > extends EventEmitter<any> {
   public readonly plugin: Plugin;
+  public readonly getItems: (
+    query: string,
+    token: {
+      cancel: (() => void) | undefined;
+    }
+  ) => Promise<SlashMenuItem[]>;
   public readonly executeItem: (item: SlashMenuItem) => void;
   public readonly closeMenu: () => void;
   public readonly clearQuery: () => void;
 
   constructor(
     editor: BlockNoteEditor<BSchema, I, S>,
-    getItems: (query: string) => Promise<SlashMenuItem[]>
+    getItems: (
+      query: string,
+      token: {
+        cancel: (() => void) | undefined;
+      }
+    ) => Promise<SlashMenuItem[]>
   ) {
     super();
     const suggestions = setupSuggestionsMenu<SlashMenuItem, BSchema, I, S>(
@@ -39,14 +50,13 @@ export class SlashMenuProsemirrorPlugin<
     );
 
     this.plugin = suggestions.plugin;
+    this.getItems = getItems;
     this.executeItem = suggestions.executeItem;
     this.closeMenu = suggestions.closeMenu;
     this.clearQuery = suggestions.clearQuery;
   }
 
-  public onUpdate(
-    callback: (state: SuggestionsMenuState<SlashMenuItem>) => void
-  ) {
+  public onUpdate(callback: (state: SuggestionsMenuState) => void) {
     return this.on("update", callback);
   }
 }

--- a/packages/core/src/extensions/SlashMenu/SlashMenuPlugin.ts
+++ b/packages/core/src/extensions/SlashMenu/SlashMenuPlugin.ts
@@ -18,24 +18,14 @@ export class SlashMenuProsemirrorPlugin<
   SlashMenuItem extends BaseSlashMenuItem<BSchema, I, S>
 > extends EventEmitter<any> {
   public readonly plugin: Plugin;
-  public readonly getItems: (
-    query: string,
-    token: {
-      cancel: (() => void) | undefined;
-    }
-  ) => Promise<SlashMenuItem[]>;
+  public readonly getItems: (query: string) => Promise<SlashMenuItem[]>;
   public readonly executeItem: (item: SlashMenuItem) => void;
   public readonly closeMenu: () => void;
   public readonly clearQuery: () => void;
 
   constructor(
     editor: BlockNoteEditor<BSchema, I, S>,
-    getItems: (
-      query: string,
-      token: {
-        cancel: (() => void) | undefined;
-      }
-    ) => Promise<SlashMenuItem[]>
+    getItems: (query: string) => Promise<SlashMenuItem[]>
   ) {
     super();
     const suggestions = setupSuggestionsMenu<SlashMenuItem, BSchema, I, S>(

--- a/packages/core/src/extensions/SlashMenu/defaultSlashMenuItems.ts
+++ b/packages/core/src/extensions/SlashMenu/defaultSlashMenuItems.ts
@@ -74,13 +74,11 @@ function insertOrUpdateBlock<
   return insertedBlock;
 }
 
-export const getDefaultSlashMenuItems = <
+export async function getDefaultSlashMenuItems<
   BSchema extends BlockSchema,
   I extends InlineContentSchema,
   S extends StyleSchema
->(
-  schema: BSchema = defaultBlockSchema as unknown as BSchema
-) => {
+>(query: string, schema: BSchema = defaultBlockSchema as unknown as BSchema) {
   const slashMenuItems: BaseSlashMenuItem<BSchema, I, S>[] = [];
 
   if ("heading" in schema && "level" in schema.heading.propSchema) {
@@ -209,5 +207,12 @@ export const getDefaultSlashMenuItems = <
     });
   }
 
-  return slashMenuItems;
-};
+  return slashMenuItems.filter(
+    ({ name, aliases }) =>
+      name.toLowerCase().startsWith(query.toLowerCase()) ||
+      (aliases &&
+        aliases.filter((alias) =>
+          alias.toLowerCase().startsWith(query.toLowerCase())
+        ).length !== 0)
+  );
+}

--- a/packages/react/src/components/SlashMenu/SlashMenuPositioner.tsx
+++ b/packages/react/src/components/SlashMenu/SlashMenuPositioner.tsx
@@ -14,15 +14,14 @@ import {
 } from "@floating-ui/react";
 import { FC, useEffect, useRef, useState } from "react";
 
-import { ReactSlashMenuItem } from "../../slashMenuItems/ReactSlashMenuItem";
 import { DefaultSlashMenu } from "./DefaultSlashMenu";
 
 export type SlashMenuProps<BSchema extends BlockSchema = DefaultBlockSchema> =
   Pick<
     SlashMenuProsemirrorPlugin<BSchema, any, any, any>,
-    "executeItem" | "closeMenu" | "clearQuery"
+    "getItems" | "executeItem" | "closeMenu" | "clearQuery"
   > &
-    Pick<SuggestionsMenuState<ReactSlashMenuItem<BSchema>>, "items"> & {
+    Pick<SuggestionsMenuState, "query"> & {
       editor: BlockNoteEditor<BSchema, any, any>;
     };
 
@@ -33,9 +32,7 @@ export const SlashMenuPositioner = <
   slashMenu?: FC<SlashMenuProps<BSchema>>;
 }) => {
   const [show, setShow] = useState<boolean>(false);
-  const [items, setItems] = useState<Promise<ReactSlashMenuItem<BSchema>[]>>(
-    new Promise((resolve) => resolve([]))
-  );
+  const [query, setQuery] = useState<string>("");
 
   const referencePos = useRef<DOMRect>();
 
@@ -62,7 +59,7 @@ export const SlashMenuPositioner = <
   useEffect(() => {
     return props.editor.slashMenu.onUpdate((slashMenuState) => {
       setShow(slashMenuState.show);
-      setItems(slashMenuState.items);
+      setQuery(slashMenuState.query);
 
       referencePos.current = slashMenuState.referencePos;
 
@@ -76,7 +73,7 @@ export const SlashMenuPositioner = <
     });
   }, [refs]);
 
-  if (!isMounted || !items === undefined) {
+  if (!isMounted || !query === undefined) {
     return null;
   }
 
@@ -93,7 +90,8 @@ export const SlashMenuPositioner = <
       }}>
       <SlashMenu
         editor={props.editor}
-        items={items}
+        query={query}
+        getItems={props.editor.slashMenu.getItems}
         executeItem={props.editor.slashMenu.executeItem}
         closeMenu={props.editor.slashMenu.closeMenu}
         clearQuery={props.editor.slashMenu.clearQuery}

--- a/packages/react/src/editor/styles.css
+++ b/packages/react/src/editor/styles.css
@@ -461,6 +461,15 @@
     gap: 0;
 }
 
+.bn-container .bn-slash-menu .bn-slash-menu-loader {
+    height: 20px;
+    width: 100%;
+}
+
+.bn-container .bn-slash-menu .bn-slash-menu-loader span {
+    background-color: var(--bn-colors-side-menu);
+}
+
 /* Side Menu & Drag Handle styling */
 .bn-container .bn-side-menu {
     background-color: transparent;

--- a/packages/react/src/hooks/useBlockNote.ts
+++ b/packages/react/src/hooks/useBlockNote.ts
@@ -23,9 +23,11 @@ const initEditor = <
   options: Partial<BlockNoteEditorOptions<BSpecs, ISpecs, SSpecs>>
 ) =>
   BlockNoteEditor.create({
-    slashMenuItems: getDefaultReactSlashMenuItems(
-      getBlockSchemaFromSpecs(options.blockSpecs || defaultBlockSpecs)
-    ),
+    slashMenuItems: (query) =>
+      getDefaultReactSlashMenuItems(
+        query,
+        getBlockSchemaFromSpecs(options.blockSpecs || defaultBlockSpecs)
+      ),
     ...options,
   });
 

--- a/packages/react/src/slashMenuItems/defaultReactSlashMenuItems.tsx
+++ b/packages/react/src/slashMenuItems/defaultReactSlashMenuItems.tsx
@@ -76,19 +76,20 @@ const extraFields: Record<
   },
 };
 
-export function getDefaultReactSlashMenuItems<
+export async function getDefaultReactSlashMenuItems<
   BSchema extends BlockSchema,
   I extends InlineContentSchema,
   S extends StyleSchema
 >(
+  query: string,
   // This type casting is weird, but it's the best way of doing it, as it allows
   // the schema type to be automatically inferred if it is defined, or be
   // inferred as any if it is not defined. I don't think it's possible to make it
   // infer to DefaultBlockSchema if it is not defined.
   schema: BSchema = defaultBlockSchema as any as BSchema
-): ReactSlashMenuItem<BSchema, I, S>[] {
+): Promise<ReactSlashMenuItem<BSchema, I, S>[]> {
   const slashMenuItems: BaseSlashMenuItem<BSchema, I, S>[] =
-    getDefaultSlashMenuItems(schema);
+    await getDefaultSlashMenuItems(query, schema);
 
   return slashMenuItems.map((item) => ({
     ...item,

--- a/tests/src/utils/components/Editor.tsx
+++ b/tests/src/utils/components/Editor.tsx
@@ -39,7 +39,10 @@ export default function Editor() {
       editor: { class: styles.editor, "data-test": "editor" },
     },
     blockSpecs,
-    slashMenuItems: [...getDefaultReactSlashMenuItems(), ...slashMenuItems],
+    slashMenuItems: async (query: string) => [
+      ...(await getDefaultReactSlashMenuItems(query)),
+      ...slashMenuItems,
+    ],
   });
 
   console.log(editor);

--- a/tests/src/utils/slashmenu.ts
+++ b/tests/src/utils/slashmenu.ts
@@ -10,4 +10,5 @@ export async function executeSlashCommand(page: Page, command: string) {
   await openSlashMenu(page);
   await page.keyboard.type(command);
   await page.keyboard.press("Enter");
+  await page.waitForTimeout(500);
 }


### PR DESCRIPTION
This PR refactors the suggestion plugin to support fetching items asynchronously. To do this, some of the existing responsibility of the suggestion plugin has to be move. Specifically, the keyboard handling is moved to the slash menu component and item filtering is moved to the function provided in the `slashMenuItems` option.

I think we can move the plugin state to the plugin view like it is in the table handles plugin, though this is still TODO.

Closes #488 