### PR TITLE
Added inputRule to CustomBlockConfig

### DIFF
--- a/examples/editor/examples/react-custom-blocks/App.tsx
+++ b/examples/editor/examples/react-custom-blocks/App.tsx
@@ -44,6 +44,12 @@ export const alertBlock = createReactBlockSpec(
         values: ["warning", "error", "info", "success"] as const,
       },
     },
+    inputRule: [
+      {input: "[]w", prop: { type: "warning"} },
+      {input: "[]e", prop: { type: "error"} },
+      {input: "[]i", prop: { type: "info"} },
+      {input: "[]s", prop: { type: "success"} },
+    ],
     content: "inline",
   },
   {

--- a/examples/editor/examples/vanilla-custom-blocks/App.tsx
+++ b/examples/editor/examples/vanilla-custom-blocks/App.tsx
@@ -45,6 +45,12 @@ const alertBlock = createBlockSpec(
       },
     },
     content: "inline",
+    inputRule: [
+      {input: "[]w", prop: { type: "warning"} },
+      {input: "[]e", prop: { type: "error"} },
+      {input: "[]i", prop: { type: "info"} },
+      {input: "[]s", prop: { type: "success"} },
+    ],
   },
   {
     render: (block, editor) => {

--- a/packages/react/src/schema/ReactBlockSpec.tsx
+++ b/packages/react/src/schema/ReactBlockSpec.tsx
@@ -18,6 +18,7 @@ import {
   StyleSchema,
 } from "@blocknote/core";
 import {
+  InputRule,
   NodeViewContent,
   NodeViewProps,
   NodeViewWrapper,
@@ -116,6 +117,27 @@ export function createReactBlockSpec<
     group: "blockContent",
     selectable: true,
 
+    addInputRules() {
+      if (blockConfig.inputRule) {
+        return blockConfig.inputRule.map(({input, prop}) =>
+         new InputRule({
+            find: new RegExp(`${input.replace(/([()[{*+.$^\\|?])/g, '\\$1')}\\s$`),
+            handler: ({ state, chain, range }) => {
+              chain()
+                .BNUpdateBlock(state.selection.from, {
+                  type: blockConfig.type,
+                  props: prop,
+                })
+                .deleteRange({ from: range.from, to: range.to });
+            }
+          })
+        );
+      }
+      else {
+        return [];
+      }
+    },
+    
     addAttributes() {
       return propsToAttributes(blockConfig.propSchema);
     },


### PR DESCRIPTION
hello.

I need simple custom input rule, then I made one.
https://github.com/TypeCellOS/BlockNote/issues/231

some RegExp that I used is:  [stackoverflow Link](https://stackoverflow.com/questions/5663987/how-to-properly-escape-characters-in-regexp)

Then, works will like that:
![tabtab](https://github.com/TypeCellOS/BlockNote/assets/53367179/e6fcd85b-4c44-4be0-af87-9a67a014d270)
