### PR TITLE
fix: Custom inline content crash

### DIFF
--- a/packages/react/src/schema/@util/ReactRenderUtil.ts
+++ b/packages/react/src/schema/@util/ReactRenderUtil.ts
@@ -10,20 +10,22 @@ export function renderToDOMSpec(
   const div = document.createElement("div");
 
   let root: Root | undefined;
-  if (!editor) {
-    // If no editor is provided, use a temporary root.
+  const { _tiptapEditor } = editor || {};
+
+  if (_tiptapEditor?.contentComponent) {
+    // Render temporarily using `EditorContent` (which is stored somewhat hacky on `_tiptapEditor.contentComponent`)
+    // This way React Context will still work, as `fc` will be rendered inside the existing React tree
+    _tiptapEditor.contentComponent.renderToElement(
+      fc((el) => (contentDOM = el || undefined)),
+      div
+    );
+  } else {
+    // If no editor is provided, or if _tiptapEditor or _tiptapEditor.contentComponent is undefined, use a temporary root.
     // This is currently only used for Styles. In this case, react context etc. won't be available inside `fc`
     root = createRoot(div);
     flushSync(() => {
       root!.render(fc((el) => (contentDOM = el || undefined)));
     });
-  } else {
-    // Render temporarily using `EditorContent` (which is stored somewhat hacky on `editor._tiptapEditor.contentComponent`)
-    // This way React Context will still work, as `fc` will be rendered inside the existing React tree
-    editor._tiptapEditor.contentComponent.renderToElement(
-      fc((el) => (contentDOM = el || undefined)),
-      div
-    );
   }
 
   if (!div.childElementCount) {


### PR DESCRIPTION
Fixes https://github.com/TypeCellOS/BlockNote/issues/750

**Before**

<img width="1728" alt="image" src="https://github.com/TypeCellOS/BlockNote/assets/5826063/569fc867-c3eb-4bd3-9862-55f98b411aba">

**After**

<img width="1727" alt="image" src="https://github.com/TypeCellOS/BlockNote/assets/5826063/8cd5050f-6190-421c-bdac-77ac84aea62d">
