### PR TITLE
fix: Keyboard shortcuts & input rules in tables

### DIFF
--- a/packages/core/src/api/getCurrentBlockContentType.ts
+++ b/packages/core/src/api/getCurrentBlockContentType.ts
@@ -1,0 +1,14 @@
+import { Editor } from "@tiptap/core";
+import { getBlockInfoFromPos } from "./getBlockInfoFromPos";
+
+// Used to get the content type of the block that the text cursor is in. This is
+// a band-aid fix to prevent input rules and keyboard shortcuts from triggering
+// in tables, but really those should be extended to work with block selections.
+export const getCurrentBlockContentType = (editor: Editor) => {
+  const { contentType } = getBlockInfoFromPos(
+    editor.state.doc,
+    editor.state.selection.from
+  );
+
+  return contentType.spec.content;
+};

--- a/packages/core/src/blocks/HeadingBlockContent/HeadingBlockContent.ts
+++ b/packages/core/src/blocks/HeadingBlockContent/HeadingBlockContent.ts
@@ -6,6 +6,7 @@ import {
 } from "../../schema";
 import { createDefaultBlockDOMOutputSpec } from "../defaultBlockHelpers";
 import { defaultProps } from "../defaultProps";
+import { getCurrentBlockContentType } from "../../api/getCurrentBlockContentType";
 
 export const headingPropSchema = {
   ...defaultProps,
@@ -45,6 +46,10 @@ const HeadingBlockContent = createStronglyTypedTiptapNode({
         return new InputRule({
           find: new RegExp(`^(#{${level}})\\s$`),
           handler: ({ state, chain, range }) => {
+            if (getCurrentBlockContentType(this.editor) !== "inline*") {
+              return;
+            }
+
             chain()
               .BNUpdateBlock(state.selection.from, {
                 type: "heading",
@@ -62,27 +67,51 @@ const HeadingBlockContent = createStronglyTypedTiptapNode({
 
   addKeyboardShortcuts() {
     return {
-      "Mod-Alt-1": () =>
-        this.editor.commands.BNUpdateBlock(this.editor.state.selection.anchor, {
-          type: "heading",
-          props: {
-            level: 1 as any,
-          },
-        }),
-      "Mod-Alt-2": () =>
-        this.editor.commands.BNUpdateBlock(this.editor.state.selection.anchor, {
-          type: "heading",
-          props: {
-            level: 2 as any,
-          },
-        }),
-      "Mod-Alt-3": () =>
-        this.editor.commands.BNUpdateBlock(this.editor.state.selection.anchor, {
-          type: "heading",
-          props: {
-            level: 3 as any,
-          },
-        }),
+      "Mod-Alt-1": () => {
+        if (getCurrentBlockContentType(this.editor) !== "inline*") {
+          return true;
+        }
+
+        return this.editor.commands.BNUpdateBlock(
+          this.editor.state.selection.anchor,
+          {
+            type: "heading",
+            props: {
+              level: 1 as any,
+            },
+          }
+        );
+      },
+      "Mod-Alt-2": () => {
+        if (getCurrentBlockContentType(this.editor) !== "inline*") {
+          return true;
+        }
+
+        return this.editor.commands.BNUpdateBlock(
+          this.editor.state.selection.anchor,
+          {
+            type: "heading",
+            props: {
+              level: 2 as any,
+            },
+          }
+        );
+      },
+      "Mod-Alt-3": () => {
+        if (getCurrentBlockContentType(this.editor) !== "inline*") {
+          return true;
+        }
+
+        return this.editor.commands.BNUpdateBlock(
+          this.editor.state.selection.anchor,
+          {
+            type: "heading",
+            props: {
+              level: 3 as any,
+            },
+          }
+        );
+      },
     };
   },
   parseHTML() {

--- a/packages/core/src/blocks/ListItemBlockContent/BulletListItemBlockContent/BulletListItemBlockContent.ts
+++ b/packages/core/src/blocks/ListItemBlockContent/BulletListItemBlockContent/BulletListItemBlockContent.ts
@@ -7,6 +7,7 @@ import {
 import { createDefaultBlockDOMOutputSpec } from "../../defaultBlockHelpers";
 import { defaultProps } from "../../defaultProps";
 import { handleEnter } from "../ListItemKeyboardShortcuts";
+import { getCurrentBlockContentType } from "../../../api/getCurrentBlockContentType";
 
 export const bulletListItemPropSchema = {
   ...defaultProps,
@@ -22,6 +23,10 @@ const BulletListItemBlockContent = createStronglyTypedTiptapNode({
       new InputRule({
         find: new RegExp(`^[-+*]\\s$`),
         handler: ({ state, chain, range }) => {
+          if (getCurrentBlockContentType(this.editor) !== "inline*") {
+            return;
+          }
+
           chain()
             .BNUpdateBlock(state.selection.from, {
               type: "bulletListItem",
@@ -37,11 +42,19 @@ const BulletListItemBlockContent = createStronglyTypedTiptapNode({
   addKeyboardShortcuts() {
     return {
       Enter: () => handleEnter(this.editor),
-      "Mod-Shift-8": () =>
-        this.editor.commands.BNUpdateBlock(this.editor.state.selection.anchor, {
-          type: "bulletListItem",
-          props: {},
-        }),
+      "Mod-Shift-8": () => {
+        if (getCurrentBlockContentType(this.editor) !== "inline*") {
+          return true;
+        }
+
+        return this.editor.commands.BNUpdateBlock(
+          this.editor.state.selection.anchor,
+          {
+            type: "bulletListItem",
+            props: {},
+          }
+        );
+      },
     };
   },
 

--- a/packages/core/src/blocks/ListItemBlockContent/NumberedListItemBlockContent/NumberedListItemBlockContent.ts
+++ b/packages/core/src/blocks/ListItemBlockContent/NumberedListItemBlockContent/NumberedListItemBlockContent.ts
@@ -8,6 +8,7 @@ import { createDefaultBlockDOMOutputSpec } from "../../defaultBlockHelpers";
 import { defaultProps } from "../../defaultProps";
 import { handleEnter } from "../ListItemKeyboardShortcuts";
 import { NumberedListIndexingPlugin } from "./NumberedListIndexingPlugin";
+import { getCurrentBlockContentType } from "../../../api/getCurrentBlockContentType";
 
 export const numberedListItemPropSchema = {
   ...defaultProps,
@@ -37,6 +38,10 @@ const NumberedListItemBlockContent = createStronglyTypedTiptapNode({
       new InputRule({
         find: new RegExp(`^1\\.\\s$`),
         handler: ({ state, chain, range }) => {
+          if (getCurrentBlockContentType(this.editor) !== "inline*") {
+            return;
+          }
+
           chain()
             .BNUpdateBlock(state.selection.from, {
               type: "numberedListItem",
@@ -52,11 +57,19 @@ const NumberedListItemBlockContent = createStronglyTypedTiptapNode({
   addKeyboardShortcuts() {
     return {
       Enter: () => handleEnter(this.editor),
-      "Mod-Shift-7": () =>
-        this.editor.commands.BNUpdateBlock(this.editor.state.selection.anchor, {
-          type: "numberedListItem",
-          props: {},
-        }),
+      "Mod-Shift-7": () => {
+        if (getCurrentBlockContentType(this.editor) !== "inline*") {
+          return true;
+        }
+
+        return this.editor.commands.BNUpdateBlock(
+          this.editor.state.selection.anchor,
+          {
+            type: "numberedListItem",
+            props: {},
+          }
+        );
+      },
     };
   },
 

--- a/packages/core/src/blocks/ParagraphBlockContent/ParagraphBlockContent.ts
+++ b/packages/core/src/blocks/ParagraphBlockContent/ParagraphBlockContent.ts
@@ -5,6 +5,7 @@ import {
 import { createDefaultBlockDOMOutputSpec } from "../defaultBlockHelpers";
 import { defaultProps } from "../defaultProps";
 import { handleEnter } from "../ListItemBlockContent/ListItemKeyboardShortcuts";
+import { getCurrentBlockContentType } from "../../api/getCurrentBlockContentType";
 
 export const paragraphPropSchema = {
   ...defaultProps,
@@ -18,11 +19,19 @@ export const ParagraphBlockContent = createStronglyTypedTiptapNode({
   addKeyboardShortcuts() {
     return {
       Enter: () => handleEnter(this.editor),
-      "Mod-Alt-0": () =>
-        this.editor.commands.BNUpdateBlock(this.editor.state.selection.anchor, {
-          type: "paragraph",
-          props: {},
-        }),
+      "Mod-Alt-0": () => {
+        if (getCurrentBlockContentType(this.editor) !== "inline*") {
+          return true;
+        }
+
+        return this.editor.commands.BNUpdateBlock(
+          this.editor.state.selection.anchor,
+          {
+            type: "paragraph",
+            props: {},
+          }
+        );
+      },
     };
   },
 


### PR DESCRIPTION
This PR adds a temp fix which blocks keyboard shortcuts and input rules from firing in table blocks. However, we should look to fix selections and make this work for multiple blocks (see #560 for more info).

Closes #555 