### PR TITLE
fix(side-menu): fix edge case when hovering group instead of a block

### DIFF
--- a/packages/core/src/extensions/SideMenu/SideMenuPlugin.ts
+++ b/packages/core/src/extensions/SideMenu/SideMenuPlugin.ts
@@ -348,6 +348,10 @@ export class SideMenuView<
 
     this.hoveredBlock = block.node;
 
+    if (!this.hoveredBlock?.hasAttribute("data-id")) {
+      return
+    }
+
     // Gets the block's content node, which lets to ignore child blocks when determining the block menu's position.
     const blockContent = block.node.firstChild as HTMLElement;
 


### PR DESCRIPTION
This typically can happen when you add `display: flex` to `.bn-block-group` with a gap.  
You can then happen to hover the group itself instead of a block or outer block element

When this happens, [the id that would be given to `editor.getBlock` would be `null`](https://github.com/TypeCellOS/BlockNote/blob/main/packages/core/src/extensions/SideMenu/SideMenuPlugin.ts#L373), [making it fail](https://github.com/TypeCellOS/BlockNote/blob/main/packages/core/src/editor/BlockNoteEditor.ts#L437) (by the way, adding an optional chaining operator or checking for null/undefined [here](https://github.com/TypeCellOS/BlockNote/blob/main/packages/core/src/editor/BlockNoteEditor.ts#L437) may be a good idea, let me know if you want me to make a PR for that).