### PR TITLE
fix: update `remarkStringify` config

### DIFF
--- a/packages/core/src/api/exporters/markdown/__snapshots__/lists/basic/markdown.md
+++ b/packages/core/src/api/exporters/markdown/__snapshots__/lists/basic/markdown.md
@@ -4,5 +4,5 @@
 1.  Numbered List Item 1
 2.  Numbered List Item 2
 
-*   \[ ] Check List Item 1
-*   \[x] Check List Item 2
+*   [ ] Check List Item 1
+*   [x] Check List Item 2

--- a/packages/core/src/api/exporters/markdown/__snapshots__/lists/nested/markdown.md
+++ b/packages/core/src/api/exporters/markdown/__snapshots__/lists/nested/markdown.md
@@ -6,5 +6,5 @@
 
     2.  Numbered List Item 2
 
-        *   \[ ] Check List Item 1
-        *   \[x] Check List Item 2
+        *   [ ] Check List Item 1
+        *   [x] Check List Item 2

--- a/packages/core/src/api/exporters/markdown/markdownExporter.ts
+++ b/packages/core/src/api/exporters/markdown/markdownExporter.ts
@@ -18,7 +18,7 @@ export function cleanHTMLToMarkdown(cleanHTMLString: string) {
     .use(addSpacesToCheckboxes)
     .use(rehypeRemark)
     .use(remarkGfm)
-    .use(remarkStringify)
+    .use(remarkStringify, { handlers: { text: (node) => node.value } })
     .processSync(cleanHTMLString);
 
   return markdownString.value as string;


### PR DESCRIPTION
Fixes #834 

---
For some reason, returning the text node within the `remarkStringify` handler option solved the issue with an extra backslash before the first bracket. 
```ts
.use(remarkStringify, { handlers: { text: (node) => node.value } })
```

# Before
![339166596-baf435ae-a584-4e66-be80-64267319d125](https://github.com/TypeCellOS/BlockNote/assets/46135573/2e6337bf-5e60-4d8d-bcc9-874ffa901eaa)


# After 

![blocknote-escape-checklist-solved](https://github.com/TypeCellOS/BlockNote/assets/46135573/18a3c847-f351-4554-8af0-8eb7ec48dfde)
