### PR TITLE
feat: implemented trailingBlock option

### DIFF
--- a/packages/core/src/editor/BlockNoteExtensions.ts
+++ b/packages/core/src/editor/BlockNoteExtensions.ts
@@ -65,6 +65,10 @@ export const getBlockNoteExtensions = <
     // DevTools,
     Gapcursor,
 
+    TrailingNode.configure({
+      trailingBlock: true,
+    }),
+
     // DropCursor,
     Placeholder.configure({
       // TODO: This shorthand is kind of ugly

--- a/packages/core/src/extensions/TrailingNode/TrailingNodeExtension.ts
+++ b/packages/core/src/extensions/TrailingNode/TrailingNodeExtension.ts
@@ -10,7 +10,7 @@ import { Plugin, PluginKey } from "prosemirror-state";
  */
 
 export interface TrailingNodeOptions {
-  node: string;
+  trailingBlock?: boolean;
 }
 
 /**
@@ -31,17 +31,23 @@ export const TrailingNode = Extension.create<TrailingNodeOptions>({
         appendTransaction: (_, __, state) => {
           const { doc, tr, schema } = state;
           const shouldInsertNodeAtEnd = plugin.getState(state);
-          const endPosition = doc.content.size - 2;
-          const type = schema.nodes["blockContainer"];
-          const contentType = schema.nodes["paragraph"];
+
           if (!shouldInsertNodeAtEnd) {
             return;
           }
 
-          return tr.insert(
-            endPosition,
-            type.create(undefined, contentType.create())
-          );
+          if (this.options.trailingBlock) {
+            const endPosition = doc.content.size - 2;
+            const type = schema.nodes["blockContainer"];
+            const contentType = schema.nodes["paragraph"];
+
+            return tr.insert(
+              endPosition,
+              type.create(undefined, contentType.create())
+            );
+          } else {
+            return;
+          }
         },
         state: {
           init: (_, _state) => {


### PR DESCRIPTION
Updated `BlockNoteExtension.ts` to configure TrailingNode extension, introducing trailingBlock option for controlling insertion of trailing block nodes. Default behavior remains unchanged with trailingBlock set to true for inserting trailing block nodes at the end of the document.

/claim #631 