### PR TITLE
fix: fix margin of block of playground in small screen

### DIFF
--- a/playground/src/style.css
+++ b/playground/src/style.css
@@ -6,7 +6,8 @@ body {
 
 .bn-container {
   padding-top: 8px;
-  margin: 0 calc((100% - 731px) / 2) 0;
+  margin: 0 auto;
+  max-width: 731px;
 }
 
 .mantine-AppShell-navbar {


### PR DESCRIPTION
The margin of block in playground pages has a bug that causes the block to go out of the small screen. This PR fixed it.

https://github.com/TypeCellOS/BlockNote/assets/38809606/7c4d6ce6-a6ec-4261-b0b5-cb8e85d75d95

