### PR TITLE
fix: Key inputs in blocks without content

### DIFF
--- a/packages/core/src/editor/BlockNoteExtensions.ts
+++ b/packages/core/src/editor/BlockNoteExtensions.ts
@@ -76,7 +76,7 @@ export const getBlockNoteExtensions = <
     UniqueID.configure({
       types: ["blockContainer"],
     }),
-    HardBreak,
+    HardBreak.extend({ priority: 10 }),
     // Comments,
 
     // basics:

--- a/packages/core/src/extensions/NonEditableBlocks/NonEditableBlockPlugin.ts
+++ b/packages/core/src/extensions/NonEditableBlocks/NonEditableBlockPlugin.ts
@@ -3,6 +3,12 @@ import { Plugin, PluginKey } from "prosemirror-state";
 const PLUGIN_KEY = new PluginKey("non-editable-block");
 // Prevent typing for blocks without inline content, as this would otherwise
 // convert them into paragraph blocks.
+// TODO: This implementation misses a lot of edge cases, e.g. inserting emojis
+//  and special characters on international keyboards (e.g. "ś" which is Alt-S
+//  on the Polish keyboard). A more robust approach would be to filter out
+//  transactions in which a no content block is selected before, and replaced
+//  with a paragraph block after (will likely need additional filtering e.g. to
+//  not filter out `updateBlock` calls).
 export const NonEditableBlockPlugin = () => {
   return new Plugin({
     key: PLUGIN_KEY,
@@ -13,15 +19,18 @@ export const NonEditableBlockPlugin = () => {
           // Checks if key input will insert a character - we want to block this
           // as it will convert the block into a paragraph.
           if (
-            event.key.length === 1 &&
+            (event.key.length === 1 || event.key === "Enter") &&
             !event.ctrlKey &&
             !event.altKey &&
-            !event.metaKey &&
-            !event.shiftKey
+            !event.metaKey
           ) {
             event.preventDefault();
+
+            return true;
           }
         }
+
+        return false;
       },
     },
   });


### PR DESCRIPTION
This PR improves how keystrokes are handled in non-editable blocks like images, so that more edge cases are covered (including special characters like ś and Enter).

A more robust approach might be to filter out transactions in which a no content block is selected before, and replaced with a paragraph block after (will likely need additional filtering e.g. to not filter out `updateBlock` calls). However, I think the current implementation gets us 90% of the way there with much less complexity so I don't think it's worth looking into.

TODO: We should merge the `releases` branch into main first