### PR TITLE
fix: Mantine setting global styles

### DIFF
--- a/packages/react/src/editor/styles.css
+++ b/packages/react/src/editor/styles.css
@@ -1,6 +1,59 @@
 @import url("@mantine/core/styles.css");
 @import url("@blocknote/core/style.css");
 
+/* Move Mantine global styles to the scope of bn-container */
+body, html {
+    height: unset;
+}
+
+*, :after, :before {
+    box-sizing: unset;
+}
+.bn-container *, .bn-container :after, .bn-container :before {
+    box-sizing: border-box;
+}
+
+button, input ,select ,textarea {
+    font: unset;
+}
+
+button, select {
+    text-transform: unset;
+}
+.bn-container button, .bn-container select {
+    text-transform: none;
+}
+
+body {
+    -webkit-font-smoothing: unset;
+    -moz-osx-font-smoothing: unset;
+    background-color: unset;
+    color: unset;
+    font-family: unset;
+    font-size: unset;
+    line-height: unset;
+    margin: unset
+}
+.bn-container {
+    -webkit-font-smoothing: var(--mantine-webkit-font-smoothing);
+    -moz-osx-font-smoothing: var(--mantine-moz-font-smoothing);
+    background-color: var(--mantine-color-body);
+    color: var(--mantine-color-text);
+    font-family: var(--mantine-font-family);
+    font-size: var(--mantine-font-size-md);
+    line-height: var(--mantine-line-height);
+    margin: 0
+}
+
+@media screen and (max-device-width:500px) {
+    body {
+        -webkit-text-size-adjust: unset;
+    }
+    .bn-container body {
+        -webkit-text-size-adjust: 100%
+    }
+}
+
 /* Default theme params */
 .bn-container {
     --bn-colors-editor-text: #3F3F3F;


### PR DESCRIPTION
Due to the Mantine update from 0.11, the way in which Mantine component styling is now different. Mantine now sets styles in CSS, some of which are set globally. This can cause issues by overwriting existing styles, when in reality they should be scoped to only elements within the editor.

This PR unsets global styles set by Mantine and moves them inside the `.bn-container` element (excluding setting CSS variables). Unfortunately, for Mantine styling to work at all, you need to import `@mantine/core/styles/global.css`, which includes said global styles. This means that AFAIK, there is no way to skip importing them, and the best we can do is to unset them. This feels really hacky, so any suggestions for a nicer fix are welcome.

Closes #523 