### PR TITLE
fix: UI element position on scroll

### DIFF
--- a/packages/core/src/extensions/FilePanel/FilePanelPlugin.ts
+++ b/packages/core/src/extensions/FilePanel/FilePanelPlugin.ts
@@ -45,7 +45,7 @@ export class FilePanelView<I extends InlineContentSchema, S extends StyleSchema>
 
     pmView.dom.addEventListener("dragstart", this.dragstartHandler);
 
-    document.addEventListener("scroll", this.scrollHandler);
+    document.addEventListener("scroll", this.scrollHandler, true);
   }
 
   mouseDownHandler = () => {
@@ -119,7 +119,7 @@ export class FilePanelView<I extends InlineContentSchema, S extends StyleSchema>
 
     this.pmView.dom.removeEventListener("dragstart", this.dragstartHandler);
 
-    document.removeEventListener("scroll", this.scrollHandler);
+    document.removeEventListener("scroll", this.scrollHandler, true);
   }
 }
 

--- a/packages/core/src/extensions/FilePanel/FilePanelPlugin.ts
+++ b/packages/core/src/extensions/FilePanel/FilePanelPlugin.ts
@@ -42,9 +42,11 @@ export class FilePanelView<I extends InlineContentSchema, S extends StyleSchema>
     };
 
     pmView.dom.addEventListener("mousedown", this.mouseDownHandler);
-
     pmView.dom.addEventListener("dragstart", this.dragstartHandler);
 
+    // Setting capture=true ensures that any parent container of the editor that
+    // gets scrolled will trigger the scroll event. Scroll events do not bubble
+    // and so won't propagate to the document by default.
     document.addEventListener("scroll", this.scrollHandler, true);
   }
 

--- a/packages/core/src/extensions/FormattingToolbar/FormattingToolbarPlugin.ts
+++ b/packages/core/src/extensions/FormattingToolbar/FormattingToolbarPlugin.ts
@@ -60,7 +60,7 @@ export class FormattingToolbarView implements PluginView {
     pmView.dom.addEventListener("dragstart", this.dragHandler);
     pmView.dom.addEventListener("dragover", this.dragHandler);
 
-    document.addEventListener("scroll", this.scrollHandler);
+    document.addEventListener("scroll", this.scrollHandler, true);
   }
 
   viewMousedownHandler = () => {
@@ -150,7 +150,7 @@ export class FormattingToolbarView implements PluginView {
     this.pmView.dom.removeEventListener("dragstart", this.dragHandler);
     this.pmView.dom.removeEventListener("dragover", this.dragHandler);
 
-    document.removeEventListener("scroll", this.scrollHandler);
+    document.removeEventListener("scroll", this.scrollHandler, true);
   }
 
   closeMenu = () => {

--- a/packages/core/src/extensions/FormattingToolbar/FormattingToolbarPlugin.ts
+++ b/packages/core/src/extensions/FormattingToolbar/FormattingToolbarPlugin.ts
@@ -60,6 +60,9 @@ export class FormattingToolbarView implements PluginView {
     pmView.dom.addEventListener("dragstart", this.dragHandler);
     pmView.dom.addEventListener("dragover", this.dragHandler);
 
+    // Setting capture=true ensures that any parent container of the editor that
+    // gets scrolled will trigger the scroll event. Scroll events do not bubble
+    // and so won't propagate to the document by default.
     document.addEventListener("scroll", this.scrollHandler, true);
   }
 

--- a/packages/core/src/extensions/LinkToolbar/LinkToolbarPlugin.ts
+++ b/packages/core/src/extensions/LinkToolbar/LinkToolbarPlugin.ts
@@ -62,6 +62,10 @@ class LinkToolbarView implements PluginView {
 
     this.pmView.dom.addEventListener("mouseover", this.mouseOverHandler);
     document.addEventListener("click", this.clickHandler, true);
+
+    // Setting capture=true ensures that any parent container of the editor that
+    // gets scrolled will trigger the scroll event. Scroll events do not bubble
+    // and so won't propagate to the document by default.
     document.addEventListener("scroll", this.scrollHandler, true);
   }
 

--- a/packages/core/src/extensions/LinkToolbar/LinkToolbarPlugin.ts
+++ b/packages/core/src/extensions/LinkToolbar/LinkToolbarPlugin.ts
@@ -62,7 +62,7 @@ class LinkToolbarView implements PluginView {
 
     this.pmView.dom.addEventListener("mouseover", this.mouseOverHandler);
     document.addEventListener("click", this.clickHandler, true);
-    document.addEventListener("scroll", this.scrollHandler);
+    document.addEventListener("scroll", this.scrollHandler, true);
   }
 
   mouseOverHandler = (event: MouseEvent) => {
@@ -267,7 +267,7 @@ class LinkToolbarView implements PluginView {
 
   destroy() {
     this.pmView.dom.removeEventListener("mouseover", this.mouseOverHandler);
-    document.removeEventListener("scroll", this.scrollHandler);
+    document.removeEventListener("scroll", this.scrollHandler, true);
     document.removeEventListener("click", this.clickHandler, true);
   }
 }

--- a/packages/core/src/extensions/SideMenu/SideMenuPlugin.ts
+++ b/packages/core/src/extensions/SideMenu/SideMenuPlugin.ts
@@ -293,13 +293,15 @@ export class SideMenuView<
     // Shows or updates menu position whenever the cursor moves, if the menu isn't frozen.
     document.body.addEventListener("mousemove", this.onMouseMove, true);
 
-    // Makes menu scroll with the page.
-    document.addEventListener("scroll", this.onScroll, true);
-
     // Unfreezes the menu whenever the user clicks.
     this.pmView.dom.addEventListener("mousedown", this.onMouseDown);
     // Hides and unfreezes the menu whenever the user presses a key.
     document.body.addEventListener("keydown", this.onKeyDown, true);
+
+    // Setting capture=true ensures that any parent container of the editor that
+    // gets scrolled will trigger the scroll event. Scroll events do not bubble
+    // and so won't propagate to the document by default.
+    document.addEventListener("scroll", this.onScroll, true);
   }
 
   /**

--- a/packages/core/src/extensions/SideMenu/SideMenuPlugin.ts
+++ b/packages/core/src/extensions/SideMenu/SideMenuPlugin.ts
@@ -533,8 +533,6 @@ export class SideMenuView<
       this.emitUpdate(this.state);
     }
 
-    this.menuFrozen = true;
-
     const blockContent = this.hoveredBlock!.firstChild! as HTMLElement;
     const blockContentBoundingBox = blockContent.getBoundingClientRect();
 

--- a/packages/core/src/extensions/SuggestionMenu/SuggestionPlugin.ts
+++ b/packages/core/src/extensions/SuggestionMenu/SuggestionPlugin.ts
@@ -37,6 +37,9 @@ class SuggestionMenuView<
       emitUpdate(menuName, this.state);
     };
 
+    // Setting capture=true ensures that any parent container of the editor that
+    // gets scrolled will trigger the scroll event. Scroll events do not bubble
+    // and so won't propagate to the document by default.
     document.addEventListener("scroll", this.handleScroll, true);
   }
 

--- a/packages/core/src/extensions/SuggestionMenu/SuggestionPlugin.ts
+++ b/packages/core/src/extensions/SuggestionMenu/SuggestionPlugin.ts
@@ -37,7 +37,7 @@ class SuggestionMenuView<
       emitUpdate(menuName, this.state);
     };
 
-    document.addEventListener("scroll", this.handleScroll);
+    document.addEventListener("scroll", this.handleScroll, true);
   }
 
   handleScroll = () => {
@@ -92,7 +92,7 @@ class SuggestionMenuView<
   }
 
   destroy() {
-    document.removeEventListener("scroll", this.handleScroll);
+    document.removeEventListener("scroll", this.handleScroll, true);
   }
 
   closeMenu = () => {

--- a/packages/core/src/extensions/TableHandles/TableHandlesPlugin.ts
+++ b/packages/core/src/extensions/TableHandles/TableHandlesPlugin.ts
@@ -119,7 +119,7 @@ export class TableHandlesView<
     document.addEventListener("dragover", this.dragOverHandler);
     document.addEventListener("drop", this.dropHandler);
 
-    document.addEventListener("scroll", this.scrollHandler);
+    document.addEventListener("scroll", this.scrollHandler, true);
   }
 
   mouseMoveHandler = (event: MouseEvent) => {
@@ -361,7 +361,7 @@ export class TableHandlesView<
     document.removeEventListener("dragover", this.dragOverHandler);
     document.removeEventListener("drop", this.dropHandler);
 
-    document.removeEventListener("scroll", this.scrollHandler);
+    document.removeEventListener("scroll", this.scrollHandler, true);
   }
 }
 

--- a/packages/core/src/extensions/TableHandles/TableHandlesPlugin.ts
+++ b/packages/core/src/extensions/TableHandles/TableHandlesPlugin.ts
@@ -119,6 +119,9 @@ export class TableHandlesView<
     document.addEventListener("dragover", this.dragOverHandler);
     document.addEventListener("drop", this.dropHandler);
 
+    // Setting capture=true ensures that any parent container of the editor that
+    // gets scrolled will trigger the scroll event. Scroll events do not bubble
+    // and so won't propagate to the document by default.
     document.addEventListener("scroll", this.scrollHandler, true);
   }
 


### PR DESCRIPTION
This PR fixes UI elements like the formatting toolbar and side menu only scrolling with the editor when the whole page is being scrolled. Now, the elements scroll with the editor regardless of which containing element is being scrolled. Additionally, the side menu is now hidden on click after being frozen, to more closely replicate Notion's UX.

Closes #748