### PR TITLE
fix: Side menu block finding logic

### DIFF
--- a/packages/core/src/extensions/SideMenu/SideMenuPlugin.ts
+++ b/packages/core/src/extensions/SideMenu/SideMenuPlugin.ts
@@ -177,12 +177,21 @@ function dragStart<
     top: e.clientY,
   };
 
-  const element = document.elementFromPoint(coords.left, coords.top);
-  if (element === null) {
+  const elements = document.elementsFromPoint(coords.left, coords.top);
+  let blockEl = undefined;
+
+  for (const element of elements) {
+    if (view.dom.contains(element)) {
+      blockEl = getDraggableBlockFromElement(element, view);
+      break;
+    }
+  }
+
+  if (!blockEl) {
     return;
   }
 
-  const pos = blockPositionFromElement(element, view);
+  const pos = blockPositionFromElement(blockEl.node, view);
   if (pos != null) {
     const selection = view.state.selection;
     const doc = view.state.doc;

--- a/packages/core/src/extensions/SideMenu/SideMenuPlugin.ts
+++ b/packages/core/src/extensions/SideMenu/SideMenuPlugin.ts
@@ -312,12 +312,16 @@ export class SideMenuView<
       left: editorBoundingBox.left + editorBoundingBox.width / 2, // take middle of editor
       top: this.mousePos.y,
     };
-    const element = document.elementFromPoint(coords.left, coords.top);
-    if (element === null) {
-      return;
-    }
 
-    const block = getDraggableBlockFromElement(element, this.pmView);
+    const elements = document.elementsFromPoint(coords.left, coords.top);
+    let block = undefined;
+
+    for (const element of elements) {
+      if (this.pmView.dom.contains(element)) {
+        block = getDraggableBlockFromElement(element, this.pmView);
+        break;
+      }
+    }
 
     // Closes the menu if the mouse cursor is beyond the editor vertically.
     if (!block || !this.editor.isEditable) {

--- a/packages/core/src/extensions/TableHandles/TableHandlesPlugin.ts
+++ b/packages/core/src/extensions/TableHandles/TableHandlesPlugin.ts
@@ -11,7 +11,7 @@ import {
 } from "../../schema";
 import { checkBlockIsDefaultType } from "../../blocks/defaultBlockTypeGuards";
 import { EventEmitter } from "../../util/EventEmitter";
-import { getDraggableBlockFromCoords } from "../SideMenu/SideMenuPlugin";
+import { getDraggableBlockFromElement } from "../SideMenu/SideMenuPlugin";
 
 let dragImageElement: HTMLElement | undefined;
 
@@ -146,7 +146,7 @@ export class TableHandlesView<
     const tableRect =
       target.parentElement!.parentElement!.getBoundingClientRect();
 
-    const blockEl = getDraggableBlockFromCoords(cellRect, this.pmView);
+    const blockEl = getDraggableBlockFromElement(target, this.pmView);
     if (!blockEl) {
       return;
     }

--- a/tests/src/end-to-end/dragdrop/dragdrop.test.ts
+++ b/tests/src/end-to-end/dragdrop/dragdrop.test.ts
@@ -66,22 +66,17 @@ test.describe("Check Block Dragging Functionality", () => {
     // Dragging first heading into next nested element.
     let dragTarget = await page.locator(H_ONE_BLOCK_SELECTOR);
     let dropTarget = await page.locator(H_TWO_BLOCK_SELECTOR);
-    await page.pause();
     await dragAndDropBlock(page, dragTarget, dropTarget, true);
 
     // Dragging second heading into next nested element.
     dragTarget = await page.locator(H_TWO_BLOCK_SELECTOR);
     dropTarget = await page.locator(H_THREE_BLOCK_SELECTOR);
-    await page.pause();
     await dragAndDropBlock(page, dragTarget, dropTarget, true);
 
     // Dragging third heading into outside nesting.
     dragTarget = await page.locator(H_THREE_BLOCK_SELECTOR);
     dropTarget = await page.locator(BLOCK_CONTAINER_SELECTOR).last();
-    await page.pause();
     await dragAndDropBlock(page, dragTarget, dropTarget, true);
-
-    await page.pause();
 
     await compareDocToSnapshot(page, "dragdropnested");
   });

--- a/tests/src/end-to-end/shadcn/shadcn.test.ts
+++ b/tests/src/end-to-end/shadcn/shadcn.test.ts
@@ -31,7 +31,7 @@ test.describe("Check ShadCN UI", () => {
     await page.keyboard.press("Shift+Home");
 
     await page.waitForSelector(LINK_BUTTON_SELECTOR);
-    await page.click(LINK_BUTTON_SELECTOR);
+    await page.click(LINK_BUTTON_SELECTOR, { position: { x: 5, y: 5 } });
 
     await page.keyboard.type("link");
     await page.keyboard.press("Enter");


### PR DESCRIPTION
This PR simplifies & fixes logic in the side menu used to find the hovered block. Specifically, this fixes an error that gets thrown in the built environment when the hovered block isn't found, and makes the behaviour consistent for both the dev and built envs.