### PR TITLE
fix: Formatting toolbar appearance on fade out

### DIFF
--- a/examples/02-ui-components/02-formatting-toolbar-buttons/App.tsx
+++ b/examples/02-ui-components/02-formatting-toolbar-buttons/App.tsx
@@ -70,57 +70,80 @@ export default function App() {
   return (
     <BlockNoteView editor={editor} formattingToolbar={false}>
       <FormattingToolbarController
-        formattingToolbar={() => (
-          <FormattingToolbar>
-            <BlockTypeDropdown key={"blockTypeDropdown"} />
+        formattingToolbar={(props) => (
+          <FormattingToolbar {...props}>
+            <BlockTypeDropdown
+              selectedBlocks={props.selectedBlocks}
+              key={"blockTypeDropdown"}
+            />
 
             {/* Extra button to toggle blue text & background */}
             <BlueButton key={"customButton"} />
 
-            <ImageCaptionButton key={"imageCaptionButton"} />
-            <ReplaceImageButton key={"replaceImageButton"} />
+            <ImageCaptionButton
+              selectedBlocks={props.selectedBlocks}
+              key={"imageCaptionButton"}
+            />
+            <ReplaceImageButton
+              selectedBlocks={props.selectedBlocks}
+              key={"replaceImageButton"}
+            />
 
             <BasicTextStyleButton
+              selectedBlocks={props.selectedBlocks}
               basicTextStyle={"bold"}
               key={"boldStyleButton"}
             />
             <BasicTextStyleButton
+              selectedBlocks={props.selectedBlocks}
               basicTextStyle={"italic"}
               key={"italicStyleButton"}
             />
             <BasicTextStyleButton
+              selectedBlocks={props.selectedBlocks}
               basicTextStyle={"underline"}
               key={"underlineStyleButton"}
             />
             <BasicTextStyleButton
+              selectedBlocks={props.selectedBlocks}
               basicTextStyle={"strike"}
               key={"strikeStyleButton"}
             />
             {/* Extra button to toggle code styles */}
             <BasicTextStyleButton
+              selectedBlocks={props.selectedBlocks}
               key={"codeStyleButton"}
               basicTextStyle={"code"}
             />
 
             <TextAlignButton
+              selectedBlocks={props.selectedBlocks}
               textAlignment={"left"}
               key={"textAlignLeftButton"}
             />
             <TextAlignButton
+              selectedBlocks={props.selectedBlocks}
               textAlignment={"center"}
               key={"textAlignCenterButton"}
             />
             <TextAlignButton
+              selectedBlocks={props.selectedBlocks}
               textAlignment={"right"}
               key={"textAlignRightButton"}
             />
 
-            <ColorStyleButton key={"colorStyleButton"} />
+            <ColorStyleButton
+              selectedBlocks={props.selectedBlocks}
+              key={"colorStyleButton"}
+            />
 
             <NestBlockButton key={"nestBlockButton"} />
             <UnnestBlockButton key={"unnestBlockButton"} />
 
-            <CreateLinkButton key={"createLinkButton"} />
+            <CreateLinkButton
+              selectedBlocks={props.selectedBlocks}
+              key={"createLinkButton"}
+            />
           </FormattingToolbar>
         )}
       />

--- a/examples/02-ui-components/03-formatting-toolbar-block-type-items/App.tsx
+++ b/examples/02-ui-components/03-formatting-toolbar-block-type-items/App.tsx
@@ -53,8 +53,9 @@ export default function App() {
   return (
     <BlockNoteView editor={editor} formattingToolbar={false}>
       <FormattingToolbarController
-        formattingToolbar={() => (
+        formattingToolbar={(props) => (
           <FormattingToolbar
+            {...props}
             blockTypeDropdownItems={[
               ...blockTypeDropdownItems,
               {

--- a/examples/05-custom-schema/03-font-style/App.tsx
+++ b/examples/05-custom-schema/03-font-style/App.tsx
@@ -97,26 +97,39 @@ export default function App() {
     <BlockNoteView editor={editor} formattingToolbar={false}>
       {/* Replaces the default Formatting Toolbar. */}
       <FormattingToolbarController
-        formattingToolbar={() => (
-          <FormattingToolbar>
-            <BlockTypeDropdown key={"blockTypeDropdown"} />
+        formattingToolbar={(props) => (
+          <FormattingToolbar {...props}>
+            <BlockTypeDropdown
+              selectedBlocks={props.selectedBlocks}
+              key={"blockTypeDropdown"}
+            />
 
-            <ImageCaptionButton key={"imageCaptionButton"} />
-            <ReplaceImageButton key={"replaceImageButton"} />
+            <ImageCaptionButton
+              selectedBlocks={props.selectedBlocks}
+              key={"imageCaptionButton"}
+            />
+            <ReplaceImageButton
+              selectedBlocks={props.selectedBlocks}
+              key={"replaceImageButton"}
+            />
 
             <BasicTextStyleButton
+              selectedBlocks={props.selectedBlocks}
               basicTextStyle={"bold"}
               key={"boldStyleButton"}
             />
             <BasicTextStyleButton
+              selectedBlocks={props.selectedBlocks}
               basicTextStyle={"italic"}
               key={"italicStyleButton"}
             />
             <BasicTextStyleButton
+              selectedBlocks={props.selectedBlocks}
               basicTextStyle={"underline"}
               key={"underlineStyleButton"}
             />
             <BasicTextStyleButton
+              selectedBlocks={props.selectedBlocks}
               basicTextStyle={"strike"}
               key={"strikeStyleButton"}
             />
@@ -124,24 +137,33 @@ export default function App() {
             <SetFontStyleButton />
 
             <TextAlignButton
+              selectedBlocks={props.selectedBlocks}
               textAlignment={"left"}
               key={"textAlignLeftButton"}
             />
             <TextAlignButton
+              selectedBlocks={props.selectedBlocks}
               textAlignment={"center"}
               key={"textAlignCenterButton"}
             />
             <TextAlignButton
+              selectedBlocks={props.selectedBlocks}
               textAlignment={"right"}
               key={"textAlignRightButton"}
             />
 
-            <ColorStyleButton key={"colorStyleButton"} />
+            <ColorStyleButton
+              selectedBlocks={props.selectedBlocks}
+              key={"colorStyleButton"}
+            />
 
             <NestBlockButton key={"nestBlockButton"} />
             <UnnestBlockButton key={"unnestBlockButton"} />
 
-            <CreateLinkButton key={"createLinkButton"} />
+            <CreateLinkButton
+              selectedBlocks={props.selectedBlocks}
+              key={"createLinkButton"}
+            />
           </FormattingToolbar>
         )}
       />

--- a/examples/05-custom-schema/react-custom-blocks/App.tsx
+++ b/examples/05-custom-schema/react-custom-blocks/App.tsx
@@ -110,11 +110,11 @@ export const bracketsParagraphBlock = createReactBlockSpec(
   {
     render: (props) => (
       <div className={"brackets-paragraph"}>
-        <div contentEditable={"false"}>{"["}</div>
-        <span contentEditable={"false"}>{"{"}</span>
+        <div>{"["}</div>
+        <span>{"{"}</span>
         <div className={"inline-content"} ref={props.contentRef} />
-        <span contentEditable={"false"}>{"}"}</span>
-        <div contentEditable={"false"}>{"]"}</div>
+        <span>{"}"}</span>
+        <div>{"]"}</div>
       </div>
     ),
   }

--- a/examples/05-custom-schema/react-custom-styles/App.tsx
+++ b/examples/05-custom-schema/react-custom-styles/App.tsx
@@ -52,7 +52,7 @@ const CustomFormattingToolbar = (props: FormattingToolbarProps) => {
   const activeStyles = useActiveStyles(editor);
 
   return (
-    <FormattingToolbar>
+    <FormattingToolbar {...props}>
       <ToolbarButton
         mainTooltip={"small"}
         onClick={() => {

--- a/examples/vanilla-js/react-vanilla-custom-styles/App.tsx
+++ b/examples/vanilla-js/react-vanilla-custom-styles/App.tsx
@@ -64,7 +64,7 @@ const CustomFormattingToolbar = (props: FormattingToolbarProps) => {
   const activeStyles = useActiveStyles(editor);
 
   return (
-    <FormattingToolbar>
+    <FormattingToolbar {...props}>
       <ToolbarButton
         mainTooltip={"small"}
         onClick={() => {

--- a/packages/core/src/editor/BlockNoteEditor.ts
+++ b/packages/core/src/editor/BlockNoteEditor.ts
@@ -155,7 +155,11 @@ export class BlockNoteEditor<
   public readonly inlineContentImplementations: InlineContentSpecs;
   public readonly styleImplementations: StyleSpecs;
 
-  public readonly formattingToolbar: FormattingToolbarProsemirrorPlugin;
+  public readonly formattingToolbar: FormattingToolbarProsemirrorPlugin<
+    BSchema,
+    ISchema,
+    SSchema
+  >;
   public readonly hyperlinkToolbar: HyperlinkToolbarProsemirrorPlugin<
     BSchema,
     ISchema,
@@ -361,7 +365,7 @@ export class BlockNoteEditor<
    * @deprecated, use `editor.document` instead
    */
   public get topLevelBlocks(): Block<BSchema, ISchema, SSchema>[] {
-    return this.topLevelBlocks;
+    return this.document;
   }
 
   /**

--- a/packages/react/src/components/FormattingToolbar/FormattingToolbarController.tsx
+++ b/packages/react/src/components/FormattingToolbar/FormattingToolbarController.tsx
@@ -1,6 +1,9 @@
 import {
   BlockSchema,
+  DefaultBlockSchema,
+  DefaultInlineContentSchema,
   DefaultProps,
+  DefaultStyleSchema,
   InlineContentSchema,
   StyleSchema,
 } from "@blocknote/core";
@@ -29,14 +32,14 @@ const textAlignmentToPlacement = (
   }
 };
 
-export const FormattingToolbarController = (props: {
-  formattingToolbar?: FC<FormattingToolbarProps>;
+export const FormattingToolbarController = <
+  BSchema extends BlockSchema = DefaultBlockSchema,
+  I extends InlineContentSchema = DefaultInlineContentSchema,
+  S extends StyleSchema = DefaultStyleSchema
+>(props: {
+  formattingToolbar?: FC<FormattingToolbarProps<BSchema, I, S>>;
 }) => {
-  const editor = useBlockNoteEditor<
-    BlockSchema,
-    InlineContentSchema,
-    StyleSchema
-  >();
+  const editor = useBlockNoteEditor<BSchema, I, S>();
 
   const [placement, setPlacement] = useState<"top-start" | "top" | "top-end">(
     () => {
@@ -83,11 +86,13 @@ export const FormattingToolbarController = (props: {
     return null;
   }
 
+  const { show, referencePos, ...data } = state;
+
   const Component = props.formattingToolbar || FormattingToolbar;
 
   return (
     <div ref={ref} style={style}>
-      <Component />
+      <Component {...data} />
     </div>
   );
 };

--- a/packages/react/src/components/FormattingToolbar/FormattingToolbarProps.ts
+++ b/packages/react/src/components/FormattingToolbar/FormattingToolbarProps.ts
@@ -1,5 +1,19 @@
 import { BlockTypeDropdownItem } from "./mantine/DefaultDropdowns/BlockTypeDropdown";
+import {
+  BlockSchema,
+  DefaultBlockSchema,
+  DefaultInlineContentSchema,
+  DefaultStyleSchema,
+  FormattingToolbarState,
+  InlineContentSchema,
+  StyleSchema,
+  UiElementPosition,
+} from "@blocknote/core";
 
-export type FormattingToolbarProps = {
+export type FormattingToolbarProps<
+  BSchema extends BlockSchema = DefaultBlockSchema,
+  I extends InlineContentSchema = DefaultInlineContentSchema,
+  S extends StyleSchema = DefaultStyleSchema
+> = Omit<FormattingToolbarState<BSchema, I, S>, keyof UiElementPosition> & {
   blockTypeDropdownItems?: BlockTypeDropdownItem[];
 };

--- a/packages/react/src/components/FormattingToolbar/mantine/DefaultButtons/BasicTextStyleButton.tsx
+++ b/packages/react/src/components/FormattingToolbar/mantine/DefaultButtons/BasicTextStyleButton.tsx
@@ -1,6 +1,10 @@
 import {
+  Block,
   BlockNoteEditor,
   BlockSchema,
+  DefaultBlockSchema,
+  DefaultInlineContentSchema,
+  DefaultStyleSchema,
   formatKeyboardShortcut,
   InlineContentSchema,
   StyleSchema,
@@ -17,7 +21,6 @@ import {
 
 import { useBlockNoteEditor } from "../../../../hooks/useBlockNoteEditor";
 import { useEditorContentOrSelectionChange } from "../../../../hooks/useEditorContentOrSelectionChange";
-import { useSelectedBlocks } from "../../../../hooks/useSelectedBlocks";
 import { ToolbarButton } from "../../../mantine-shared/Toolbar/ToolbarButton";
 
 type BasicTextStyle = "bold" | "italic" | "underline" | "strike" | "code";
@@ -38,12 +41,16 @@ const shortcuts = {
   code: "",
 } satisfies Record<BasicTextStyle, string>;
 
-function checkBasicTextStyleInSchema<Style extends BasicTextStyle>(
+function checkBasicTextStyleInSchema<
+  Style extends BasicTextStyle,
+  BSchema extends BlockSchema,
+  I extends InlineContentSchema
+>(
   style: Style,
-  editor: BlockNoteEditor<BlockSchema, InlineContentSchema, StyleSchema>
+  editor: BlockNoteEditor<BSchema, I, any>
 ): editor is BlockNoteEditor<
-  BlockSchema,
-  InlineContentSchema,
+  BSchema,
+  I,
   {
     [k in Style]: {
       type: k;
@@ -58,8 +65,14 @@ function checkBasicTextStyleInSchema<Style extends BasicTextStyle>(
   );
 }
 
-export const BasicTextStyleButton = <Style extends BasicTextStyle>(props: {
+export const BasicTextStyleButton = <
+  Style extends BasicTextStyle,
+  BSchema extends BlockSchema = DefaultBlockSchema,
+  I extends InlineContentSchema = DefaultInlineContentSchema,
+  S extends StyleSchema = DefaultStyleSchema
+>(props: {
   basicTextStyle: Style;
+  selectedBlocks: Block<BSchema, I, S>[];
 }) => {
   const editor = useBlockNoteEditor<
     BlockSchema,
@@ -71,8 +84,6 @@ export const BasicTextStyleButton = <Style extends BasicTextStyle>(props: {
     props.basicTextStyle,
     editor
   );
-
-  const selectedBlocks = useSelectedBlocks(editor);
 
   const [active, setActive] = useState<boolean>(
     props.basicTextStyle in editor.getActiveStyles()
@@ -101,8 +112,8 @@ export const BasicTextStyleButton = <Style extends BasicTextStyle>(props: {
       return false;
     }
     // Also don't show when none of the selected blocks have text content
-    return !!selectedBlocks.find((block) => block.content !== undefined);
-  }, [basicTextStyleInSchema, selectedBlocks]);
+    return !!props.selectedBlocks.find((block) => block.content !== undefined);
+  }, [basicTextStyleInSchema, props.selectedBlocks]);
 
   if (!show) {
     return null;

--- a/packages/react/src/components/FormattingToolbar/mantine/DefaultButtons/ColorStyleButton.tsx
+++ b/packages/react/src/components/FormattingToolbar/mantine/DefaultButtons/ColorStyleButton.tsx
@@ -1,6 +1,10 @@
 import {
+  Block,
   BlockNoteEditor,
   BlockSchema,
+  DefaultBlockSchema,
+  DefaultInlineContentSchema,
+  DefaultStyleSchema,
   InlineContentSchema,
   StyleSchema,
 } from "@blocknote/core";
@@ -10,17 +14,20 @@ import { useCallback, useMemo, useState } from "react";
 import { useBlockNoteEditor } from "../../../../hooks/useBlockNoteEditor";
 import { useEditorContentOrSelectionChange } from "../../../../hooks/useEditorContentOrSelectionChange";
 import { usePreventMenuOverflow } from "../../../../hooks/usePreventMenuOverflow";
-import { useSelectedBlocks } from "../../../../hooks/useSelectedBlocks";
 import { ColorIcon } from "../../../mantine-shared/ColorPicker/ColorIcon";
 import { ColorPicker } from "../../../mantine-shared/ColorPicker/ColorPicker";
 import { ToolbarButton } from "../../../mantine-shared/Toolbar/ToolbarButton";
 
-function checkColorInSchema<Color extends "text" | "background">(
+function checkColorInSchema<
+  Color extends "text" | "background",
+  BSchema extends BlockSchema,
+  I extends InlineContentSchema
+>(
   color: Color,
-  editor: BlockNoteEditor<BlockSchema, InlineContentSchema, StyleSchema>
+  editor: BlockNoteEditor<BSchema, I, any>
 ): editor is BlockNoteEditor<
-  BlockSchema,
-  InlineContentSchema,
+  BSchema,
+  I,
   Color extends "text"
     ? {
         textColor: {
@@ -42,7 +49,13 @@ function checkColorInSchema<Color extends "text" | "background">(
   );
 }
 
-export const ColorStyleButton = () => {
+export const ColorStyleButton = <
+  BSchema extends BlockSchema = DefaultBlockSchema,
+  I extends InlineContentSchema = DefaultInlineContentSchema,
+  S extends StyleSchema = DefaultStyleSchema
+>(props: {
+  selectedBlocks: Block<BSchema, I, S>[];
+}) => {
   const editor = useBlockNoteEditor<
     BlockSchema,
     InlineContentSchema,
@@ -51,8 +64,6 @@ export const ColorStyleButton = () => {
 
   const textColorInSchema = checkColorInSchema("text", editor);
   const backgroundColorInSchema = checkColorInSchema("background", editor);
-
-  const selectedBlocks = useSelectedBlocks(editor);
 
   const [currentTextColor, setCurrentTextColor] = useState<string>(
     textColorInSchema
@@ -115,14 +126,14 @@ export const ColorStyleButton = () => {
       return false;
     }
 
-    for (const block of selectedBlocks) {
+    for (const block of props.selectedBlocks) {
       if (block.content !== undefined) {
         return true;
       }
     }
 
     return false;
-  }, [backgroundColorInSchema, selectedBlocks, textColorInSchema]);
+  }, [backgroundColorInSchema, props.selectedBlocks, textColorInSchema]);
 
   if (!show) {
     return null;

--- a/packages/react/src/components/FormattingToolbar/mantine/DefaultButtons/CreateLinkButton.tsx
+++ b/packages/react/src/components/FormattingToolbar/mantine/DefaultButtons/CreateLinkButton.tsx
@@ -2,7 +2,12 @@ import { useCallback, useMemo, useState } from "react";
 import { RiLink } from "react-icons/ri";
 
 import {
+  Block,
+  BlockNoteEditor,
   BlockSchema,
+  DefaultBlockSchema,
+  DefaultInlineContentSchema,
+  DefaultStyleSchema,
   formatKeyboardShortcut,
   InlineContentSchema,
   StyleSchema,
@@ -10,20 +15,43 @@ import {
 
 import { useBlockNoteEditor } from "../../../../hooks/useBlockNoteEditor";
 import { useEditorContentOrSelectionChange } from "../../../../hooks/useEditorContentOrSelectionChange";
-import { useSelectedBlocks } from "../../../../hooks/useSelectedBlocks";
 import { EditHyperlinkMenu } from "../../../HyperlinkToolbar/mantine/EditHyperlinkMenu/EditHyperlinkMenu";
 import { ToolbarButton } from "../../../mantine-shared/Toolbar/ToolbarButton";
 import { ToolbarInputDropdownButton } from "../../../mantine-shared/Toolbar/ToolbarInputDropdownButton";
 
-// TODO: Make sure Link is in inline content schema
-export const CreateLinkButton = () => {
+function checkLinkInSchema<BSchema extends BlockSchema, S extends StyleSchema>(
+  editor: BlockNoteEditor<BSchema, any, S>
+): editor is BlockNoteEditor<
+  BSchema,
+  {
+    link: {
+      type: "link";
+      propSchema: any;
+      content: "styled";
+    };
+  },
+  S
+> {
+  return (
+    "link" in editor.schema.inlineContentSchema &&
+    editor.schema.inlineContentSchema["link"] === "link"
+  );
+}
+
+export const CreateLinkButton = <
+  BSchema extends BlockSchema = DefaultBlockSchema,
+  I extends InlineContentSchema = DefaultInlineContentSchema,
+  S extends StyleSchema = DefaultStyleSchema
+>(props: {
+  selectedBlocks: Block<BSchema, I, S>[];
+}) => {
   const editor = useBlockNoteEditor<
     BlockSchema,
     InlineContentSchema,
     StyleSchema
   >();
 
-  const selectedBlocks = useSelectedBlocks(editor);
+  const linkInSchema = checkLinkInSchema(editor);
 
   const [url, setUrl] = useState<string>(editor.getSelectedLinkUrl() || "");
   const [text, setText] = useState<string>(editor.getSelectedText());
@@ -42,14 +70,18 @@ export const CreateLinkButton = () => {
   );
 
   const show = useMemo(() => {
-    for (const block of selectedBlocks) {
+    if (!linkInSchema) {
+      return false;
+    }
+
+    for (const block of props.selectedBlocks) {
       if (block.content === undefined) {
         return false;
       }
     }
 
     return true;
-  }, [selectedBlocks]);
+  }, [linkInSchema, props.selectedBlocks]);
 
   if (!show) {
     return null;

--- a/packages/react/src/components/FormattingToolbar/mantine/DefaultButtons/ImageCaptionButton.tsx
+++ b/packages/react/src/components/FormattingToolbar/mantine/DefaultButtons/ImageCaptionButton.tsx
@@ -1,7 +1,11 @@
 import {
+  Block,
   BlockSchema,
   checkBlockIsDefaultType,
   checkDefaultBlockTypeInSchema,
+  DefaultBlockSchema,
+  DefaultInlineContentSchema,
+  DefaultStyleSchema,
   InlineContentSchema,
   StyleSchema,
 } from "@blocknote/core";
@@ -15,13 +19,18 @@ import {
 import { RiText } from "react-icons/ri";
 
 import { useBlockNoteEditor } from "../../../../hooks/useBlockNoteEditor";
-import { useSelectedBlocks } from "../../../../hooks/useSelectedBlocks";
 import { ToolbarButton } from "../../../mantine-shared/Toolbar/ToolbarButton";
 import { ToolbarInputDropdown } from "../../../mantine-shared/Toolbar/ToolbarInputDropdown";
 import { ToolbarInputDropdownButton } from "../../../mantine-shared/Toolbar/ToolbarInputDropdownButton";
 import { ToolbarInputDropdownItem } from "../../../mantine-shared/Toolbar/ToolbarInputDropdownItem";
 
-export const ImageCaptionButton = () => {
+export const ImageCaptionButton = <
+  BSchema extends BlockSchema = DefaultBlockSchema,
+  I extends InlineContentSchema = DefaultInlineContentSchema,
+  S extends StyleSchema = DefaultStyleSchema
+>(props: {
+  selectedBlocks: Block<BSchema, I, S>[];
+}) => {
   const editor = useBlockNoteEditor<
     BlockSchema,
     InlineContentSchema,
@@ -30,22 +39,20 @@ export const ImageCaptionButton = () => {
 
   const [currentEditingCaption, setCurrentEditingCaption] = useState<string>();
 
-  const selectedBlocks = useSelectedBlocks(editor);
-
   const imageBlock = useMemo(() => {
     // Checks if only one block is selected.
-    if (selectedBlocks.length !== 1) {
+    if (props.selectedBlocks.length !== 1) {
       return undefined;
     }
 
-    const block = selectedBlocks[0];
+    const block = props.selectedBlocks[0];
 
     if (checkBlockIsDefaultType("image", block, editor)) {
       return block;
     }
 
     return undefined;
-  }, [editor, selectedBlocks]);
+  }, [editor, props.selectedBlocks]);
 
   const handleEnter = useCallback(
     (event: KeyboardEvent) => {

--- a/packages/react/src/components/FormattingToolbar/mantine/DefaultButtons/ReplaceImageButton.tsx
+++ b/packages/react/src/components/FormattingToolbar/mantine/DefaultButtons/ReplaceImageButton.tsx
@@ -1,6 +1,10 @@
 import {
+  Block,
   BlockSchema,
   checkBlockIsDefaultType,
+  DefaultBlockSchema,
+  DefaultInlineContentSchema,
+  DefaultStyleSchema,
   InlineContentSchema,
   StyleSchema,
 } from "@blocknote/core";
@@ -9,26 +13,30 @@ import { useEffect, useState } from "react";
 import { RiImageEditFill } from "react-icons/ri";
 
 import { useBlockNoteEditor } from "../../../../hooks/useBlockNoteEditor";
-import { useSelectedBlocks } from "../../../../hooks/useSelectedBlocks";
 import { ImageToolbar } from "../../../ImageToolbar/mantine/ImageToolbar";
 import { ToolbarButton } from "../../../mantine-shared/Toolbar/ToolbarButton";
 
-export const ReplaceImageButton = () => {
+export const ReplaceImageButton = <
+  BSchema extends BlockSchema = DefaultBlockSchema,
+  I extends InlineContentSchema = DefaultInlineContentSchema,
+  S extends StyleSchema = DefaultStyleSchema
+>(props: {
+  selectedBlocks: Block<BSchema, I, S>[];
+}) => {
   const editor = useBlockNoteEditor<
     BlockSchema,
     InlineContentSchema,
     StyleSchema
   >();
 
-  const selectedBlocks = useSelectedBlocks(editor);
-
   const [isOpen, setIsOpen] = useState<boolean>(false);
 
   useEffect(() => {
     setIsOpen(false);
-  }, [selectedBlocks]);
+  }, []);
 
-  const block = selectedBlocks.length === 1 ? selectedBlocks[0] : undefined;
+  const block =
+    props.selectedBlocks.length === 1 ? props.selectedBlocks[0] : undefined;
 
   if (
     block === undefined ||

--- a/packages/react/src/components/FormattingToolbar/mantine/DefaultButtons/TextAlignButton.tsx
+++ b/packages/react/src/components/FormattingToolbar/mantine/DefaultButtons/TextAlignButton.tsx
@@ -1,8 +1,12 @@
 import {
+  Block,
   BlockSchema,
   checkBlockHasDefaultProp,
   checkBlockTypeHasDefaultProp,
+  DefaultBlockSchema,
+  DefaultInlineContentSchema,
   DefaultProps,
+  DefaultStyleSchema,
   InlineContentSchema,
   StyleSchema,
 } from "@blocknote/core";
@@ -16,7 +20,6 @@ import {
 } from "react-icons/ri";
 
 import { useBlockNoteEditor } from "../../../../hooks/useBlockNoteEditor";
-import { useSelectedBlocks } from "../../../../hooks/useSelectedBlocks";
 import { ToolbarButton } from "../../../mantine-shared/Toolbar/ToolbarButton";
 
 type TextAlignment = DefaultProps["textAlignment"];
@@ -28,30 +31,35 @@ const icons: Record<TextAlignment, IconType> = {
   justify: RiAlignJustify,
 };
 
-export const TextAlignButton = (props: { textAlignment: TextAlignment }) => {
+export const TextAlignButton = <
+  BSchema extends BlockSchema = DefaultBlockSchema,
+  I extends InlineContentSchema = DefaultInlineContentSchema,
+  S extends StyleSchema = DefaultStyleSchema
+>(props: {
+  textAlignment: TextAlignment;
+  selectedBlocks: Block<BSchema, I, S>[];
+}) => {
   const editor = useBlockNoteEditor<
     BlockSchema,
     InlineContentSchema,
     StyleSchema
   >();
 
-  const selectedBlocks = useSelectedBlocks(editor);
-
   const textAlignment = useMemo(() => {
-    const block = selectedBlocks[0];
+    const block = props.selectedBlocks[0];
 
     if (checkBlockHasDefaultProp("textAlignment", block, editor)) {
       return block.props.textAlignment;
     }
 
     return;
-  }, [editor, selectedBlocks]);
+  }, [editor, props.selectedBlocks]);
 
   const setTextAlignment = useCallback(
     (textAlignment: TextAlignment) => {
       editor.focus();
 
-      for (const block of selectedBlocks) {
+      for (const block of props.selectedBlocks) {
         if (checkBlockTypeHasDefaultProp("textAlignment", block.type, editor)) {
           editor.updateBlock(block, {
             props: { textAlignment: textAlignment },
@@ -59,12 +67,14 @@ export const TextAlignButton = (props: { textAlignment: TextAlignment }) => {
         }
       }
     },
-    [editor, selectedBlocks]
+    [editor, props.selectedBlocks]
   );
 
   const show = useMemo(() => {
-    return !!selectedBlocks.find((block) => "textAlignment" in block.props);
-  }, [selectedBlocks]);
+    return !!props.selectedBlocks.find(
+      (block) => "textAlignment" in block.props
+    );
+  }, [props.selectedBlocks]);
 
   if (!show) {
     return null;

--- a/packages/react/src/components/FormattingToolbar/mantine/FormattingToolbar.tsx
+++ b/packages/react/src/components/FormattingToolbar/mantine/FormattingToolbar.tsx
@@ -14,30 +14,76 @@ import {
   BlockTypeDropdown,
   BlockTypeDropdownItem,
 } from "./DefaultDropdowns/BlockTypeDropdown";
+import {
+  Block,
+  BlockSchema,
+  DefaultBlockSchema,
+  DefaultInlineContentSchema,
+  DefaultStyleSchema,
+  InlineContentSchema,
+  StyleSchema,
+} from "@blocknote/core";
 
-export const getFormattingToolbarItems = (
+export const getFormattingToolbarItems = <
+  BSchema extends BlockSchema,
+  I extends InlineContentSchema,
+  S extends StyleSchema
+>(
+  selectedBlocks: Block<BSchema, I, S>[],
   blockTypeDropdownItems?: BlockTypeDropdownItem[]
 ): JSX.Element[] => [
   <BlockTypeDropdown
-    key={"blockTypeDropdown"}
+    selectedBlocks={selectedBlocks}
     items={blockTypeDropdownItems}
+    key={"blockTypeDropdown"}
   />,
-  <ImageCaptionButton key={"imageCaptionButton"} />,
-  <ReplaceImageButton key={"replaceImageButton"} />,
-  <BasicTextStyleButton basicTextStyle={"bold"} key={"boldStyleButton"} />,
-  <BasicTextStyleButton basicTextStyle={"italic"} key={"italicStyleButton"} />,
+  <ImageCaptionButton
+    selectedBlocks={selectedBlocks}
+    key={"imageCaptionButton"}
+  />,
+  <ReplaceImageButton
+    selectedBlocks={selectedBlocks}
+    key={"replaceImageButton"}
+  />,
   <BasicTextStyleButton
+    selectedBlocks={selectedBlocks}
+    basicTextStyle={"bold"}
+    key={"boldStyleButton"}
+  />,
+  <BasicTextStyleButton
+    selectedBlocks={selectedBlocks}
+    basicTextStyle={"italic"}
+    key={"italicStyleButton"}
+  />,
+  <BasicTextStyleButton
+    selectedBlocks={selectedBlocks}
     basicTextStyle={"underline"}
     key={"underlineStyleButton"}
   />,
-  <BasicTextStyleButton basicTextStyle={"strike"} key={"strikeStyleButton"} />,
-  <TextAlignButton textAlignment={"left"} key={"textAlignLeftButton"} />,
-  <TextAlignButton textAlignment={"center"} key={"textAlignCenterButton"} />,
-  <TextAlignButton textAlignment={"right"} key={"textAlignRightButton"} />,
-  <ColorStyleButton key={"colorStyleButton"} />,
+  <BasicTextStyleButton
+    selectedBlocks={selectedBlocks}
+    basicTextStyle={"strike"}
+    key={"strikeStyleButton"}
+  />,
+  <TextAlignButton
+    selectedBlocks={selectedBlocks}
+    textAlignment={"left"}
+    key={"textAlignLeftButton"}
+  />,
+  <TextAlignButton
+    selectedBlocks={selectedBlocks}
+    textAlignment={"center"}
+    key={"textAlignCenterButton"}
+  />,
+  <TextAlignButton
+    selectedBlocks={selectedBlocks}
+    textAlignment={"right"}
+    key={"textAlignRightButton"}
+  />,
+  <ColorStyleButton selectedBlocks={selectedBlocks} key={"colorStyleButton"} />,
   <NestBlockButton key={"nestBlockButton"} />,
   <UnnestBlockButton key={"unnestBlockButton"} />,
-  <CreateLinkButton key={"createLinkButton"} />,
+  <CreateLinkButton selectedBlocks={selectedBlocks} key={"createLinkButton"} />,
 ];
 
 // TODO: props.blockTypeDropdownItems should only be available if no children
@@ -54,13 +100,20 @@ export const getFormattingToolbarItems = (
  * - Custom buttons: The `ToolbarButton` component in the
  * `components/mantine-shared/Toolbar` directory.
  */
-export const FormattingToolbar = (
-  props: FormattingToolbarProps & { children?: React.ReactNode }
+export const FormattingToolbar = <
+  BSchema extends BlockSchema = DefaultBlockSchema,
+  I extends InlineContentSchema = DefaultInlineContentSchema,
+  S extends StyleSchema = DefaultStyleSchema
+>(
+  props: FormattingToolbarProps<BSchema, I, S> & { children?: React.ReactNode }
 ) => {
   return (
     <Toolbar>
       {props.children ||
-        getFormattingToolbarItems(props.blockTypeDropdownItems)}
+        getFormattingToolbarItems(
+          props.selectedBlocks,
+          props.blockTypeDropdownItems
+        )}
     </Toolbar>
   );
 };


### PR DESCRIPTION
Because formatting toolbar buttons manage their own state, they check whether they should be shown based on the block that the text cursor is in. This can be a problem if the user clicks a block of a different type to close the toolbar, as it can cause the toolbar state to change as it's fading out, which looks bad. This PR fixes that by making the plugin figure out which block(s) are selected instead, and including them in the plugin state for the toolbar buttons.

The difference between this approach and using `useSelectedBlocks` is that the plugin will NOT update the selected blocks if `state.show` is `false`, so the selected blocks are only updated when the formatting toolbar itself is shown/updated.

This is similar to how & why we pass the hovered block in the side menu/drag handle menu, so I think this pattern makes sense.