### PR TITLE
fix: Mantine sub-menu rendering in the DOM

### DIFF
--- a/packages/mantine/src/menu/Menu.tsx
+++ b/packages/mantine/src/menu/Menu.tsx
@@ -81,6 +81,8 @@ const SubMenu = forwardRef<
 
   const [opened, setOpened] = useState(false);
 
+  const itemRef = useRef<HTMLButtonElement | null>(null);
+
   const menuCloseTimer = useRef<ReturnType<typeof setTimeout> | undefined>();
 
   const mouseLeave = useCallback(() => {
@@ -107,11 +109,22 @@ const SubMenu = forwardRef<
       }}>
       <Mantine.Menu.Item
         className="bn-menu-item bn-mt-sub-menu-item"
-        ref={ref}
+        ref={(node) => {
+          itemRef.current = node;
+          if (typeof ref === "function") {
+            ref(node);
+          } else if (ref) {
+            ref.current = node;
+          }
+        }}
         onMouseOver={mouseOver}
         onMouseLeave={mouseLeave}>
         <Mantine.Menu
-          withinPortal={false}
+          portalProps={{
+            target: itemRef.current
+              ? itemRef.current.parentElement!
+              : undefined,
+          }}
           middlewares={{ flip: true, shift: true, inline: false, size: true }}
           trigger={"hover"}
           opened={opened}

--- a/packages/mantine/src/menu/Menu.tsx
+++ b/packages/mantine/src/menu/Menu.tsx
@@ -1,4 +1,5 @@
 import * as Mantine from "@mantine/core";
+import { mergeRefs } from "@mantine/hooks";
 
 import { assertEmpty } from "@blocknote/core";
 import { ComponentProps } from "@blocknote/react";
@@ -109,14 +110,7 @@ const SubMenu = forwardRef<
       }}>
       <Mantine.Menu.Item
         className="bn-menu-item bn-mt-sub-menu-item"
-        ref={(node) => {
-          itemRef.current = node;
-          if (typeof ref === "function") {
-            ref(node);
-          } else if (ref) {
-            ref.current = node;
-          }
-        }}
+        ref={mergeRefs(ref, itemRef)}
         onMouseOver={mouseOver}
         onMouseLeave={mouseLeave}>
         <Mantine.Menu


### PR DESCRIPTION
Right now, Mantine sub-menu dropdowns are being rendered within the menu item that opens them. This throws an error as the menu item is a button, and the dropdown contains more menu items which are also buttons (`button` elements are not valid descendants of other `button` elements).

This PR makes sub menu dropdowns get rendered in the same dropdown as the menu items which trigger them, same as how Ariakit and ShadCN do it. 