### PR TITLE
build(deps): bump prosemirror-trailing-node to 2.0.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4574,43 +4574,8 @@
     },
     "node_modules/@remirror/core-constants": {
       "version": "2.0.2",
-      "license": "MIT"
-    },
-    "node_modules/@remirror/core-helpers": {
-      "version": "3.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "@remirror/core-constants": "^2.0.2",
-        "@remirror/types": "^1.0.1",
-        "@types/object.omit": "^3.0.0",
-        "@types/object.pick": "^1.3.2",
-        "@types/throttle-debounce": "^2.1.0",
-        "case-anything": "^2.1.13",
-        "dash-get": "^1.0.2",
-        "deepmerge": "^4.3.1",
-        "fast-deep-equal": "^3.1.3",
-        "make-error": "^1.3.6",
-        "object.omit": "^3.0.0",
-        "object.pick": "^1.3.0",
-        "throttle-debounce": "^3.0.1"
-      }
-    },
-    "node_modules/@remirror/types": {
-      "version": "1.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "type-fest": "^2.19.0"
-      }
-    },
-    "node_modules/@remirror/types/node_modules/type-fest": {
-      "version": "2.19.0",
-      "license": "(MIT OR CC0-1.0)",
-      "engines": {
-        "node": ">=12.20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
+      "resolved": "https://registry.npmjs.org/@remirror/core-constants/-/core-constants-2.0.2.tgz",
+      "integrity": "sha512-dyHY+sMF0ihPus3O27ODd4+agdHMEmuRdyiZJ2CCWjPV5UFmn17ZbElvk6WOGVE4rdCJKZQCrPV2BcikOMLUGQ=="
     },
     "node_modules/@remix-run/router": {
       "version": "1.14.1",
@@ -5269,14 +5234,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/object.omit": {
-      "version": "3.0.3",
-      "license": "MIT"
-    },
-    "node_modules/@types/object.pick": {
-      "version": "1.3.4",
-      "license": "MIT"
-    },
     "node_modules/@types/parse-json": {
       "version": "4.0.2",
       "dev": true,
@@ -5314,10 +5271,6 @@
     "node_modules/@types/semver": {
       "version": "7.5.6",
       "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/throttle-debounce": {
-      "version": "2.1.0",
       "license": "MIT"
     },
     "node_modules/@types/unist": {
@@ -6804,16 +6757,6 @@
         "tslib": "^2.2.0"
       }
     },
-    "node_modules/case-anything": {
-      "version": "2.1.13",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12.13"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/mesqueeb"
-      }
-    },
     "node_modules/ccount": {
       "version": "2.0.1",
       "license": "MIT",
@@ -8012,10 +7955,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/dash-get": {
-      "version": "1.0.2",
-      "license": "MIT"
-    },
     "node_modules/data-uri-to-buffer": {
       "version": "2.0.2",
       "license": "MIT"
@@ -8139,13 +8078,6 @@
       "version": "0.1.4",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/deepmerge": {
-      "version": "4.3.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/defaults": {
       "version": "1.0.4",
@@ -11498,26 +11430,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/is-extendable": {
-      "version": "1.0.1",
-      "license": "MIT",
-      "dependencies": {
-        "is-plain-object": "^2.0.4"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/is-extendable/node_modules/is-plain-object": {
-      "version": "2.0.4",
-      "license": "MIT",
-      "dependencies": {
-        "isobject": "^3.0.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "devOptional": true,
@@ -11891,6 +11803,7 @@
     },
     "node_modules/isobject": {
       "version": "3.0.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -12646,10 +12559,6 @@
       "bin": {
         "semver": "bin/semver.js"
       }
-    },
-    "node_modules/make-error": {
-      "version": "1.3.6",
-      "license": "ISC"
     },
     "node_modules/make-fetch-happen": {
       "version": "10.2.1",
@@ -15282,26 +15191,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/object.omit": {
-      "version": "3.0.0",
-      "license": "MIT",
-      "dependencies": {
-        "is-extendable": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/object.pick": {
-      "version": "1.3.0",
-      "license": "MIT",
-      "dependencies": {
-        "isobject": "^3.0.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/object.values": {
       "version": "1.1.7",
       "dev": true,
@@ -16735,11 +16624,11 @@
       }
     },
     "node_modules/prosemirror-trailing-node": {
-      "version": "2.0.7",
-      "license": "MIT",
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/prosemirror-trailing-node/-/prosemirror-trailing-node-2.0.8.tgz",
+      "integrity": "sha512-ujRYhSuhQb1Jsarh1IHqb2KoSnRiD7wAMDGucP35DN7j5af6X7B18PfdPIrbwsPTqIAj0fyOvxbuPsWhNvylmA==",
       "dependencies": {
         "@remirror/core-constants": "^2.0.2",
-        "@remirror/core-helpers": "^3.0.0",
         "escape-string-regexp": "^4.0.0"
       },
       "peerDependencies": {
@@ -19338,13 +19227,6 @@
       },
       "engines": {
         "node": ">=0.8"
-      }
-    },
-    "node_modules/throttle-debounce": {
-      "version": "3.0.1",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/through": {


### PR DESCRIPTION
Bump prosemirror-trailing-node to 2.0.8 to pick up remirror/remirror#2245, which drops @remirror/core-helpers.
The latter package was heavy, bringing in several additional dependencies, but was only used to create
an array of unique elements, and to check for the presence of elements in arrays.

Accordingly, they have been replaced in 2.0.8 with equivalent code that relies on standard built-in objects.

_This PR has been submitted through the course of work for @opengovsg_