### PR TITLE
Fix remove 'mousemove' event listener

### DIFF
--- a/packages/core/src/extensions/SideMenu/SideMenuPlugin.ts
+++ b/packages/core/src/extensions/SideMenu/SideMenuPlugin.ts
@@ -511,7 +511,7 @@ export class SideMenuView<
       this.sideMenuState.show = false;
       this.updateSideMenu(this.sideMenuState);
     }
-    document.body.removeEventListener("mousemove", this.onMouseMove);
+    document.body.removeEventListener("mousemove", this.onMouseMove, true);
     document.body.removeEventListener("dragover", this.onDragOver);
     this.pmView.dom.removeEventListener("dragstart", this.onDragStart);
     document.body.removeEventListener("drop", this.onDrop, true);


### PR DESCRIPTION
L 290 shows mousemove event is use capure, but destroy not use it, it makes remove not work.

Issue 603 is caused by this bug.
closes https://github.com/TypeCellOS/BlockNote/issues/603