### PR TITLE
fix: More Notion-like side menu positioning

### DIFF
--- a/packages/ariakit/src/menu/Menu.tsx
+++ b/packages/ariakit/src/menu/Menu.tsx
@@ -40,6 +40,7 @@ export const MenuDropdown = forwardRef<
 
   return (
     <Ariakit.Menu
+      unmountOnHide={true}
       className={mergeCSSClasses("bn-ak-menu", className || "")}
       ref={ref}>
       {children}

--- a/packages/ariakit/src/sideMenu/SideMenu.tsx
+++ b/packages/ariakit/src/sideMenu/SideMenu.tsx
@@ -10,10 +10,10 @@ export const SideMenu = forwardRef<
 >((props, ref) => {
   const { className, children, ...rest } = props;
 
-  assertEmpty(rest);
+  assertEmpty(rest, false);
 
   return (
-    <Ariakit.Group className={className} ref={ref}>
+    <Ariakit.Group className={className} ref={ref} {...rest}>
       {children}
     </Ariakit.Group>
   );

--- a/packages/mantine/src/sideMenu/SideMenu.tsx
+++ b/packages/mantine/src/sideMenu/SideMenu.tsx
@@ -10,10 +10,15 @@ export const SideMenu = forwardRef<
 >((props, ref) => {
   const { className, children, ...rest } = props;
 
-  assertEmpty(rest);
+  assertEmpty(rest, false);
 
   return (
-    <Mantine.Group align={"center"} gap={0} className={className} ref={ref}>
+    <Mantine.Group
+      align={"center"}
+      gap={0}
+      className={className}
+      ref={ref}
+      {...rest}>
       {children}
     </Mantine.Group>
   );

--- a/packages/react/src/components/SideMenu/SideMenu.tsx
+++ b/packages/react/src/components/SideMenu/SideMenu.tsx
@@ -6,7 +6,7 @@ import {
   InlineContentSchema,
   StyleSchema,
 } from "@blocknote/core";
-import { ReactNode } from "react";
+import { ReactNode, useMemo } from "react";
 
 import { AddBlockButton } from "./DefaultButtons/AddBlockButton";
 import { DragHandleButton } from "./DefaultButtons/DragHandleButton";
@@ -33,8 +33,32 @@ export const SideMenu = <
 
   const { addBlock, ...rest } = props;
 
+  const blockHeight = useMemo(() => {
+    if (props.block.type === "heading") {
+      return `h${props.block.props.level}`;
+    }
+
+    if (props.editor.schema.blockSchema[props.block.type].isFileBlock) {
+      if (!props.block.props.url) {
+        return "add-file-button";
+      }
+
+      if (props.block.type === "file") {
+        return "file";
+      }
+
+      if (props.block.type === "audio") {
+        return "audio";
+      }
+    }
+
+    return "default";
+  }, [props.block, props.editor.schema.blockSchema]);
+
   return (
-    <Components.SideMenu.Root className={"bn-side-menu"}>
+    <Components.SideMenu.Root
+      className={"bn-side-menu"}
+      data-block-height={blockHeight}>
       {props.children || (
         <>
           <AddBlockButton addBlock={addBlock} />

--- a/packages/react/src/components/SideMenu/SideMenuController.tsx
+++ b/packages/react/src/components/SideMenu/SideMenuController.tsx
@@ -39,7 +39,7 @@ export const SideMenuController = <
     state?.referencePos || null,
     1000,
     {
-      placement: "left",
+      placement: "left-start",
     }
   );
 

--- a/packages/react/src/editor/styles.css
+++ b/packages/react/src/editor/styles.css
@@ -210,3 +210,31 @@
 [data-background-color="pink"] {
   background-color: var(--bn-colors-highlights-pink-background);
 }
+
+.bn-side-menu[data-block-height="default"] {
+  height: 30px;
+}
+
+.bn-side-menu[data-block-height="h1"] {
+  height: 78px;
+}
+
+.bn-side-menu[data-block-height="h2"] {
+  height: 54px;
+}
+
+.bn-side-menu[data-block-height="h3"] {
+  height: 37px;
+}
+
+.bn-side-menu[data-block-height="add-file-button"] {
+  height: 54px;
+}
+
+.bn-side-menu[data-block-height="file"] {
+  height: 38px;
+}
+
+.bn-side-menu[data-block-height="audio"] {
+  height: 60px;
+}

--- a/packages/shadcn/src/sideMenu/SideMenu.tsx
+++ b/packages/shadcn/src/sideMenu/SideMenu.tsx
@@ -8,10 +8,10 @@ export const SideMenu = forwardRef<
 >((props, ref) => {
   const { className, children, ...rest } = props;
 
-  assertEmpty(rest);
+  assertEmpty(rest, false);
 
   return (
-    <div className={className} ref={ref}>
+    <div className={className} ref={ref} {...rest}>
       {children}
     </div>
   );

--- a/packages/shadcn/src/style.css
+++ b/packages/shadcn/src/style.css
@@ -82,6 +82,7 @@
 }
 
 .bn-side-menu {
+  align-items: center;
   display: flex;
   justify-content: center;
 }


### PR DESCRIPTION
This PR changes the side menu to be positioned centered on the first line of a block. Blocks with no text content usually assume the line height of a paragraph block.

This solution is a bit hacky in that the line height values for different blocks are hard coded instead of taking them from a bounding box, though fixing this would add a lot of complexity. Fortunately, it's easy for consumers to change those values via CSS.

Also, Notion does not center the side menu for things like file blocks, instead using the paragraph block line height, as you can see below:
![Screenshot 2024-06-05 at 22 45 12](https://github.com/TypeCellOS/BlockNote/assets/50169049/541bb6b7-6ec3-4848-913f-fbffaf9bd9d5)
I think this looks really ugly since the block is short enough that I think it should be centered, so I changed this for file & audio blocks also, as well as for when the add file button is showing in all types of file blocks.

Closes #386 