### PR TITLE
chore(docs): include comments about dynamic locales in TS

### DIFF
--- a/examples/01-basic/10-localization/App.tsx
+++ b/examples/01-basic/10-localization/App.tsx
@@ -3,14 +3,17 @@ import "@blocknote/core/fonts/inter.css";
 import { BlockNoteView } from "@blocknote/mantine";
 import "@blocknote/mantine/style.css";
 import { useCreateBlockNote } from "@blocknote/react";
+// import { useTranslation } from "some-i18n-library"; // You can use any i18n library you like
 
 export default function App() {
+  // const { lang } = useTranslation('common'); // You can get the current language from the i18n library or alternatively from a router
   // Creates a new editor instance.
   const editor = useCreateBlockNote({
     // Passes the Dutch (NL) dictionary to the editor instance.
     // You can also provide your own dictionary here to customize the strings used in the editor,
     // or submit a Pull Request to add support for your language of your choice
     dictionary: locales.nl,
+    // dictionary: locales[lang as keyof typeof locales], // Use the language from the i18n library dynamically
   });
 
   // Renders the editor instance using a React component.


### PR DESCRIPTION
I couldn't figure out how to add additional text under the preview block so I just added comments to the actual preview block.

The comments I added simply show how to use dynamic language in TS with 

```ts
 dictionary: locales[lang as keyof typeof locales]
```