### PR TITLE
chore: Mantine 7.4.2

### DIFF
--- a/examples/editor/package.json
+++ b/examples/editor/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@blocknote/core": "^0.11.0",
     "@blocknote/react": "^0.11.0",
-    "@mantine/core": "^7.3.1",
+    "@mantine/core": "^7.4.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.20.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -50,9 +50,6 @@
     "clean": "rimraf dist && rimraf types"
   },
   "dependencies": {
-    "@emotion/cache": "^11.10.5",
-    "@emotion/serialize": "^1.1.1",
-    "@emotion/utils": "^1.2.0",
     "@tiptap/core": "^2.0.3",
     "@tiptap/extension-bold": "^2.0.3",
     "@tiptap/extension-code": "^2.0.3",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -52,9 +52,9 @@
   "dependencies": {
     "@blocknote/core": "^0.11.0",
     "@floating-ui/react": "^0.26.4",
-    "@mantine/core": "^7.3.1",
-    "@mantine/hooks": "^7.3.1",
-    "@mantine/utils": "^6.0.5",
+    "@mantine/core": "^7.4.2",
+    "@mantine/hooks": "7.4.2",
+    "@mantine/utils": "^6.0.21",
     "@tiptap/core": "^2.0.3",
     "@tiptap/react": "^2.0.3",
     "lodash.foreach": "^4.5.0",


### PR DESCRIPTION
This update should help to mitigate the issues from #523. While Mantine still sets some global styles in 7.4.2, there is not much we can do to reset these styles ourselves (see #525 for an attempt of that).