### PR TITLE
fix: don't call `setEditable` when not necessary

### DIFF
--- a/packages/core/src/editor/BlockNoteEditor.ts
+++ b/packages/core/src/editor/BlockNoteEditor.ts
@@ -654,7 +654,9 @@ export class BlockNoteEditor<
    * @param editable True to make the editor editable, or false to lock it.
    */
   public set isEditable(editable: boolean) {
-    this._tiptapEditor.setEditable(editable);
+    if (this._tiptapEditor.options.editable !== editable) {
+      this._tiptapEditor.setEditable(editable);
+    }
   }
 
   /**


### PR DESCRIPTION
We were always triggering `setEditable` even if this wasn't necessary. This triggered an `onChange` before the view was mounted

fixes #622 