### PR TITLE
fix: Removed ShadCN focus global CSS

### DIFF
--- a/packages/shadcn/src/style.css
+++ b/packages/shadcn/src/style.css
@@ -77,6 +77,10 @@
   z-index: 99999 !important;
 }
 
+.bn-editor:focus-visible {
+  outline: none;
+}
+
 .bn-side-menu {
   display: flex;
   justify-content: center;

--- a/packages/shadcn/src/style.css
+++ b/packages/shadcn/src/style.css
@@ -73,10 +73,6 @@
   @apply bg-background text-foreground;
 }
 
-:focus-visible {
-  outline: none;
-}
-
 [data-radix-popper-content-wrapper] {
   z-index: 99999 !important;
 }


### PR DESCRIPTION
We have a CSS rule to remove the focus ring from focused elements in ShadCN that is scoped globally instead of to the editor, which this PR fixes.

Closes #787