### PR TITLE
fix: match query anywhere to filter slash menu items

### DIFF
--- a/packages/core/src/extensions/SuggestionMenu/getDefaultSlashMenuItems.ts
+++ b/packages/core/src/extensions/SuggestionMenu/getDefaultSlashMenuItems.ts
@@ -234,10 +234,10 @@ export function filterSuggestionItems<
 >(items: T[], query: string) {
   return items.filter(
     ({ title, aliases }) =>
-      title.toLowerCase().startsWith(query.toLowerCase()) ||
+      title.toLowerCase().includes(query.toLowerCase()) ||
       (aliases &&
         aliases.filter((alias) =>
-          alias.toLowerCase().startsWith(query.toLowerCase())
+          alias.toLowerCase().includes(query.toLowerCase())
         ).length !== 0)
   );
 }


### PR DESCRIPTION
Notion menu item filtering 
<img width="403" alt="image" src="https://github.com/TypeCellOS/BlockNote/assets/6894311/e2ff9cd9-93fe-492a-b93f-2d1957eeb1ea">

Current BlockNote filtering only matches start of the word. This PR fixes it to match query anywhere in the item or alias text