### PR TITLE
fix: Remove `all: unset` from default styles

### DIFF
--- a/packages/core/src/editor/editor.css
+++ b/packages/core/src/editor/editor.css
@@ -36,7 +36,6 @@ Tippy popups that are appended to document.body directly
 .bn-default-styles h2,
 .bn-default-styles h3,
 .bn-default-styles li {
-  all: unset;
   margin: 0;
   padding: 0;
   font-size: inherit;


### PR DESCRIPTION
Besides being bad practice, using `all: unset` in the default styles causes issues with keystrokes when the text cursor is at the start of a block, before non-editable inline content. I think we can just remove it as it doesn't seem to cause any styling issues.