### PR TITLE
feat: CSS variables for placeholders

### DIFF
--- a/packages/core/src/editor/Block.css
+++ b/packages/core/src/editor/Block.css
@@ -314,31 +314,31 @@ NESTED BLOCKS
 }
 
 /* TODO: would be nicer if defined from code */
+.bn-container {
+  --bn-default-placeholder: "Enter text or type '/' for commands";
+  --bn-filter-placeholder: "Type to filter";
+  --bn-heading-placeholder: "Heading";
+  --bn-list-placeholder: "List";
+}
 
 .bn-block-content.bn-is-empty.bn-has-anchor .bn-inline-content:before {
-  content: "Enter text or type '/' for commands";
+  content: var(--bn-default-placeholder);
 }
 
 .bn-block-content.bn-is-filter.bn-has-anchor .bn-inline-content:before {
-  content: "Type to filter";
+  content: var(--bn-filter-placeholder);
 }
 
 .bn-block-content[data-content-type="heading"].bn-is-empty
   .bn-inline-content:before {
-  content: "Heading";
+  content: var(--bn-heading-placeholder);
 }
 
 .bn-block-content[data-content-type="bulletListItem"].bn-is-empty
   .bn-inline-content:before,
 .bn-block-content[data-content-type="numberedListItem"].bn-is-empty
   .bn-inline-content:before {
-  content: "List";
-}
-
-.bn-is-empty
-  .bn-block-content[data-content-type="captionedImage"]
-  .bn-inline-content:before {
-  content: "Caption";
+  content: var(--bn-list-placeholder);
 }
 
 /* TEXT COLORS */


### PR DESCRIPTION
This PR allows for setting CSS variables to customize the default placeholders. It contains only basic functionality as it's meant as a temporary solution before we fix performance issues in #503:
- Can change default placeholder which appears in the block which contains the text cursor
- Can change placeholder which is appears after pressing the add block button
- Can change placeholders for default heading and list item blocks, which are always visible and overwrite the default placeholder
- No support for custom blocks or more advanced filtering based on block

Default placeholders:
```css
.bn-container {
  --bn-default-placeholder: "Enter text or type '/' for commands";
  --bn-filter-placeholder: "Type to filter";
  --bn-heading-placeholder: "Heading";
  --bn-list-placeholder: "List";
}
```