### PR TITLE
use nonce value is supplied

### DIFF
--- a/packages/core/src/extensions/Placeholder/PlaceholderPlugin.ts
+++ b/packages/core/src/extensions/Placeholder/PlaceholderPlugin.ts
@@ -12,6 +12,10 @@ export const PlaceholderPlugin = (
     key: PLUGIN_KEY,
     view: () => {
       const styleEl = document.createElement("style");
+      const nonce = editor._tiptapEditor.options.injectNonce;
+      if (nonce) {
+        styleEl.setAttribute("nonce", nonce);
+      }
       document.head.appendChild(styleEl);
       const styleSheet = styleEl.sheet!;
 


### PR DESCRIPTION
This fixes an issue with dynamically injected style tags with a strict content security policy.