### PR TITLE
fix: Safari toolbar buttons & dropdowns

### DIFF
--- a/packages/core/src/extensions/FormattingToolbar/FormattingToolbarPlugin.ts
+++ b/packages/core/src/extensions/FormattingToolbar/FormattingToolbarPlugin.ts
@@ -39,6 +39,7 @@ export class FormattingToolbarView {
           "Attempting to update uninitialized formatting toolbar"
         );
       }
+      console.log(this.state);
 
       emitUpdate(this.state);
     };
@@ -95,8 +96,12 @@ export class FormattingToolbarView {
       (editorWrapper === (event.relatedTarget as Node) ||
         editorWrapper.contains(event.relatedTarget as Node))
     ) {
+      console.log(event);
+      console.log(this.state);
       return;
     }
+    console.log(event);
+    console.log(this.state);
 
     if (this.state?.show) {
       this.state.show = false;

--- a/packages/core/src/extensions/FormattingToolbar/FormattingToolbarPlugin.ts
+++ b/packages/core/src/extensions/FormattingToolbar/FormattingToolbarPlugin.ts
@@ -3,8 +3,8 @@ import { EditorState, Plugin, PluginKey } from "prosemirror-state";
 import { EditorView } from "prosemirror-view";
 
 import type { BlockNoteEditor } from "../../editor/BlockNoteEditor";
-import { BlockSchema, InlineContentSchema, StyleSchema } from "../../schema";
 import { UiElementPosition } from "../../extensions-shared/UiElementPosition";
+import { BlockSchema, InlineContentSchema, StyleSchema } from "../../schema";
 import { EventEmitter } from "../../util/EventEmitter";
 
 export type FormattingToolbarState = UiElementPosition;
@@ -39,7 +39,6 @@ export class FormattingToolbarView {
           "Attempting to update uninitialized formatting toolbar"
         );
       }
-      console.log(this.state);
 
       emitUpdate(this.state);
     };
@@ -96,12 +95,8 @@ export class FormattingToolbarView {
       (editorWrapper === (event.relatedTarget as Node) ||
         editorWrapper.contains(event.relatedTarget as Node))
     ) {
-      console.log(event);
-      console.log(this.state);
       return;
     }
-    console.log(event);
-    console.log(this.state);
 
     if (this.state?.show) {
       this.state.show = false;

--- a/packages/core/src/util/browser.ts
+++ b/packages/core/src/util/browser.ts
@@ -1,8 +1,8 @@
 export const isAppleOS = () =>
-    typeof navigator !== "undefined" &&
-    (/Mac/.test(navigator.platform) ||
-        (/AppleWebKit/.test(navigator.userAgent) &&
-            /Mobile\/\w+/.test(navigator.userAgent)));
+  typeof navigator !== "undefined" &&
+  (/Mac/.test(navigator.platform) ||
+    (/AppleWebKit/.test(navigator.userAgent) &&
+      /Mobile\/\w+/.test(navigator.userAgent)));
 
 export function formatKeyboardShortcut(shortcut: string) {
   if (isAppleOS()) {
@@ -16,3 +16,5 @@ export function mergeCSSClasses(...classes: string[]) {
   return classes.filter((c) => c).join(" ");
 }
 
+export const isSafari = () =>
+  /^((?!chrome|android).)*safari/i.test(navigator.userAgent);

--- a/packages/react/src/components/mantine-shared/Toolbar/ToolbarButton.tsx
+++ b/packages/react/src/components/mantine-shared/Toolbar/ToolbarButton.tsx
@@ -1,5 +1,5 @@
 import { ActionIcon, Button, Tooltip } from "@mantine/core";
-import { ForwardedRef, MouseEvent, forwardRef } from "react";
+import { MouseEvent, forwardRef, useRef } from "react";
 import type { IconType } from "react-icons";
 
 import { TooltipContent } from "../Tooltip/TooltipContent";
@@ -17,8 +17,9 @@ export type ToolbarButtonProps = {
 /**
  * Helper for basic buttons that show in the formatting toolbar.
  */
-export const ToolbarButton = forwardRef(
-  (props: ToolbarButtonProps, ref: ForwardedRef<HTMLButtonElement>) => {
+export const ToolbarButton = forwardRef<HTMLButtonElement, ToolbarButtonProps>(
+  (props, ref) => {
+    const buttonRef = useRef<HTMLButtonElement | null>(null);
     const ButtonIcon = props.icon;
 
     return (
@@ -33,6 +34,13 @@ export const ToolbarButton = forwardRef(
         {/*Creates an ActionIcon instead of a Button if only an icon is provided as content.*/}
         {props.children ? (
           <Button
+            // Needed as Safari doesn't focus button elements on mouse down
+            // unlike other browsers.
+            onMouseDown={() => {
+              if (buttonRef.current !== null) {
+                buttonRef.current.focus();
+              }
+            }}
             onClick={props.onClick}
             data-selected={props.isSelected ? "true" : undefined}
             data-test={
@@ -41,12 +49,27 @@ export const ToolbarButton = forwardRef(
             }
             size={"xs"}
             disabled={props.isDisabled || false}
-            ref={ref}>
+            // TODO: Ugly code for combining refs
+            ref={(node) => {
+              buttonRef.current = node;
+              if (typeof ref === "function") {
+                ref(node);
+              } else if (ref) {
+                ref.current = node;
+              }
+            }}>
             {ButtonIcon && <ButtonIcon />}
             {props.children}
           </Button>
         ) : (
           <ActionIcon
+            // Needed as Safari doesn't focus button elements on mouse down
+            // unlike other browsers.
+            onMouseDown={() => {
+              if (buttonRef.current !== null) {
+                buttonRef.current.focus();
+              }
+            }}
             onClick={props.onClick}
             data-selected={props.isSelected ? "true" : undefined}
             data-test={
@@ -55,7 +78,15 @@ export const ToolbarButton = forwardRef(
             }
             size={30}
             disabled={props.isDisabled || false}
-            ref={ref}>
+            // TODO: Ugly code for combining refs
+            ref={(node) => {
+              buttonRef.current = node;
+              if (typeof ref === "function") {
+                ref(node);
+              } else if (ref) {
+                ref.current = node;
+              }
+            }}>
             {ButtonIcon && <ButtonIcon />}
           </ActionIcon>
         )}

--- a/packages/react/src/components/mantine-shared/Toolbar/ToolbarButton.tsx
+++ b/packages/react/src/components/mantine-shared/Toolbar/ToolbarButton.tsx
@@ -2,6 +2,7 @@ import { ActionIcon, Button, Tooltip } from "@mantine/core";
 import { MouseEvent, forwardRef } from "react";
 import type { IconType } from "react-icons";
 
+import { isSafari } from "@blocknote/core";
 import { TooltipContent } from "../Tooltip/TooltipContent";
 
 export type ToolbarButtonProps = {
@@ -36,7 +37,9 @@ export const ToolbarButton = forwardRef<HTMLButtonElement, ToolbarButtonProps>(
             // Needed as Safari doesn't focus button elements on mouse down
             // unlike other browsers.
             onMouseDown={(e) => {
-              (e.currentTarget as HTMLButtonElement).focus();
+              if (isSafari()) {
+                (e.currentTarget as HTMLButtonElement).focus();
+              }
             }}
             onClick={props.onClick}
             data-selected={props.isSelected ? "true" : undefined}
@@ -55,7 +58,9 @@ export const ToolbarButton = forwardRef<HTMLButtonElement, ToolbarButtonProps>(
             // Needed as Safari doesn't focus button elements on mouse down
             // unlike other browsers.
             onMouseDown={(e) => {
-              (e.currentTarget as HTMLButtonElement).focus();
+              if (isSafari()) {
+                (e.currentTarget as HTMLButtonElement).focus();
+              }
             }}
             onClick={props.onClick}
             data-selected={props.isSelected ? "true" : undefined}

--- a/packages/react/src/components/mantine-shared/Toolbar/ToolbarButton.tsx
+++ b/packages/react/src/components/mantine-shared/Toolbar/ToolbarButton.tsx
@@ -1,5 +1,5 @@
 import { ActionIcon, Button, Tooltip } from "@mantine/core";
-import { MouseEvent, forwardRef, useRef } from "react";
+import { MouseEvent, forwardRef } from "react";
 import type { IconType } from "react-icons";
 
 import { TooltipContent } from "../Tooltip/TooltipContent";
@@ -19,7 +19,6 @@ export type ToolbarButtonProps = {
  */
 export const ToolbarButton = forwardRef<HTMLButtonElement, ToolbarButtonProps>(
   (props, ref) => {
-    const buttonRef = useRef<HTMLButtonElement | null>(null);
     const ButtonIcon = props.icon;
 
     return (
@@ -36,10 +35,8 @@ export const ToolbarButton = forwardRef<HTMLButtonElement, ToolbarButtonProps>(
           <Button
             // Needed as Safari doesn't focus button elements on mouse down
             // unlike other browsers.
-            onMouseDown={() => {
-              if (buttonRef.current !== null) {
-                buttonRef.current.focus();
-              }
+            onMouseDown={(e) => {
+              (e.currentTarget as HTMLButtonElement).focus();
             }}
             onClick={props.onClick}
             data-selected={props.isSelected ? "true" : undefined}
@@ -49,15 +46,7 @@ export const ToolbarButton = forwardRef<HTMLButtonElement, ToolbarButtonProps>(
             }
             size={"xs"}
             disabled={props.isDisabled || false}
-            // TODO: Ugly code for combining refs
-            ref={(node) => {
-              buttonRef.current = node;
-              if (typeof ref === "function") {
-                ref(node);
-              } else if (ref) {
-                ref.current = node;
-              }
-            }}>
+            ref={ref}>
             {ButtonIcon && <ButtonIcon />}
             {props.children}
           </Button>
@@ -65,10 +54,8 @@ export const ToolbarButton = forwardRef<HTMLButtonElement, ToolbarButtonProps>(
           <ActionIcon
             // Needed as Safari doesn't focus button elements on mouse down
             // unlike other browsers.
-            onMouseDown={() => {
-              if (buttonRef.current !== null) {
-                buttonRef.current.focus();
-              }
+            onMouseDown={(e) => {
+              (e.currentTarget as HTMLButtonElement).focus();
             }}
             onClick={props.onClick}
             data-selected={props.isSelected ? "true" : undefined}
@@ -78,15 +65,7 @@ export const ToolbarButton = forwardRef<HTMLButtonElement, ToolbarButtonProps>(
             }
             size={30}
             disabled={props.isDisabled || false}
-            // TODO: Ugly code for combining refs
-            ref={(node) => {
-              buttonRef.current = node;
-              if (typeof ref === "function") {
-                ref(node);
-              } else if (ref) {
-                ref.current = node;
-              }
-            }}>
+            ref={ref}>
             {ButtonIcon && <ButtonIcon />}
           </ActionIcon>
         )}

--- a/packages/react/src/components/mantine-shared/Toolbar/ToolbarDropdownTarget.tsx
+++ b/packages/react/src/components/mantine-shared/Toolbar/ToolbarDropdownTarget.tsx
@@ -1,5 +1,5 @@
 import { Button } from "@mantine/core";
-import { MouseEventHandler, forwardRef, useRef } from "react";
+import { MouseEventHandler, forwardRef } from "react";
 import type { IconType } from "react-icons";
 import { HiChevronDown } from "react-icons/hi";
 
@@ -14,17 +14,14 @@ export const ToolbarDropdownTarget = forwardRef<
   HTMLButtonElement,
   ToolbarDropdownTargetProps
 >((props: ToolbarDropdownTargetProps, ref) => {
-  const buttonRef = useRef<HTMLButtonElement | null>(null);
   const TargetIcon = props.icon;
 
   return (
     <Button
       // Needed as Safari doesn't focus button elements on mouse down
       // unlike other browsers.
-      onMouseDown={() => {
-        if (buttonRef.current !== null) {
-          buttonRef.current.focus();
-        }
+      onMouseDown={(e) => {
+        (e.currentTarget as HTMLButtonElement).focus();
       }}
       leftSection={TargetIcon && <TargetIcon size={16} />}
       rightSection={<HiChevronDown />}
@@ -32,15 +29,7 @@ export const ToolbarDropdownTarget = forwardRef<
       variant={"subtle"}
       disabled={props.isDisabled}
       onClick={props.onClick}
-      // TODO: Ugly code for combining refs
-      ref={(node) => {
-        buttonRef.current = node;
-        if (typeof ref === "function") {
-          ref(node);
-        } else if (ref) {
-          ref.current = node;
-        }
-      }}>
+      ref={ref}>
       {props.text}
     </Button>
   );

--- a/packages/react/src/components/mantine-shared/Toolbar/ToolbarDropdownTarget.tsx
+++ b/packages/react/src/components/mantine-shared/Toolbar/ToolbarDropdownTarget.tsx
@@ -1,5 +1,5 @@
 import { Button } from "@mantine/core";
-import { MouseEventHandler, forwardRef } from "react";
+import { MouseEventHandler, forwardRef, useRef } from "react";
 import type { IconType } from "react-icons";
 import { HiChevronDown } from "react-icons/hi";
 
@@ -14,16 +14,33 @@ export const ToolbarDropdownTarget = forwardRef<
   HTMLButtonElement,
   ToolbarDropdownTargetProps
 >((props: ToolbarDropdownTargetProps, ref) => {
+  const buttonRef = useRef<HTMLButtonElement | null>(null);
   const TargetIcon = props.icon;
+
   return (
     <Button
+      // Needed as Safari doesn't focus button elements on mouse down
+      // unlike other browsers.
+      onMouseDown={() => {
+        if (buttonRef.current !== null) {
+          buttonRef.current.focus();
+        }
+      }}
       leftSection={TargetIcon && <TargetIcon size={16} />}
       rightSection={<HiChevronDown />}
       size={"xs"}
       variant={"subtle"}
       disabled={props.isDisabled}
       onClick={props.onClick}
-      ref={ref}>
+      // TODO: Ugly code for combining refs
+      ref={(node) => {
+        buttonRef.current = node;
+        if (typeof ref === "function") {
+          ref(node);
+        } else if (ref) {
+          ref.current = node;
+        }
+      }}>
       {props.text}
     </Button>
   );

--- a/packages/react/src/components/mantine-shared/Toolbar/ToolbarDropdownTarget.tsx
+++ b/packages/react/src/components/mantine-shared/Toolbar/ToolbarDropdownTarget.tsx
@@ -1,3 +1,4 @@
+import { isSafari } from "@blocknote/core";
 import { Button } from "@mantine/core";
 import { MouseEventHandler, forwardRef } from "react";
 import type { IconType } from "react-icons";
@@ -21,7 +22,9 @@ export const ToolbarDropdownTarget = forwardRef<
       // Needed as Safari doesn't focus button elements on mouse down
       // unlike other browsers.
       onMouseDown={(e) => {
-        (e.currentTarget as HTMLButtonElement).focus();
+        if (isSafari()) {
+          (e.currentTarget as HTMLButtonElement).focus();
+        }
       }}
       leftSection={TargetIcon && <TargetIcon size={16} />}
       rightSection={<HiChevronDown />}


### PR DESCRIPTION
Apparently, buttons are not focused on click in Safari (https://stackoverflow.com/questions/61245883/why-blur-and-focus-doesnt-work-on-safari). Since we use a blur event handler to hide the formatting toolbar sometimes, this wasn't working which caused the link button and block type dropdown to close the formatting toolbar on click. This PR forces toolbar buttons to become focused on mouse down, which fixes the issue. Doesn't seem to be a problem for other UI elements.

closes https://github.com/TypeCellOS/BlockNote/issues/530