### PR TITLE
refactor: Remove `keydown` handler from suggestion plugin

### DIFF
--- a/packages/core/src/extensions/SuggestionMenu/SuggestionPlugin.ts
+++ b/packages/core/src/extensions/SuggestionMenu/SuggestionPlugin.ts
@@ -245,30 +245,6 @@ export class SuggestionMenuProseMirrorPlugin<
       },
 
       props: {
-        handleKeyDown(view, event) {
-          const suggestionPluginState: SuggestionPluginState = (
-            this as Plugin
-          ).getState(view.state);
-
-          if (
-            triggerCharacters.includes(event.key) &&
-            suggestionPluginState === undefined
-          ) {
-            event.preventDefault();
-
-            view.dispatch(
-              view.state.tr
-                .insertText(event.key)
-                .scrollIntoView()
-                .setMeta(suggestionMenuPluginKey, {
-                  triggerCharacter: event.key,
-                })
-            );
-
-            return true;
-          }
-          return false;
-        },
         handleTextInput(view, _from, _to, text) {
           const suggestionPluginState: SuggestionPluginState = (
             this as Plugin


### PR DESCRIPTION
No longer needed as `textInput` handler was added to also make suggestion menus work on mobile.