### PR TITLE
refactor: `contentRef` prop into `useContent` hook

### DIFF
--- a/examples/02-ui-components/03-formatting-toolbar-block-type-items/Alert.tsx
+++ b/examples/02-ui-components/03-formatting-toolbar-block-type-items/Alert.tsx
@@ -1,5 +1,14 @@
-import { defaultProps } from "@blocknote/core";
-import { createReactBlockSpec } from "@blocknote/react";
+import {
+  BlockConfig,
+  DefaultInlineContentSchema,
+  defaultProps,
+  DefaultStyleSchema,
+} from "@blocknote/core";
+import {
+  createReactBlockSpec,
+  ReactCustomBlockRenderProps,
+  useContent,
+} from "@blocknote/react";
 import { Menu } from "@mantine/core";
 import { MdCancel, MdCheckCircle, MdError, MdInfo } from "react-icons/md";
 
@@ -49,72 +58,79 @@ export const alertTypes = [
   },
 ] as const;
 
-// The Alert block.
-export const Alert = createReactBlockSpec(
-  {
-    type: "alert",
-    propSchema: {
-      textAlignment: defaultProps.textAlignment,
-      textColor: defaultProps.textColor,
-      type: {
-        default: "warning",
-        values: ["warning", "error", "info", "success"],
-      },
+const alertBlockConfig = {
+  type: "alert",
+  propSchema: {
+    textAlignment: defaultProps.textAlignment,
+    textColor: defaultProps.textColor,
+    type: {
+      default: "warning",
+      values: ["warning", "error", "info", "success"],
     },
-    content: "inline",
   },
-  {
-    render: (props) => {
-      const alertType = alertTypes.find(
-        (a) => a.value === props.block.props.type
-      )!;
-      const Icon = alertType.icon;
+  content: "inline",
+} satisfies BlockConfig;
 
-      return (
-        <div className={"alert"} data-alert-type={props.block.props.type}>
-          {/*Icon which opens a menu to choose the Alert type*/}
-          <Menu withinPortal={false} zIndex={999999}>
-            <Menu.Target>
-              <div className={"alert-icon-wrapper"} contentEditable={false}>
-                <Icon
-                  className={"alert-icon"}
-                  data-alert-icon-type={props.block.props.type}
-                  size={32}
-                />
-              </div>
-            </Menu.Target>
-            {/*Dropdown to change the Alert type*/}
-            <Menu.Dropdown>
-              <Menu.Label>Alert Type</Menu.Label>
-              <Menu.Divider />
-              {alertTypes.map((type) => {
-                const ItemIcon = type.icon;
+const RenderAlert = (
+  props: ReactCustomBlockRenderProps<
+    typeof alertBlockConfig,
+    DefaultInlineContentSchema,
+    DefaultStyleSchema
+  >
+) => {
+  const contentProps = useContent();
 
-                return (
-                  <Menu.Item
-                    key={type.value}
-                    leftSection={
-                      <ItemIcon
-                        className={"alert-icon"}
-                        data-alert-icon-type={type.value}
-                      />
-                    }
-                    onClick={() =>
-                      props.editor.updateBlock(props.block, {
-                        type: "alert",
-                        props: { type: type.value },
-                      })
-                    }>
-                    {type.title}
-                  </Menu.Item>
-                );
-              })}
-            </Menu.Dropdown>
-          </Menu>
-          {/*Rich text field for user to type in*/}
-          <div className={"inline-content"} ref={props.contentRef} />
-        </div>
-      );
-    },
-  }
-);
+  const alertType = alertTypes.find((a) => a.value === props.block.props.type)!;
+  const Icon = alertType.icon;
+
+  return (
+    <div className={"alert"} data-alert-type={props.block.props.type}>
+      {/*Icon which opens a menu to choose the Alert type*/}
+      <Menu withinPortal={false} zIndex={999999}>
+        <Menu.Target>
+          <div className={"alert-icon-wrapper"} contentEditable={false}>
+            <Icon
+              className={"alert-icon"}
+              data-alert-icon-type={props.block.props.type}
+              size={32}
+            />
+          </div>
+        </Menu.Target>
+        {/*Dropdown to change the Alert type*/}
+        <Menu.Dropdown>
+          <Menu.Label>Alert Type</Menu.Label>
+          <Menu.Divider />
+          {alertTypes.map((type) => {
+            const ItemIcon = type.icon;
+
+            return (
+              <Menu.Item
+                key={type.value}
+                leftSection={
+                  <ItemIcon
+                    className={"alert-icon"}
+                    data-alert-icon-type={type.value}
+                  />
+                }
+                onClick={() =>
+                  props.editor.updateBlock(props.block, {
+                    type: "alert",
+                    props: { type: type.value },
+                  })
+                }>
+                {type.title}
+              </Menu.Item>
+            );
+          })}
+        </Menu.Dropdown>
+      </Menu>
+      {/*Rich text field for user to type in*/}
+      <div className={"inline-content"} {...contentProps} />
+    </div>
+  );
+};
+
+// The Alert block.
+export const Alert = createReactBlockSpec(alertBlockConfig, {
+  render: RenderAlert,
+});

--- a/examples/05-custom-schema/01-alert-block/Alert.tsx
+++ b/examples/05-custom-schema/01-alert-block/Alert.tsx
@@ -1,5 +1,14 @@
-import { defaultProps } from "@blocknote/core";
-import { createReactBlockSpec } from "@blocknote/react";
+import {
+  BlockConfig,
+  DefaultInlineContentSchema,
+  defaultProps,
+  DefaultStyleSchema,
+} from "@blocknote/core";
+import {
+  createReactBlockSpec,
+  ReactCustomBlockRenderProps,
+  useContent,
+} from "@blocknote/react";
 import { Menu } from "@mantine/core";
 import { MdCancel, MdCheckCircle, MdError, MdInfo } from "react-icons/md";
 import "./styles.css";
@@ -48,71 +57,79 @@ export const alertTypes = [
   },
 ] as const;
 
-// The Alert block.
-export const Alert = createReactBlockSpec(
-  {
-    type: "alert",
-    propSchema: {
-      textAlignment: defaultProps.textAlignment,
-      textColor: defaultProps.textColor,
-      type: {
-        default: "warning",
-        values: ["warning", "error", "info", "success"],
-      },
+const alertBlockConfig = {
+  type: "alert",
+  propSchema: {
+    textAlignment: defaultProps.textAlignment,
+    textColor: defaultProps.textColor,
+    type: {
+      default: "warning",
+      values: ["warning", "error", "info", "success"],
     },
-    content: "inline",
   },
-  {
-    render: (props) => {
-      const alertType = alertTypes.find(
-        (a) => a.value === props.block.props.type
-      )!;
-      const Icon = alertType.icon;
-      return (
-        <div className={"alert"} data-alert-type={props.block.props.type}>
-          {/*Icon which opens a menu to choose the Alert type*/}
-          <Menu withinPortal={false} zIndex={999999}>
-            <Menu.Target>
-              <div className={"alert-icon-wrapper"} contentEditable={false}>
-                <Icon
-                  className={"alert-icon"}
-                  data-alert-icon-type={props.block.props.type}
-                  size={32}
-                />
-              </div>
-            </Menu.Target>
-            {/*Dropdown to change the Alert type*/}
-            <Menu.Dropdown>
-              <Menu.Label>Alert Type</Menu.Label>
-              <Menu.Divider />
-              {alertTypes.map((type) => {
-                const ItemIcon = type.icon;
+  content: "inline",
+} satisfies BlockConfig;
 
-                return (
-                  <Menu.Item
-                    key={type.value}
-                    leftSection={
-                      <ItemIcon
-                        className={"alert-icon"}
-                        data-alert-icon-type={type.value}
-                      />
-                    }
-                    onClick={() =>
-                      props.editor.updateBlock(props.block, {
-                        type: "alert",
-                        props: { type: type.value },
-                      })
-                    }>
-                    {type.title}
-                  </Menu.Item>
-                );
-              })}
-            </Menu.Dropdown>
-          </Menu>
-          {/*Rich text field for user to type in*/}
-          <div className={"inline-content"} ref={props.contentRef} />
-        </div>
-      );
-    },
-  }
-);
+const RenderAlert = (
+  props: ReactCustomBlockRenderProps<
+    typeof alertBlockConfig,
+    DefaultInlineContentSchema,
+    DefaultStyleSchema
+  >
+) => {
+  const contentProps = useContent();
+
+  const alertType = alertTypes.find((a) => a.value === props.block.props.type)!;
+  const Icon = alertType.icon;
+
+  return (
+    <div className={"alert"} data-alert-type={props.block.props.type}>
+      {/*Icon which opens a menu to choose the Alert type*/}
+      <Menu withinPortal={false} zIndex={999999}>
+        <Menu.Target>
+          <div className={"alert-icon-wrapper"} contentEditable={false}>
+            <Icon
+              className={"alert-icon"}
+              data-alert-icon-type={props.block.props.type}
+              size={32}
+            />
+          </div>
+        </Menu.Target>
+        {/*Dropdown to change the Alert type*/}
+        <Menu.Dropdown>
+          <Menu.Label>Alert Type</Menu.Label>
+          <Menu.Divider />
+          {alertTypes.map((type) => {
+            const ItemIcon = type.icon;
+
+            return (
+              <Menu.Item
+                key={type.value}
+                leftSection={
+                  <ItemIcon
+                    className={"alert-icon"}
+                    data-alert-icon-type={type.value}
+                  />
+                }
+                onClick={() =>
+                  props.editor.updateBlock(props.block, {
+                    type: "alert",
+                    props: { type: type.value },
+                  })
+                }>
+                {type.title}
+              </Menu.Item>
+            );
+          })}
+        </Menu.Dropdown>
+      </Menu>
+      {/*Rich text field for user to type in*/}
+      <div className={"inline-content"} {...contentProps} />
+    </div>
+  );
+};
+
+// The Alert block.
+export const Alert = createReactBlockSpec(alertBlockConfig, {
+  render: RenderAlert,
+});

--- a/examples/05-custom-schema/03-font-style/Font.tsx
+++ b/examples/05-custom-schema/03-font-style/Font.tsx
@@ -1,4 +1,10 @@
-import { createReactStyleSpec } from "@blocknote/react";
+import { createReactStyleSpec, useContent } from "@blocknote/react";
+
+const RenderFont = (props: { value: string }) => {
+  const { style, ...rest } = useContent();
+
+  return <span style={{ fontFamily: props.value, ...style }} {...rest} />;
+};
 
 // The Font style.
 export const Font = createReactStyleSpec(
@@ -7,8 +13,6 @@ export const Font = createReactStyleSpec(
     propSchema: "string",
   },
   {
-    render: (props) => (
-      <span style={{ fontFamily: props.value }} ref={props.contentRef} />
-    ),
+    render: RenderFont,
   }
 );

--- a/examples/05-custom-schema/react-custom-blocks/App.tsx
+++ b/examples/05-custom-schema/react-custom-blocks/App.tsx
@@ -1,10 +1,18 @@
 import {
+  BlockConfig,
   BlockNoteSchema,
   defaultBlockSpecs,
+  DefaultInlineContentSchema,
   defaultProps,
+  DefaultStyleSchema,
 } from "@blocknote/core";
 import "@blocknote/core/fonts/inter.css";
-import { createReactBlockSpec, useCreateBlockNote } from "@blocknote/react";
+import {
+  createReactBlockSpec,
+  ReactCustomBlockRenderProps,
+  useContent,
+  useCreateBlockNote,
+} from "@blocknote/react";
 import { BlockNoteView } from "@blocknote/mantine";
 import "@blocknote/mantine/style.css";
 
@@ -34,6 +42,55 @@ const alertTypes = {
   },
 };
 
+const alertBlockConfig = {
+  type: "alert",
+  propSchema: {
+    textAlignment: defaultProps.textAlignment,
+    textColor: defaultProps.textColor,
+    type: {
+      default: "warning",
+      values: ["warning", "error", "info", "success"],
+    },
+  },
+  content: "inline",
+} satisfies BlockConfig;
+
+const AlertBlock = (
+  props: ReactCustomBlockRenderProps<
+    typeof alertBlockConfig,
+    DefaultInlineContentSchema,
+    DefaultStyleSchema
+  >
+) => {
+  const contentProps = useContent();
+
+  return (
+    <div
+      className={"alert"}
+      style={{
+        backgroundColor:
+          alertTypes[props.block.props.type as keyof typeof alertTypes]
+            .backgroundColor,
+      }}>
+      <select
+        contentEditable={false}
+        value={props.block.props.type}
+        onChange={(event) => {
+          props.editor.updateBlock(props.block, {
+            type: "alert",
+            props: { type: event.target.value as keyof typeof alertTypes },
+          });
+        }}>
+        <option value="warning">{alertTypes["warning"].icon}</option>
+        <option value="error">{alertTypes["error"].icon}</option>
+        <option value="info">{alertTypes["info"].icon}</option>
+        <option value="success">{alertTypes["success"].icon}</option>
+      </select>
+      <div className={"inline-content"} {...contentProps} />
+    </div>
+  );
+};
+
 export const alertBlock = createReactBlockSpec(
   {
     type: "alert",
@@ -48,29 +105,7 @@ export const alertBlock = createReactBlockSpec(
     content: "inline",
   },
   {
-    render: (props) => (
-      <div
-        className={"alert"}
-        style={{
-          backgroundColor: alertTypes[props.block.props.type].backgroundColor,
-        }}>
-        <select
-          contentEditable={false}
-          value={props.block.props.type}
-          onChange={(event) => {
-            props.editor.updateBlock(props.block, {
-              type: "alert",
-              props: { type: event.target.value as keyof typeof alertTypes },
-            });
-          }}>
-          <option value="warning">{alertTypes["warning"].icon}</option>
-          <option value="error">{alertTypes["error"].icon}</option>
-          <option value="info">{alertTypes["info"].icon}</option>
-          <option value="success">{alertTypes["success"].icon}</option>
-        </select>
-        <div className={"inline-content"} ref={props.contentRef} />
-      </div>
-    ),
+    render: AlertBlock,
   }
 );
 
@@ -96,6 +131,20 @@ const simpleImageBlock = createReactBlockSpec(
   }
 );
 
+const BracketsParagraph = () => {
+  const contentProps = useContent();
+
+  return (
+    <div className={"brackets-paragraph"}>
+      <div contentEditable={"false"}>{"["}</div>
+      <span contentEditable={"false"}>{"{"}</span>
+      <div className={"inline-content"} {...contentProps} />
+      <span contentEditable={"false"}>{"}"}</span>
+      <div contentEditable={"false"}>{"]"}</div>
+    </div>
+  );
+};
+
 export const bracketsParagraphBlock = createReactBlockSpec(
   {
     type: "bracketsParagraph",
@@ -105,15 +154,7 @@ export const bracketsParagraphBlock = createReactBlockSpec(
     },
   },
   {
-    render: (props) => (
-      <div className={"brackets-paragraph"}>
-        <div contentEditable={"false"}>{"["}</div>
-        <span contentEditable={"false"}>{"{"}</span>
-        <div className={"inline-content"} ref={props.contentRef} />
-        <span contentEditable={"false"}>{"}"}</span>
-        <div contentEditable={"false"}>{"]"}</div>
-      </div>
-    ),
+    render: BracketsParagraph,
   }
 );
 

--- a/examples/05-custom-schema/react-custom-inline-content/App.tsx
+++ b/examples/05-custom-schema/react-custom-inline-content/App.tsx
@@ -2,6 +2,7 @@ import { BlockNoteSchema, defaultInlineContentSpecs } from "@blocknote/core";
 import "@blocknote/core/fonts/inter.css";
 import {
   createReactInlineContentSpec,
+  useContent,
   useCreateBlockNote,
 } from "@blocknote/react";
 import { BlockNoteView } from "@blocknote/mantine";
@@ -24,6 +25,16 @@ const mention = createReactInlineContentSpec(
   }
 );
 
+const Tag = () => {
+  const contentProps = useContent();
+
+  return (
+    <span>
+      #<span {...contentProps} />
+    </span>
+  );
+};
+
 const tag = createReactInlineContentSpec(
   {
     type: "tag",
@@ -31,13 +42,7 @@ const tag = createReactInlineContentSpec(
     content: "styled",
   },
   {
-    render: (props) => {
-      return (
-        <span>
-          #<span ref={props.contentRef}></span>
-        </span>
-      );
-    },
+    render: Tag,
   }
 );
 

--- a/examples/05-custom-schema/react-custom-styles/App.tsx
+++ b/examples/05-custom-schema/react-custom-styles/App.tsx
@@ -8,10 +8,17 @@ import {
   useActiveStyles,
   useBlockNoteEditor,
   useComponentsContext,
+  useContent,
   useCreateBlockNote,
 } from "@blocknote/react";
 import { BlockNoteView } from "@blocknote/mantine";
 import "@blocknote/mantine/style.css";
+
+const Small = () => {
+  const contentProps = useContent();
+
+  return <small {...contentProps} />;
+};
 
 const small = createReactStyleSpec(
   {
@@ -19,11 +26,15 @@ const small = createReactStyleSpec(
     propSchema: "boolean",
   },
   {
-    render: (props) => {
-      return <small ref={props.contentRef}></small>;
-    },
+    render: Small,
   }
 );
+
+const FontSize = (props: { value: string }) => {
+  const { style, ...rest } = useContent();
+
+  return <span style={{ fontSize: props.value, ...style }} {...rest} />;
+};
 
 const fontSize = createReactStyleSpec(
   {
@@ -31,11 +42,7 @@ const fontSize = createReactStyleSpec(
     propSchema: "string",
   },
   {
-    render: (props) => {
-      return (
-        <span ref={props.contentRef} style={{ fontSize: props.value }}></span>
-      );
-    },
+    render: FontSize,
   }
 );
 

--- a/packages/react/src/hooks/useContent.tsx
+++ b/packages/react/src/hooks/useContent.tsx
@@ -1,0 +1,9 @@
+import { useReactNodeView } from "@tiptap/react";
+
+export function useContent() {
+  return {
+    ref: useReactNodeView().nodeViewContentRef,
+    style: { whiteSpace: "pre-wrap" },
+    "data-node-view-content": "",
+  };
+}

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -69,6 +69,7 @@ export * from "./components/TableHandles/TableHandleMenu/TableHandleMenuProps";
 
 export * from "./hooks/useActiveStyles";
 export * from "./hooks/useBlockNoteEditor";
+export * from "./hooks/useContent";
 export * from "./hooks/useCreateBlockNote";
 export * from "./hooks/useEditorChange";
 export * from "./hooks/useEditorContentOrSelectionChange";

--- a/packages/react/src/schema/@util/ReactRenderUtil.ts
+++ b/packages/react/src/schema/@util/ReactRenderUtil.ts
@@ -3,7 +3,7 @@ import { flushSync } from "react-dom";
 import { Root, createRoot } from "react-dom/client";
 
 export function renderToDOMSpec(
-  fc: (refCB: (ref: HTMLElement | null) => void) => React.ReactNode,
+  fc: () => React.ReactNode,
   editor: BlockNoteEditor<any, any, any> | undefined
 ) {
   let contentDOM: HTMLElement | undefined;
@@ -15,15 +15,12 @@ export function renderToDOMSpec(
     // This is currently only used for Styles. In this case, react context etc. won't be available inside `fc`
     root = createRoot(div);
     flushSync(() => {
-      root!.render(fc((el) => (contentDOM = el || undefined)));
+      root!.render(fc());
     });
   } else {
     // Render temporarily using `EditorContent` (which is stored somewhat hacky on `editor._tiptapEditor.contentComponent`)
     // This way React Context will still work, as `fc` will be rendered inside the existing React tree
-    editor._tiptapEditor.contentComponent.renderToElement(
-      fc((el) => (contentDOM = el || undefined)),
-      div
-    );
+    editor._tiptapEditor.contentComponent.renderToElement(fc(), div);
   }
 
   if (!div.childElementCount) {

--- a/packages/react/src/schema/ReactBlockSpec.tsx
+++ b/packages/react/src/schema/ReactBlockSpec.tsx
@@ -18,7 +18,6 @@ import {
   StyleSchema,
 } from "@blocknote/core";
 import {
-  NodeViewContent,
   NodeViewProps,
   NodeViewWrapper,
   ReactNodeViewRenderer,
@@ -35,7 +34,6 @@ export type ReactCustomBlockRenderProps<
 > = {
   block: BlockFromConfig<T, I, S>;
   editor: BlockNoteEditor<BlockSchemaWithBlock<T["type"], T>, I, S>;
-  contentRef: (node: HTMLElement | null) => void;
 };
 
 // extend BlockConfig but use a React render function
@@ -156,9 +154,6 @@ export function createReactBlockSpec<
             const blockContentDOMAttributes =
               this.options.domAttributes?.blockContent || {};
 
-            // hacky, should export `useReactNodeView` from tiptap to get access to ref
-            const ref = (NodeViewContent({}) as any).ref;
-
             const BlockContent = blockImplementation.render;
             return (
               <BlockContentWrapper
@@ -167,11 +162,7 @@ export function createReactBlockSpec<
                 propSchema={blockConfig.propSchema}
                 isFileBlock={blockConfig.isFileBlock}
                 domAttributes={blockContentDOMAttributes}>
-                <BlockContent
-                  block={block as any}
-                  editor={editor as any}
-                  contentRef={ref}
-                />
+                <BlockContent block={block as any} editor={editor as any} />
               </BlockContentWrapper>
             );
           },
@@ -190,17 +181,13 @@ export function createReactBlockSpec<
 
       const BlockContent = blockImplementation.render;
       const output = renderToDOMSpec(
-        (refCB) => (
+        () => (
           <BlockContentWrapper
             blockType={block.type}
             blockProps={block.props}
             propSchema={blockConfig.propSchema}
             domAttributes={blockContentDOMAttributes}>
-            <BlockContent
-              block={block as any}
-              editor={editor as any}
-              contentRef={refCB}
-            />
+            <BlockContent block={block as any} editor={editor as any} />
           </BlockContentWrapper>
         ),
         editor
@@ -215,18 +202,14 @@ export function createReactBlockSpec<
 
       const BlockContent =
         blockImplementation.toExternalHTML || blockImplementation.render;
-      const output = renderToDOMSpec((refCB) => {
+      const output = renderToDOMSpec(() => {
         return (
           <BlockContentWrapper
             blockType={block.type}
             blockProps={block.props}
             propSchema={blockConfig.propSchema}
             domAttributes={blockContentDOMAttributes}>
-            <BlockContent
-              block={block as any}
-              editor={editor as any}
-              contentRef={refCB}
-            />
+            <BlockContent block={block as any} editor={editor as any} />
           </BlockContentWrapper>
         );
       }, editor);

--- a/packages/react/src/schema/ReactInlineContentSpec.tsx
+++ b/packages/react/src/schema/ReactInlineContentSpec.tsx
@@ -15,7 +15,6 @@ import {
   StyleSchema,
 } from "@blocknote/core";
 import {
-  NodeViewContent,
   NodeViewProps,
   NodeViewWrapper,
   ReactNodeViewRenderer,
@@ -34,7 +33,6 @@ export type ReactInlineContentImplementation<
 > = {
   render: FC<{
     inlineContent: InlineContentFromConfig<T, S>;
-    contentRef: (node: HTMLElement | null) => void;
   }>;
   // TODO?
   // toExternalHTML?: FC<{
@@ -119,7 +117,7 @@ export function createReactInlineContentSpec<
       ) as any as InlineContentFromConfig<T, S>; // TODO: fix cast
       const Content = inlineContentImplementation.render;
       const output = renderToDOMSpec(
-        (refCB) => <Content inlineContent={ic} contentRef={refCB} />,
+        () => <Content inlineContent={ic} />,
         editor
       );
 
@@ -137,9 +135,6 @@ export function createReactInlineContentSpec<
       return (props) =>
         ReactNodeViewRenderer(
           (props: NodeViewProps) => {
-            // hacky, should export `useReactNodeView` from tiptap to get access to ref
-            const ref = (NodeViewContent({}) as any).ref;
-
             const Content = inlineContentImplementation.render;
             return (
               <InlineContentWrapper
@@ -147,7 +142,6 @@ export function createReactInlineContentSpec<
                 inlineContentType={inlineContentConfig.type}
                 propSchema={inlineContentConfig.propSchema}>
                 <Content
-                  contentRef={ref}
                   inlineContent={
                     nodeToCustomInlineContent(
                       props.node,

--- a/packages/react/src/schema/ReactStyleSpec.tsx
+++ b/packages/react/src/schema/ReactStyleSpec.tsx
@@ -13,9 +13,7 @@ import { renderToDOMSpec } from "./@util/ReactRenderUtil";
 
 // extend BlockConfig but use a React render function
 export type ReactCustomStyleImplementation<T extends StyleConfig> = {
-  render: T["propSchema"] extends "boolean"
-    ? FC<{ contentRef: (el: HTMLElement | null) => void }>
-    : FC<{ contentRef: (el: HTMLElement | null) => void; value: string }>;
+  render: T["propSchema"] extends "boolean" ? FC : FC<{ value: string }>;
 };
 
 // A function to create custom block for API consumers
@@ -44,7 +42,7 @@ export function createReactStyleSpec<T extends StyleConfig>(
 
       const Content = styleImplementation.render;
       const renderResult = renderToDOMSpec(
-        (refCB) => <Content {...props} contentRef={refCB} />,
+        () => <Content {...props} />,
         undefined
       );
 

--- a/packages/react/src/test/testCases/customReactBlocks.tsx
+++ b/packages/react/src/test/testCases/customReactBlocks.tsx
@@ -13,33 +13,42 @@ import { createContext, useContext } from "react";
 import { createReactBlockSpec } from "../../schema/ReactBlockSpec";
 import { ReactFileBlock } from "../../blocks/FileBlockContent/FileBlockContent";
 import { ReactImageBlock } from "../../blocks/ImageBlockContent/ImageBlockContent";
+import { useContent } from "../../hooks/useContent";
 
-const ReactCustomParagraph = createReactBlockSpec(
+const ReactCustomParagraph = () => {
+  const contentProps = useContent();
+
+  return <p className={"react-custom-paragraph"} {...contentProps} />;
+};
+
+const reactCustomParagraph = createReactBlockSpec(
   {
     type: "reactCustomParagraph",
     propSchema: defaultProps,
     content: "inline",
   },
   {
-    render: (props) => (
-      <p ref={props.contentRef} className={"react-custom-paragraph"} />
-    ),
+    render: ReactCustomParagraph,
     toExternalHTML: () => (
       <p className={"react-custom-paragraph"}>Hello World</p>
     ),
   }
 );
 
-const SimpleReactCustomParagraph = createReactBlockSpec(
+const SimpleReactCustomParagraph = () => {
+  const contentProps = useContent();
+
+  return <p className={"simple-react-custom-paragraph"} {...contentProps} />;
+};
+
+const simpleReactCustomParagraph = createReactBlockSpec(
   {
     type: "simpleReactCustomParagraph",
     propSchema: defaultProps,
     content: "inline",
   },
   {
-    render: (props) => (
-      <p ref={props.contentRef} className={"simple-react-custom-paragraph"} />
-    ),
+    render: SimpleReactCustomParagraph,
   }
 );
 
@@ -70,8 +79,8 @@ const schema = BlockNoteSchema.create({
     ...defaultBlockSpecs,
     reactFile: ReactFileBlock,
     reactImage: ReactImageBlock,
-    reactCustomParagraph: ReactCustomParagraph,
-    simpleReactCustomParagraph: SimpleReactCustomParagraph,
+    reactCustomParagraph: reactCustomParagraph,
+    simpleReactCustomParagraph: simpleReactCustomParagraph,
     reactContextParagraph: ReactContextParagraph,
   },
 });

--- a/packages/react/src/test/testCases/customReactInlineContent.tsx
+++ b/packages/react/src/test/testCases/customReactInlineContent.tsx
@@ -8,6 +8,7 @@ import {
   uploadToTmpFilesDotOrg_DEV_ONLY,
 } from "@blocknote/core";
 import { createReactInlineContentSpec } from "../../schema/ReactInlineContentSpec";
+import { useContent } from "../../hooks/useContent";
 
 const mention = createReactInlineContentSpec(
   {
@@ -26,6 +27,16 @@ const mention = createReactInlineContentSpec(
   }
 );
 
+const Tag = () => {
+  const contentProps = useContent();
+
+  return (
+    <span>
+      #<span {...contentProps} />
+    </span>
+  );
+};
+
 const tag = createReactInlineContentSpec(
   {
     type: "tag",
@@ -33,13 +44,7 @@ const tag = createReactInlineContentSpec(
     content: "styled",
   },
   {
-    render: (props) => {
-      return (
-        <span>
-          #<span ref={props.contentRef}></span>
-        </span>
-      );
-    },
+    render: Tag,
   }
 );
 

--- a/packages/react/src/test/testCases/customReactStyles.tsx
+++ b/packages/react/src/test/testCases/customReactStyles.tsx
@@ -8,6 +8,13 @@ import {
   uploadToTmpFilesDotOrg_DEV_ONLY,
 } from "@blocknote/core";
 import { createReactStyleSpec } from "../../schema/ReactStyleSpec";
+import { useContent } from "../../hooks/useContent";
+
+const Small = () => {
+  const contentProps = useContent();
+
+  return <small {...contentProps} />;
+};
 
 const small = createReactStyleSpec(
   {
@@ -15,11 +22,15 @@ const small = createReactStyleSpec(
     propSchema: "boolean",
   },
   {
-    render: (props) => {
-      return <small ref={props.contentRef}></small>;
-    },
+    render: Small,
   }
 );
+
+const FontSize = (props: { value: string }) => {
+  const { style, ...rest } = useContent();
+
+  return <span style={{ fontSize: props.value, ...style }} {...rest} />;
+};
 
 const fontSize = createReactStyleSpec(
   {
@@ -27,11 +38,7 @@ const fontSize = createReactStyleSpec(
     propSchema: "string",
   },
   {
-    render: (props) => {
-      return (
-        <span ref={props.contentRef} style={{ fontSize: props.value }}></span>
-      );
-    },
+    render: FontSize,
   }
 );
 

--- a/tests/src/utils/customblocks/ReactAlert.tsx
+++ b/tests/src/utils/customblocks/ReactAlert.tsx
@@ -1,5 +1,15 @@
-import { BlockNoteEditor, defaultProps } from "@blocknote/core";
-import { createReactBlockSpec } from "@blocknote/react";
+import {
+  BlockConfig,
+  BlockNoteEditor,
+  DefaultInlineContentSchema,
+  defaultProps,
+  DefaultStyleSchema,
+} from "@blocknote/core";
+import {
+  createReactBlockSpec,
+  ReactCustomBlockRenderProps,
+  useContent,
+} from "@blocknote/react";
 import { useEffect, useState } from "react";
 import { RiAlertFill } from "react-icons/ri";
 
@@ -22,97 +32,105 @@ const values = {
   },
 } as const;
 
-export const ReactAlert = createReactBlockSpec(
-  {
-    type: "reactAlert",
-    propSchema: {
-      textAlignment: defaultProps.textAlignment,
-      textColor: defaultProps.textColor,
-      type: {
-        default: "warning",
-        values: ["warning", "error", "info", "success"],
-      },
-    } as const,
-    content: "inline",
-  },
-  {
-    render: function Render(props) {
-      const [type, setType] = useState(props.block.props.type);
-
-      useEffect(() => {
-        console.log("ReactAlert initialize");
-        return () => {
-          console.log(" ReactAlert cleanup");
-        };
-      }, []);
-
-      console.log("ReactAlert render");
-
-      // Tests to see if types are correct:
-
-      const test: "reactAlert" = props.block.type;
-      console.log(test);
-
-      // @ts-expect-error
-      const test1: "othertype" = props.block.type;
-      console.log(test1);
-
-      return (
-        <div
-          style={{
-            display: "flex",
-            flexGrow: 1,
-            backgroundColor:
-              values[type as keyof typeof values].backgroundColor,
-          }}>
-          <div
-            style={{
-              marginRight: "0.5rem",
-              userSelect: "none",
-              cursor: "pointer",
-            }}
-            contentEditable={false}
-            onClick={() => {
-              if (type === "warning") {
-                props.editor.updateBlock(props.block, {
-                  props: {
-                    type: "error",
-                  },
-                });
-                setType("error");
-              } else if (type === "error") {
-                props.editor.updateBlock(props.block, {
-                  props: {
-                    type: "info",
-                  },
-                });
-                setType("info");
-              } else if (type === "info") {
-                props.editor.updateBlock(props.block, {
-                  props: {
-                    type: "success",
-                  },
-                });
-                setType("success");
-              } else if (type === "success") {
-                props.editor.updateBlock(props.block, {
-                  props: {
-                    type: "warning",
-                  },
-                });
-                setType("warning");
-              } else {
-                throw new Error("Unknown alert type");
-              }
-            }}>
-            {values[type as keyof typeof values].icon}
-          </div>
-          <span ref={props.contentRef} />
-        </div>
-      );
+const reactAlertConfig = {
+  type: "reactAlert" as const,
+  propSchema: {
+    textAlignment: defaultProps.textAlignment,
+    textColor: defaultProps.textColor,
+    type: {
+      default: "warning",
+      values: ["warning", "error", "info", "success"],
     },
-  }
-);
+  },
+  content: "inline",
+} satisfies BlockConfig;
+
+const RenderReactAlert = (
+  props: ReactCustomBlockRenderProps<
+    typeof reactAlertConfig,
+    DefaultInlineContentSchema,
+    DefaultStyleSchema
+  >
+) => {
+  const contentProps = useContent();
+
+  const [type, setType] = useState(props.block.props.type);
+
+  useEffect(() => {
+    console.log("ReactAlert initialize");
+    return () => {
+      console.log(" ReactAlert cleanup");
+    };
+  }, []);
+
+  console.log("ReactAlert render");
+
+  // Tests to see if types are correct:
+
+  const test: "reactAlert" = props.block.type;
+  console.log(test);
+
+  // @ts-expect-error
+  const test1: "othertype" = props.block.type;
+  console.log(test1);
+
+  return (
+    <div
+      style={{
+        display: "flex",
+        flexGrow: 1,
+        backgroundColor: values[type as keyof typeof values].backgroundColor,
+      }}>
+      <div
+        style={{
+          marginRight: "0.5rem",
+          userSelect: "none",
+          cursor: "pointer",
+        }}
+        contentEditable={false}
+        onClick={() => {
+          if (type === "warning") {
+            props.editor.updateBlock(props.block, {
+              props: {
+                type: "error",
+              },
+            });
+            setType("error");
+          } else if (type === "error") {
+            props.editor.updateBlock(props.block, {
+              props: {
+                type: "info",
+              },
+            });
+            setType("info");
+          } else if (type === "info") {
+            props.editor.updateBlock(props.block, {
+              props: {
+                type: "success",
+              },
+            });
+            setType("success");
+          } else if (type === "success") {
+            props.editor.updateBlock(props.block, {
+              props: {
+                type: "warning",
+              },
+            });
+            setType("warning");
+          } else {
+            throw new Error("Unknown alert type");
+          }
+        }}>
+        {values[type as keyof typeof values].icon}
+      </div>
+      <span {...contentProps} />
+    </div>
+  );
+};
+
+export const ReactAlert = createReactBlockSpec(reactAlertConfig, {
+  render: RenderReactAlert,
+});
 export const insertReactAlert = {
   title: "Insert React Alert",
   onItemClick: (editor: BlockNoteEditor<any, any, any>) => {

--- a/tests/src/utils/customblocks/ReactImage.tsx
+++ b/tests/src/utils/customblocks/ReactImage.tsx
@@ -1,40 +1,53 @@
-import { BlockNoteEditor, defaultProps } from "@blocknote/core";
-import { createReactBlockSpec } from "@blocknote/react";
+import {
+  BlockConfig,
+  BlockNoteEditor,
+  DefaultInlineContentSchema,
+  defaultProps,
+  DefaultStyleSchema,
+} from "@blocknote/core";
+import {
+  createReactBlockSpec,
+  ReactCustomBlockRenderProps,
+  useContent,
+} from "@blocknote/react";
 import { RiImage2Fill } from "react-icons/ri";
 
-export const ReactImage = createReactBlockSpec(
-  {
-    type: "reactImage",
-    propSchema: {
-      ...defaultProps,
-      src: {
-        default: "https://via.placeholder.com/1000",
-      },
+const reactImageConfig = {
+  type: "reactImage",
+  propSchema: {
+    ...defaultProps,
+    src: {
+      default: "https://via.placeholder.com/1000",
     },
-    content: "inline",
   },
-  {
-    render: ({ block, contentRef }) => {
-      return (
-        <div
-          style={{
-            display: "flex",
-            flexDirection: "column",
-          }}>
-          <img
-            style={{
-              width: "100%",
-            }}
-            src={block.props.src}
-            alt={"test"}
-            contentEditable={false}
-          />
-          <span ref={contentRef} style={{ flexGrow: 1 }} />
-        </div>
-      );
-    },
-  }
-);
+  content: "inline",
+} satisfies BlockConfig;
+
+const RenderReactImage = (
+  props: ReactCustomBlockRenderProps<
+    typeof reactImageConfig,
+    DefaultInlineContentSchema,
+    DefaultStyleSchema
+  >
+) => {
+  const { style, ...rest } = useContent();
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column" }}>
+      <img
+        style={{ width: "100%" }}
+        src={props.block.props.src}
+        alt={"test"}
+        contentEditable={false}
+      />
+      <span style={{ flexGrow: 1, ...style }} {...rest} />
+    </div>
+  );
+};
+
+export const ReactImage = createReactBlockSpec(reactImageConfig, {
+  render: RenderReactImage,
+});
 
 export const insertReactImage = {
   title: "Insert React Image",


### PR DESCRIPTION
This PR removes the hacky fix used for the `contentRef` prop by refactoring it into a `useContent` prop. Now setting the editable element in a React block is done via this hook instead of the `contentRef` prop.

Closes #659

TODO: There are currently a pretty big problem in that because this uses a hook which runs asynchronously, exporting to HTML does not properly serialize the content.