### PR TITLE
fix: Hide toolbars with no children

### DIFF
--- a/packages/react/src/editor/styles.css
+++ b/packages/react/src/editor/styles.css
@@ -326,6 +326,10 @@
   width: fit-content;
 }
 
+.bn-container .bn-toolbar:empty {
+  display: none;
+}
+
 .bn-container .bn-toolbar .mantine-Button-root,
 .bn-container .bn-toolbar .mantine-ActionIcon-root {
   background-color: var(--bn-colors-menu-background);


### PR DESCRIPTION
This PR ensures that `Toolbar` components (in formatting & hyperlink toolbars) are hidden when they contain no children. Currently, they are still visible due to padding and a drop shadow.