### PR TITLE
feat: persist table resize

### DIFF
--- a/packages/core/src/blocks/TableBlockContent/TableBlockContent.ts
+++ b/packages/core/src/blocks/TableBlockContent/TableBlockContent.ts
@@ -1,4 +1,4 @@
-import { mergeAttributes, Node } from "@tiptap/core";
+import { Node } from "@tiptap/core";
 import { TableCell } from "@tiptap/extension-table-cell";
 import { TableHeader } from "@tiptap/extension-table-header";
 import { TableRow } from "@tiptap/extension-table-row";
@@ -44,6 +44,13 @@ const TableParagraph = Node.create({
   group: "tableContent",
   content: "inline*",
 
+  addAttributes() {
+    return {
+      width: {
+        default: "default",
+      },
+    };
+  },
   parseHTML() {
     return [
       { tag: "td" },
@@ -71,11 +78,17 @@ const TableParagraph = Node.create({
   },
 
   renderHTML({ HTMLAttributes }) {
-    return [
-      "p",
-      mergeAttributes(this.options.HTMLAttributes, HTMLAttributes),
-      0,
-    ];
+    const p = document.createElement("p");
+    p.style.setProperty("min-width", "100px", "important");
+
+    if (HTMLAttributes.width && HTMLAttributes.width !== "default") {
+      p.style.width = HTMLAttributes.width;
+    }
+
+    return {
+      dom: p,
+      contentDOM: p,
+    };
   },
 });
 

--- a/packages/core/src/schema/blocks/types.ts
+++ b/packages/core/src/schema/blocks/types.ts
@@ -6,6 +6,7 @@ import type {
   InlineContent,
   InlineContentSchema,
   PartialInlineContent,
+  PartialInlineContentElement,
 } from "../inlineContent/types";
 import type { PropSchema, Props } from "../propTypes";
 import type { StyleSchema } from "../styles/types";
@@ -148,9 +149,13 @@ export type TableContent<
 > = {
   type: "tableContent";
   rows: {
-    cells: InlineContent<I, S>[][];
+    cells: CellContent<I, S>[];
   }[];
 };
+
+export type CellContent<I extends InlineContentSchema, T extends StyleSchema> =
+  | (InlineContent<I, T> & { width?: string })[]
+  | string;
 
 // A BlockConfig has all the information to get the type of a Block (which is a specific instance of the BlockConfig.
 // i.e.: paragraphConfig: BlockConfig defines what a "paragraph" is / supports, and BlockFromConfigNoChildren<paragraphConfig> is the shape of a specific paragraph block.
@@ -223,9 +228,14 @@ export type PartialTableContent<
 > = {
   type: "tableContent";
   rows: {
-    cells: PartialInlineContent<I, S>[];
+    cells: PartialCellContent<I, S>[];
   }[];
 };
+
+export type PartialCellContent<
+  I extends InlineContentSchema,
+  T extends StyleSchema
+> = (PartialInlineContentElement<I, T> & { width: string })[] | string;
 
 type PartialBlockFromConfigNoChildren<
   B extends BlockConfig,

--- a/packages/core/src/schema/inlineContent/types.ts
+++ b/packages/core/src/schema/inlineContent/types.ts
@@ -115,7 +115,7 @@ export type InlineContent<
   T extends StyleSchema
 > = InlineContentFromConfig<I[keyof I], T>;
 
-type PartialInlineContentElement<
+export type PartialInlineContentElement<
   I extends InlineContentSchema,
   T extends StyleSchema
 > = PartialInlineContentFromConfig<I[keyof I], T>;


### PR DESCRIPTION
When resizing a table, prosemirror changes the colgroup's col widths without transmitting this data to the table nodes. This is related to [this issue](https://github.com/TypeCellOS/BlockNote/issues/655). The fix consists of listening to the mouse up event and checking for a change in any of the columns from prosemirror. If there is a change that should affect a cell, we update the cells of the table. This will re-render the table. We persist the width information in a property for the node. Thus we had to change the typing of cell contents.