### PR TITLE
fix: Add block button behaviour on blocks with different content

### DIFF
--- a/packages/core/src/extensions/SideMenu/SideMenuPlugin.ts
+++ b/packages/core/src/extensions/SideMenu/SideMenuPlugin.ts
@@ -550,7 +550,10 @@ export class SideMenuView<
     const { contentNode, startPos, endPos } = blockInfo;
 
     // Creates a new block if current one is not empty for the suggestion menu to open in.
-    if (contentNode.textContent.length !== 0) {
+    if (
+      contentNode.type.spec.content !== "inline*" ||
+      contentNode.textContent.length !== 0
+    ) {
       const newBlockInsertionPos = endPos + 1;
       const newBlockContentPos = newBlockInsertionPos + 2;
 


### PR DESCRIPTION
This PR makes the add block button always create a new block below for blocks with table content and no content.