### PR TITLE
fix: ShadCN Tailwind scoping

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21696,9 +21696,9 @@
       }
     },
     "node_modules/react-hook-form": {
-      "version": "7.51.5",
-      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.51.5.tgz",
-      "integrity": "sha512-J2ILT5gWx1XUIJRETiA7M19iXHlG74+6O3KApzvqB/w8S5NQR7AbU8HVZrMALdmDgWpRPYiZJl0zx8Z4L2mP6Q==",
+      "version": "7.52.0",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.52.0.tgz",
+      "integrity": "sha512-mJX506Xc6mirzLsmXUJyqlAI3Kj9Ph2RhplYhUVffeOQSnubK2uVqBFOBJmvKikvbFV91pxVXmDiR+QMF19x6A==",
       "engines": {
         "node": ">=12.22.0"
       },
@@ -21707,7 +21707,7 @@
         "url": "https://opencollective.com/react-hook-form"
       },
       "peerDependencies": {
-        "react": "^16.8.0 || ^17 || ^18"
+        "react": "^16.8.0 || ^17 || ^18 || ^19"
       }
     },
     "node_modules/react-icons": {
@@ -27295,7 +27295,7 @@
       "dependencies": {
         "@blocknote/core": "^0.14.1",
         "@blocknote/react": "^0.14.1",
-        "@hookform/resolvers": "^3.3.4",
+        "@hookform/resolvers": "^3.6.0",
         "@radix-ui/react-dropdown-menu": "^2.0.6",
         "@radix-ui/react-label": "^2.0.2",
         "@radix-ui/react-popover": "^1.0.7",
@@ -27311,11 +27311,11 @@
         "postcss": "^8.4.38",
         "react": "^18",
         "react-dom": "^18",
-        "react-hook-form": "^7.51.3",
+        "react-hook-form": "^7.52.0",
         "tailwind-merge": "^2.3.0",
         "tailwindcss": "^3.4.3",
         "tailwindcss-animate": "^1.0.7",
-        "zod": "^3.22.4"
+        "zod": "^3.23.8"
       },
       "devDependencies": {
         "@radix-ui/colors": "^3.0.0",

--- a/packages/ariakit/src/ariakitStyles.css
+++ b/packages/ariakit/src/ariakitStyles.css
@@ -2,7 +2,7 @@
 responsible for the majority of the styling. */
 
 /* https://ariakit.org/examples/menu-nested */
-.bn-ak-button {
+.bn-aria-kit .bn-ak-button {
     --border: rgb(0 0 0/13%);
     --highlight: rgb(255 255 255/20%);
     --shadow: rgb(0 0 0/10%);
@@ -33,7 +33,7 @@ responsible for the majority of the styling. */
     font-weight: 500;
 }
 
-.bn-ak-button:where(.dark, .dark *) {
+.bn-aria-kit .bn-ak-button:where(.dark, .dark *) {
     --border: rgb(255 255 255/10%);
     --highlight: rgb(255 255 255/5%);
     --shadow: rgb(0 0 0/25%);
@@ -45,24 +45,24 @@ responsible for the majority of the styling. */
             inset 0 1px 0 var(--highlight);
 }
 
-.bn-ak-button:not(:active):hover {
+.bn-aria-kit .bn-ak-button:not(:active):hover {
     --border: rgb(0 0 0/33%);
 }
 
-.bn-ak-button:where(.dark, .dark *):not(:active):hover {
+.bn-aria-kit .bn-ak-button:where(.dark, .dark *):not(:active):hover {
     --border: rgb(255 255 255/25%);
 }
 
-.bn-ak-button[aria-disabled="true"] {
+.bn-aria-kit .bn-ak-button[aria-disabled="true"] {
     opacity: 0.5;
 }
 
-.bn-ak-button[data-focus-visible] {
+.bn-aria-kit .bn-ak-button[data-focus-visible] {
     outline-style: solid;
 }
 
-.bn-ak-button:active,
-.bn-ak-button[data-active] {
+.bn-aria-kit .bn-ak-button:active,
+.bn-aria-kit .bn-ak-button[data-active] {
     padding-top: 0.125rem;
     box-shadow:
             inset 0 0 0 1px var(--border),
@@ -70,19 +70,19 @@ responsible for the majority of the styling. */
 }
 
 @media (min-width: 640px) {
-    .bn-ak-button {
+    .bn-aria-kit .bn-ak-button {
         gap: 0.5rem;
     }
 }
 
-.bn-ak-button:active:where(.dark, .dark *),
-.bn-ak-button[data-active]:where(.dark, .dark *) {
+.bn-aria-kit .bn-ak-button:active:where(.dark, .dark *),
+.bn-aria-kit .bn-ak-button[data-active]:where(.dark, .dark *) {
     box-shadow:
             inset 0 0 0 1px var(--border),
             inset 0 1px 1px 1px var(--shadow);
 }
 
-.bn-ak-menu {
+.bn-aria-kit .bn-ak-menu {
     position: relative;
     z-index: 50;
     display: flex;
@@ -104,7 +104,7 @@ responsible for the majority of the styling. */
     overflow: visible;
 }
 
-.bn-ak-menu:where(.dark, .dark *) {
+.bn-aria-kit .bn-ak-menu:where(.dark, .dark *) {
     border-color: hsl(204 4% 24%);
     background-color: hsl(204 4% 16%);
     color: hsl(204 20% 100%);
@@ -113,7 +113,7 @@ responsible for the majority of the styling. */
             0 4px 6px -4px rgb(0 0 0 / 0.1);
 }
 
-.bn-ak-menu-item {
+.bn-aria-kit .bn-ak-menu-item {
     display: flex;
     cursor: default;
     scroll-margin: 0.5rem;
@@ -124,38 +124,41 @@ responsible for the majority of the styling. */
     outline: none !important;
 }
 
-.bn-ak-menu-item[aria-disabled="true"] {
+.bn-aria-kit .bn-ak-menu-item[aria-disabled="true"] {
     opacity: 0.25;
 }
 
-.bn-ak-menu-item[data-active-item] {
+.bn-aria-kit .bn-ak-menu-item[data-active-item] {
     background-color: hsl(204 100% 40%);
     color: hsl(204 20% 100%);
 }
 
-.bn-ak-menu-item:active,
-.bn-ak-menu-item[data-active] {
+.bn-aria-kit .bn-ak-menu-item:active,
+.bn-aria-kit .bn-ak-menu-item[data-active] {
     background-color: hsl(204 100% 32%);
     padding-top: 9px;
     padding-bottom: 7px;
 }
 
-.bn-ak-menu:not(:focus) .bn-ak-menu-item:not(:focus)[aria-expanded="true"] {
+.bn-aria-kit .bn-ak-menu:not(:focus)
+.bn-aria-kit .bn-ak-menu-item:not(:focus)[aria-expanded="true"] {
     background-color: hsl(204 4% 0% / 7.5%);
     color: currentColor;
 }
 
+.bn-aria-kit
 .bn-ak-menu:not(:focus)
+.bn-aria-kit
 .bn-ak-menu-item:not(:focus)[aria-expanded="true"]:where(.dark, .dark *) {
     background-color: hsl(204 20% 100% / 0.1);
 }
 
-.bn-ak-menu-item .label {
+.bn-aria-kit .bn-ak-menu-item .label {
     flex: 1 1 0%;
 }
 
 /* https://ariakit.org/examples/form-select */
-.bn-ak-button {
+.bn-aria-kit .bn-ak-button {
     --border: rgb(0 0 0/13%);
     --highlight: rgb(255 255 255/20%);
     --shadow: rgb(0 0 0/10%);
@@ -186,7 +189,7 @@ responsible for the majority of the styling. */
     border-radius: 0.375rem;
 }
 
-.bn-ak-button:where(.dark, .dark *) {
+.bn-aria-kit .bn-ak-button:where(.dark, .dark *) {
     --border: rgb(255 255 255/10%);
     --highlight: rgb(255 255 255/5%);
     --shadow: rgb(0 0 0/25%);
@@ -198,15 +201,15 @@ responsible for the majority of the styling. */
             inset 0 1px 0 var(--highlight);
 }
 
-.bn-ak-button:not(:active):hover {
+.bn-aria-kit .bn-ak-button:not(:active):hover {
     --border: rgb(0 0 0/33%);
 }
 
-.bn-ak-button:where(.dark, .dark *):not(:active):hover {
+.bn-aria-kit .bn-ak-button:where(.dark, .dark *):not(:active):hover {
     --border: rgb(255 255 255/25%);
 }
 
-.bn-ak-primary {
+.bn-aria-kit .bn-ak-primary {
     --border: rgba(0, 0, 0, 0.15);
     --highlight: rgba(255, 255, 255, 0.25);
     --shadow: rgba(0, 0, 0, 0.15);
@@ -215,33 +218,33 @@ responsible for the majority of the styling. */
     justify-content: center;
 }
 
-.bn-ak-primary:hover {
+.bn-aria-kit .bn-ak-primary:hover {
     --border: rgba(0, 0, 0, 0.35);
     background-color: hsl(204 100% 35%);
 }
 
-.bn-ak-primary:where(.dark, .dark *) {
+.bn-aria-kit .bn-ak-primary:where(.dark, .dark *) {
     --border: rgba(255, 255, 255, 0.25);
     --highlight: rgba(255, 255, 255, 0.1);
     --shadow: rgba(0, 0, 0, 0.25);
     background-color: hsl(204 100% 35%);
 }
 
-.bn-ak-primary:hover:where(.dark, .dark *) {
+.bn-aria-kit .bn-ak-primary:hover:where(.dark, .dark *) {
     --border: rgba(255, 255, 255, 0.45);
     background-color: hsl(204 100% 40%);
 }
 
-.bn-ak-button[aria-disabled="true"] {
+.bn-aria-kit .bn-ak-button[aria-disabled="true"] {
     opacity: 0.5;
 }
 
-.bn-ak-button[data-focus-visible] {
+.bn-aria-kit .bn-ak-button[data-focus-visible] {
     outline-style: solid;
 }
 
-.bn-ak-button:active,
-.bn-ak-button[data-active] {
+.bn-aria-kit .bn-ak-button:active,
+.bn-aria-kit .bn-ak-button[data-active] {
     padding-top: 0.125rem;
     box-shadow:
             inset 0 0 0 1px var(--border),
@@ -249,19 +252,19 @@ responsible for the majority of the styling. */
 }
 
 @media (min-width: 640px) {
-    .bn-ak-button {
+    .bn-aria-kit .bn-ak-button {
         gap: 0.5rem;
     }
 }
 
-.bn-ak-button:active:where(.dark, .dark *),
-.bn-ak-button[data-active]:where(.dark, .dark *) {
+.bn-aria-kit .bn-ak-button:active:where(.dark, .dark *),
+.bn-aria-kit .bn-ak-button[data-active]:where(.dark, .dark *) {
     box-shadow:
             inset 0 0 0 1px var(--border),
             inset 0 1px 1px 1px var(--shadow);
 }
 
-.bn-ak-wrapper {
+.bn-aria-kit .bn-ak-wrapper {
     display: flex;
     width: 320px;
     max-width: 100%;
@@ -275,11 +278,11 @@ responsible for the majority of the styling. */
             0 1px 2px -1px rgb(0 0 0 / 0.1);
 }
 
-.bn-ak-label {
+.bn-aria-kit .bn-ak-label {
     padding-left: 1rem;
 }
 
-.bn-ak-popover {
+.bn-aria-kit .bn-ak-popover {
     z-index: 50;
     display: flex;
     max-height: min(var(--popover-available-height, 300px), 300px);
@@ -298,7 +301,7 @@ responsible for the majority of the styling. */
             0 4px 6px -4px rgb(0 0 0 / 0.1);
 }
 
-.bn-ak-popover:where(.dark, .dark *) {
+.bn-aria-kit .bn-ak-popover:where(.dark, .dark *) {
     border-color: hsl(204 4% 24%);
     background-color: hsl(204 4% 16%);
     color: hsl(204 20% 100%);
@@ -307,7 +310,7 @@ responsible for the majority of the styling. */
             0 4px 6px -4px rgb(0 0 0 / 0.1);
 }
 
-.bn-ak-select-item {
+.bn-aria-kit .bn-ak-select-item {
     display: flex;
     cursor: default;
     scroll-margin: 0.5rem;
@@ -318,29 +321,29 @@ responsible for the majority of the styling. */
     outline: none !important;
 }
 
-.bn-ak-select-item[aria-disabled="true"] {
+.bn-aria-kit .bn-ak-select-item[aria-disabled="true"] {
     opacity: 0.5;
 }
 
-.bn-ak-select-item[data-active-item] {
+.bn-aria-kit .bn-ak-select-item[data-active-item] {
     background-color: hsl(204 100% 40%);
     color: hsl(204 20% 100%);
 }
 
-.bn-ak-wrapper:where(.dark, .dark *) {
+.bn-aria-kit .bn-ak-wrapper:where(.dark, .dark *) {
     background-color: hsl(204 4% 16%);
     box-shadow:
             0 1px 3px 0 rgb(0 0 0 / 0.25),
             0 1px 2px -1px rgb(0 0 0 / 0.1);
 }
 
-.bn-ak-field {
+.bn-aria-kit .bn-ak-field {
     display: flex;
     flex-direction: column;
     gap: 0.5rem;
 }
 
-.bn-ak-input {
+.bn-aria-kit .bn-ak-input {
     height: 2.5rem;
     width: 100%;
     border-radius: 0.375rem;
@@ -356,23 +359,23 @@ responsible for the majority of the styling. */
             inset 0 2px 5px 0 rgba(0 0 0 / 0.05);
 }
 
-.bn-ak-input::placeholder {
+.bn-aria-kit .bn-ak-input::placeholder {
     color: hsl(204 4% 0% / 0.6);
 }
 
-.bn-ak-input:hover {
+.bn-aria-kit .bn-ak-input:hover {
     background-color: hsl(204 20% 94%);
 }
 
-.bn-ak-popover:focus-visible,
-.bn-ak-popover[data-focus-visible],
-.bn-ak-input:focus-visible,
-.bn-ak-input[data-focus-visible] {
+.bn-aria-kit .bn-ak-popover:focus-visible,
+.bn-aria-kit .bn-ak-popover[data-focus-visible],
+.bn-aria-kit .bn-ak-input:focus-visible,
+.bn-aria-kit .bn-ak-input[data-focus-visible] {
     outline: 2px solid hsl(204 100% 40%);
     outline-offset: -1px;
 }
 
-.bn-ak-input:where(.dark, .dark *) {
+.bn-aria-kit .bn-ak-input:where(.dark, .dark *) {
     background-color: hsl(204 4% 10%);
     color: hsl(204 20% 100%);
     box-shadow:
@@ -381,15 +384,15 @@ responsible for the majority of the styling. */
             inset 0 2px 5px 0 rgba(0 0 0 / 0.15);
 }
 
-.bn-ak-input:where(.dark, .dark *)::placeholder {
+.bn-aria-kit .bn-ak-input:where(.dark, .dark *)::placeholder {
     color: hsl(204 20% 100% / 46%);
 }
 
-.bn-ak-input:hover:where(.dark, .dark *) {
+.bn-aria-kit .bn-ak-input:hover:where(.dark, .dark *) {
     background-color: hsl(204 4% 8%);
 }
 
-.bn-ak-error {
+.bn-aria-kit .bn-ak-error {
     width: fit-content;
     border-radius: 0.375rem;
     border-width: 1px;
@@ -402,24 +405,24 @@ responsible for the majority of the styling. */
     color: hsl(357 100% 30%);
 }
 
-.bn-ak-error:empty {
+.bn-aria-kit .bn-ak-error:empty {
     display: none;
 }
 
-.bn-ak-error:where(.dark, .dark *) {
+.bn-aria-kit .bn-ak-error:where(.dark, .dark *) {
     border-color: hsl(357 56% 50% / 0.4);
     background-color: hsl(357 56% 42% / 0.25);
     color: hsl(357 100% 90%);
 }
 
-.bn-ak-buttons {
+.bn-aria-kit .bn-ak-buttons {
     display: flex;
     gap: 1rem;
     padding-top: 1rem;
 }
 
 /* https://ariakit.org/components/menu */
-.bn-ak-button {
+.bn-aria-kit .bn-ak-button {
     --border: rgb(0 0 0/13%);
     --highlight: rgb(255 255 255/20%);
     --shadow: rgb(0 0 0/10%);
@@ -450,7 +453,7 @@ responsible for the majority of the styling. */
     font-weight: 500;
 }
 
-.bn-ak-button:where(.dark, .dark *) {
+.bn-aria-kit .bn-ak-button:where(.dark, .dark *) {
     --border: rgb(255 255 255/10%);
     --highlight: rgb(255 255 255/5%);
     --shadow: rgb(0 0 0/25%);
@@ -462,24 +465,24 @@ responsible for the majority of the styling. */
             inset 0 1px 0 var(--highlight);
 }
 
-.bn-ak-button:not(:active):hover {
+.bn-aria-kit .bn-ak-button:not(:active):hover {
     --border: rgb(0 0 0/33%);
 }
 
-.bn-ak-button:where(.dark, .dark *):not(:active):hover {
+.bn-aria-kit .bn-ak-button:where(.dark, .dark *):not(:active):hover {
     --border: rgb(255 255 255/25%);
 }
 
-.bn-ak-button[aria-disabled="true"] {
+.bn-aria-kit .bn-ak-button[aria-disabled="true"] {
     opacity: 0.5;
 }
 
-.bn-ak-button[data-focus-visible] {
+.bn-aria-kit .bn-ak-button[data-focus-visible] {
     outline-style: solid;
 }
 
-.bn-ak-button:active,
-.bn-ak-button[data-active] {
+.bn-aria-kit .bn-ak-button:active,
+.bn-aria-kit .bn-ak-button[data-active] {
     padding-top: 0.125rem;
     box-shadow:
             inset 0 0 0 1px var(--border),
@@ -487,19 +490,19 @@ responsible for the majority of the styling. */
 }
 
 @media (min-width: 640px) {
-    .bn-ak-button {
+    .bn-aria-kit .bn-ak-button {
         gap: 0.5rem;
     }
 }
 
-.bn-ak-button:active:where(.dark, .dark *),
-.bn-ak-button[data-active]:where(.dark, .dark *) {
+.bn-aria-kit .bn-ak-button:active:where(.dark, .dark *),
+.bn-aria-kit .bn-ak-button[data-active]:where(.dark, .dark *) {
     box-shadow:
             inset 0 0 0 1px var(--border),
             inset 0 1px 1px 1px var(--shadow);
 }
 
-.bn-ak-separator {
+.bn-aria-kit .bn-ak-separator {
     margin-top: 0.5rem;
     margin-bottom: 0.5rem;
     height: 0px;
@@ -508,11 +511,11 @@ responsible for the majority of the styling. */
     border-color: hsl(204 20% 88%);
 }
 
-.bn-ak-separator:where(.dark, .dark *) {
+.bn-aria-kit .bn-ak-separator:where(.dark, .dark *) {
     border-color: hsl(204 4% 28%);
 }
 
-.bn-ak-menu {
+.bn-aria-kit .bn-ak-menu {
     position: relative;
     z-index: 50;
     display: flex;
@@ -534,7 +537,7 @@ responsible for the majority of the styling. */
     outline: none !important;
 }
 
-.bn-ak-menu:where(.dark, .dark *) {
+.bn-aria-kit .bn-ak-menu:where(.dark, .dark *) {
     border-color: hsl(204 4% 24%);
     background-color: hsl(204 4% 16%);
     color: hsl(204 20% 100%);
@@ -543,7 +546,7 @@ responsible for the majority of the styling. */
             0 4px 6px -4px rgb(0 0 0 / 0.1);
 }
 
-.bn-ak-menu-item {
+.bn-aria-kit .bn-ak-menu-item {
     display: flex;
     cursor: default;
     scroll-margin: 0.5rem;
@@ -554,24 +557,24 @@ responsible for the majority of the styling. */
     outline: none !important;
 }
 
-.bn-ak-menu-item[aria-disabled="true"] {
+.bn-aria-kit .bn-ak-menu-item[aria-disabled="true"] {
     opacity: 0.25;
 }
 
-.bn-ak-menu-item[data-active-item] {
+.bn-aria-kit .bn-ak-menu-item[data-active-item] {
     background-color: hsl(204 100% 40%);
     color: hsl(204 20% 100%);
 }
 
-.bn-ak-menu-item:active,
-.bn-ak-menu-item[data-active] {
+.bn-aria-kit .bn-ak-menu-item:active,
+.bn-aria-kit .bn-ak-menu-item[data-active] {
     background-color: hsl(204 100% 32%);
     padding-top: 9px;
     padding-bottom: 7px;
 }
 
 /* https://ariakit.org/examples/select-group */
-.bn-ak-button {
+.bn-aria-kit .bn-ak-button {
     --border: rgb(0 0 0/13%);
     --highlight: rgb(255 255 255/20%);
     --shadow: rgb(0 0 0/10%);
@@ -602,7 +605,7 @@ responsible for the majority of the styling. */
     justify-content: space-between;
 }
 
-.bn-ak-button:where(.dark, .dark *) {
+.bn-aria-kit .bn-ak-button:where(.dark, .dark *) {
     --border: rgb(255 255 255/10%);
     --highlight: rgb(255 255 255/5%);
     --shadow: rgb(0 0 0/25%);
@@ -614,24 +617,24 @@ responsible for the majority of the styling. */
             inset 0 1px 0 var(--highlight);
 }
 
-.bn-ak-button:not(:active):hover {
+.bn-aria-kit .bn-ak-button:not(:active):hover {
     --border: rgb(0 0 0/33%);
 }
 
-.bn-ak-button:where(.dark, .dark *):not(:active):hover {
+.bn-aria-kit .bn-ak-button:where(.dark, .dark *):not(:active):hover {
     --border: rgb(255 255 255/25%);
 }
 
-.bn-ak-button[aria-disabled="true"] {
+.bn-aria-kit .bn-ak-button[aria-disabled="true"] {
     opacity: 0.5;
 }
 
-.bn-ak-button[data-focus-visible] {
+.bn-aria-kit .bn-ak-button[data-focus-visible] {
     outline-style: solid;
 }
 
-.bn-ak-button:active,
-.bn-ak-button[data-active] {
+.bn-aria-kit .bn-ak-button:active,
+.bn-aria-kit .bn-ak-button[data-active] {
     padding-top: 0.125rem;
     box-shadow:
             inset 0 0 0 1px var(--border),
@@ -639,26 +642,26 @@ responsible for the majority of the styling. */
 }
 
 @media (min-width: 640px) {
-    .bn-ak-button {
+    .bn-aria-kit .bn-ak-button {
         gap: 0.5rem;
     }
 }
 
-.bn-ak-button:active:where(.dark, .dark *),
-.bn-ak-button[data-active]:where(.dark, .dark *) {
+.bn-aria-kit .bn-ak-button:active:where(.dark, .dark *),
+.bn-aria-kit .bn-ak-button[data-active]:where(.dark, .dark *) {
     box-shadow:
             inset 0 0 0 1px var(--border),
             inset 0 1px 1px 1px var(--shadow);
 }
 
-.bn-ak-wrapper {
+.bn-aria-kit .bn-ak-wrapper {
     display: flex;
     flex-direction: column;
     gap: 0.5rem;
     padding: 1rem;
 }
 
-.bn-ak-popover {
+.bn-aria-kit .bn-ak-popover {
     z-index: 50;
     display: flex;
     max-height: min(var(--popover-available-height, 300px), 300px);
@@ -677,13 +680,13 @@ responsible for the majority of the styling. */
             0 4px 6px -4px rgb(0 0 0 / 0.1);
 }
 
-.bn-ak-popover:focus-visible,
-.bn-ak-popover[data-focus-visible] {
+.bn-aria-kit .bn-ak-popover:focus-visible,
+.bn-aria-kit .bn-ak-popover[data-focus-visible] {
     outline: 2px solid hsl(204 100% 40%);
     outline-offset: -1px;
 }
 
-.bn-ak-popover:where(.dark, .dark *) {
+.bn-aria-kit .bn-ak-popover:where(.dark, .dark *) {
     border-color: hsl(204 4% 24%);
     background-color: hsl(204 4% 16%);
     color: hsl(204 20% 100%);
@@ -692,7 +695,7 @@ responsible for the majority of the styling. */
             0 4px 6px -4px rgb(0 0 0 / 0.1);
 }
 
-.bn-ak-select-item {
+.bn-aria-kit .bn-ak-select-item {
     display: flex;
     cursor: default;
     scroll-margin: 0.5rem;
@@ -703,16 +706,16 @@ responsible for the majority of the styling. */
     outline: none !important;
 }
 
-.bn-ak-select-item[aria-disabled="true"] {
+.bn-aria-kit .bn-ak-select-item[aria-disabled="true"] {
     opacity: 0.5;
 }
 
-.bn-ak-select-item[data-active-item] {
+.bn-aria-kit .bn-ak-select-item[data-active-item] {
     background-color: hsl(204 100% 40%);
     color: hsl(204 20% 100%);
 }
 
-.bn-ak-separator {
+.bn-aria-kit .bn-ak-separator {
     margin-top: 0.5rem;
     margin-bottom: 0.5rem;
     height: 0px;
@@ -721,11 +724,11 @@ responsible for the majority of the styling. */
     border-color: hsl(204 20% 88%);
 }
 
-.bn-ak-separator:where(.dark, .dark *) {
+.bn-aria-kit .bn-ak-separator:where(.dark, .dark *) {
     border-color: hsl(204 4% 28%);
 }
 
-.bn-ak-group-label {
+.bn-aria-kit .bn-ak-group-label {
     cursor: default;
     padding: 0.5rem;
     font-size: 0.875rem;
@@ -734,12 +737,12 @@ responsible for the majority of the styling. */
     opacity: 0.6;
 }
 
-.bn-ak-group-label + * {
+.bn-aria-kit .bn-ak-group-label + * {
     scroll-margin-top: 2.5rem;
 }
 
 /* https://ariakit.org/components/tab */
-.bn-ak-wrapper {
+.bn-aria-kit .bn-ak-wrapper {
     display: flex;
     flex-direction: column;
     gap: 0.5rem;
@@ -751,19 +754,19 @@ responsible for the majority of the styling. */
             0 1px 2px -1px rgb(0 0 0 / 0.1);
 }
 
-.bn-ak-wrapper:where(.dark, .dark *) {
+.bn-aria-kit .bn-ak-wrapper:where(.dark, .dark *) {
     background-color: hsl(204 4% 16%);
     box-shadow:
             0 1px 3px 0 rgb(0 0 0 / 0.25),
             0 1px 2px -1px rgb(0 0 0 / 0.1);
 }
 
-.bn-ak-tab-list {
+.bn-aria-kit .bn-ak-tab-list {
     display: flex;
     gap: 0.5rem;
 }
 
-.bn-ak-tab {
+.bn-aria-kit .bn-ak-tab {
     display: flex;
     height: 2.5rem;
     user-select: none;
@@ -783,51 +786,51 @@ responsible for the majority of the styling. */
     outline-color: hsl(204 100% 40%);
 }
 
-.bn-ak-tab:hover {
+.bn-aria-kit .bn-ak-tab:hover {
     background-color: hsl(204 4% 0% / 7.5%);
 }
 
-.bn-ak-tab[aria-disabled="true"] {
+.bn-aria-kit .bn-ak-tab[aria-disabled="true"] {
     opacity: 0.5;
 }
 
-.bn-ak-tab[aria-selected="true"] {
+.bn-aria-kit .bn-ak-tab[aria-selected="true"] {
     background-color: hsl(204 100% 40%);
     color: hsl(204 20% 100%);
 }
 
-.bn-ak-tab:hover[aria-selected="true"] {
+.bn-aria-kit .bn-ak-tab:hover[aria-selected="true"] {
     background-color: hsl(204 100% 32%);
 }
 
-.bn-ak-tab[data-focus-visible] {
+.bn-aria-kit .bn-ak-tab[data-focus-visible] {
     outline-style: solid;
 }
 
-.bn-ak-tab:active,
-.bn-ak-tab[data-active] {
+.bn-aria-kit .bn-ak-tab:active,
+.bn-aria-kit .bn-ak-tab[data-active] {
     padding-top: 0.125rem;
 }
 
-.bn-ak-tab:hover:where(.dark, .dark *) {
+.bn-aria-kit .bn-ak-tab:hover:where(.dark, .dark *) {
     background-color: hsl(204 20% 100% / 0.1);
 }
 
-.bn-ak-tab[aria-selected="true"]:where(.dark, .dark *) {
+.bn-aria-kit .bn-ak-tab[aria-selected="true"]:where(.dark, .dark *) {
     background-color: hsl(204 100% 40%);
     color: hsl(204 20% 100%);
 }
 
-.bn-ak-tab:hover[aria-selected="true"]:where(.dark, .dark *) {
+.bn-aria-kit .bn-ak-tab:hover[aria-selected="true"]:where(.dark, .dark *) {
     background-color: hsl(204 100% 32%);
 }
 
-.bn-ak-panels {
+.bn-aria-kit .bn-ak-panels {
     padding: 0.5rem;
 }
 
 /* https://ariakit.org/components/toolbar */
-.bn-ak-button {
+.bn-aria-kit .bn-ak-button {
     --border: rgb(0 0 0/13%);
     --highlight: rgb(255 255 255/20%);
     --shadow: rgb(0 0 0/10%);
@@ -859,7 +862,7 @@ responsible for the majority of the styling. */
     border-radius: 0.25rem;
 }
 
-.bn-ak-button:where(.dark, .dark *) {
+.bn-aria-kit .bn-ak-button:where(.dark, .dark *) {
     --border: rgb(255 255 255/10%);
     --highlight: rgb(255 255 255/5%);
     --shadow: rgb(0 0 0/25%);
@@ -871,24 +874,24 @@ responsible for the majority of the styling. */
             inset 0 1px 0 var(--highlight);
 }
 
-.bn-ak-button:not(:active):hover {
+.bn-aria-kit .bn-ak-button:not(:active):hover {
     --border: rgb(0 0 0/33%);
 }
 
-.bn-ak-button:where(.dark, .dark *):not(:active):hover {
+.bn-aria-kit .bn-ak-button:where(.dark, .dark *):not(:active):hover {
     --border: rgb(255 255 255/25%);
 }
 
-.bn-ak-button[aria-disabled="true"] {
+.bn-aria-kit .bn-ak-button[aria-disabled="true"] {
     opacity: 0.5;
 }
 
-.bn-ak-button[data-focus-visible] {
+.bn-aria-kit .bn-ak-button[data-focus-visible] {
     outline-style: solid;
 }
 
-.bn-ak-button:active,
-.bn-ak-button[data-active] {
+.bn-aria-kit .bn-ak-button:active,
+.bn-aria-kit .bn-ak-button[data-active] {
     padding-top: 0.125rem;
     box-shadow:
             inset 0 0 0 1px var(--border),
@@ -896,43 +899,43 @@ responsible for the majority of the styling. */
 }
 
 @media (min-width: 640px) {
-    .bn-ak-button {
+    .bn-aria-kit .bn-ak-button {
         gap: 0.5rem;
     }
 }
 
-.bn-ak-button:active:where(.dark, .dark *),
-.bn-ak-button[data-active]:where(.dark, .dark *) {
+.bn-aria-kit .bn-ak-button:active:where(.dark, .dark *),
+.bn-aria-kit .bn-ak-button[data-active]:where(.dark, .dark *) {
     box-shadow:
             inset 0 0 0 1px var(--border),
             inset 0 1px 1px 1px var(--shadow);
 }
 
-.bn-ak-secondary {
+.bn-aria-kit .bn-ak-secondary {
     background-color: transparent;
     color: currentColor;
     box-shadow: none;
 }
 
-.bn-ak-secondary:hover {
+.bn-aria-kit .bn-ak-secondary:hover {
     background-color: hsl(204 4% 0% / 0.05);
 }
 
-.bn-ak-secondary:where(.dark, .dark *) {
+.bn-aria-kit .bn-ak-secondary:where(.dark, .dark *) {
     background-color: transparent;
     box-shadow: none;
 }
 
-.bn-ak-secondary:hover:where(.dark, .dark *) {
+.bn-aria-kit .bn-ak-secondary:hover:where(.dark, .dark *) {
     background-color: hsl(204 20% 100% / 0.05);
 }
 
-.bn-ak-secondary:active:where(.dark, .dark *),
-.bn-ak-secondary[data-active]:where(.dark, .dark *) {
+.bn-aria-kit .bn-ak-secondary:active:where(.dark, .dark *),
+.bn-aria-kit .bn-ak-secondary[data-active]:where(.dark, .dark *) {
     box-shadow: none;
 }
 
-.bn-ak-toolbar {
+.bn-aria-kit .bn-ak-toolbar {
     display: flex;
     max-width: 100%;
     align-items: center;
@@ -946,25 +949,25 @@ responsible for the majority of the styling. */
             0 1px 2px -1px rgb(0 0 0 / 0.1);
 }
 
-.bn-ak-toolbar:where(.dark, .dark *) {
+.bn-aria-kit .bn-ak-toolbar:where(.dark, .dark *) {
     background-color: hsl(204 4% 16%);
     box-shadow:
             0 1px 3px 0 rgb(0 0 0 / 0.25),
             0 1px 2px -1px rgb(0 0 0 / 0.1);
 }
 
-.bn-ak-separator {
+.bn-aria-kit .bn-ak-separator {
     height: 2rem;
     border-right-width: 1px;
     border-color: hsl(204 20% 88%);
 }
 
-.bn-ak-separator:where(.dark, .dark *) {
+.bn-aria-kit .bn-ak-separator:where(.dark, .dark *) {
     border-color: hsl(204 4% 28%);
 }
 
 /* https://ariakit.org/components/tooltip */
-.bn-ak-tooltip {
+.bn-aria-kit .bn-ak-tooltip {
     z-index: 50;
     cursor: default;
     border-radius: 0.375rem;
@@ -981,14 +984,14 @@ responsible for the majority of the styling. */
     box-shadow: 0 1px 2px 0 rgb(0 0 0 / 0.05);
 }
 
-.bn-ak-tooltip:where(.dark, .dark *) {
+.bn-aria-kit .bn-ak-tooltip:where(.dark, .dark *) {
     border-color: hsl(204 4% 24%);
     background-color: hsl(204 4% 16%);
     color: white;
     box-shadow: 0 1px 2px 0 rgb(0 0 0 / 0.15);
 }
 
-.bn-ak-link {
+.bn-aria-kit .bn-ak-link {
     font-weight: 500;
     color: hsl(204 100% 35%);
     text-decoration-line: underline;
@@ -996,10 +999,10 @@ responsible for the majority of the styling. */
     text-underline-offset: 0.25em;
 }
 
-.bn-ak-link:hover {
+.bn-aria-kit .bn-ak-link:hover {
     text-decoration-thickness: 3px;
 }
 
-.bn-ak-link:where(.dark, .dark *) {
+.bn-aria-kit .bn-ak-link:where(.dark, .dark *) {
     color: hsl(204 100% 64%);
 }

--- a/packages/ariakit/src/ariakitStyles.css
+++ b/packages/ariakit/src/ariakitStyles.css
@@ -2,7 +2,7 @@
 responsible for the majority of the styling. */
 
 /* https://ariakit.org/examples/menu-nested */
-.bn-aria-kit .bn-ak-button {
+.bn-ak-button {
     --border: rgb(0 0 0/13%);
     --highlight: rgb(255 255 255/20%);
     --shadow: rgb(0 0 0/10%);
@@ -33,7 +33,7 @@ responsible for the majority of the styling. */
     font-weight: 500;
 }
 
-.bn-aria-kit .bn-ak-button:where(.dark, .dark *) {
+.bn-ak-button:where(.dark, .dark *) {
     --border: rgb(255 255 255/10%);
     --highlight: rgb(255 255 255/5%);
     --shadow: rgb(0 0 0/25%);
@@ -45,24 +45,24 @@ responsible for the majority of the styling. */
             inset 0 1px 0 var(--highlight);
 }
 
-.bn-aria-kit .bn-ak-button:not(:active):hover {
+.bn-ak-button:not(:active):hover {
     --border: rgb(0 0 0/33%);
 }
 
-.bn-aria-kit .bn-ak-button:where(.dark, .dark *):not(:active):hover {
+.bn-ak-button:where(.dark, .dark *):not(:active):hover {
     --border: rgb(255 255 255/25%);
 }
 
-.bn-aria-kit .bn-ak-button[aria-disabled="true"] {
+.bn-ak-button[aria-disabled="true"] {
     opacity: 0.5;
 }
 
-.bn-aria-kit .bn-ak-button[data-focus-visible] {
+.bn-ak-button[data-focus-visible] {
     outline-style: solid;
 }
 
-.bn-aria-kit .bn-ak-button:active,
-.bn-aria-kit .bn-ak-button[data-active] {
+.bn-ak-button:active,
+.bn-ak-button[data-active] {
     padding-top: 0.125rem;
     box-shadow:
             inset 0 0 0 1px var(--border),
@@ -70,19 +70,19 @@ responsible for the majority of the styling. */
 }
 
 @media (min-width: 640px) {
-    .bn-aria-kit .bn-ak-button {
+    .bn-ak-button {
         gap: 0.5rem;
     }
 }
 
-.bn-aria-kit .bn-ak-button:active:where(.dark, .dark *),
-.bn-aria-kit .bn-ak-button[data-active]:where(.dark, .dark *) {
+.bn-ak-button:active:where(.dark, .dark *),
+.bn-ak-button[data-active]:where(.dark, .dark *) {
     box-shadow:
             inset 0 0 0 1px var(--border),
             inset 0 1px 1px 1px var(--shadow);
 }
 
-.bn-aria-kit .bn-ak-menu {
+.bn-ak-menu {
     position: relative;
     z-index: 50;
     display: flex;
@@ -104,7 +104,7 @@ responsible for the majority of the styling. */
     overflow: visible;
 }
 
-.bn-aria-kit .bn-ak-menu:where(.dark, .dark *) {
+.bn-ak-menu:where(.dark, .dark *) {
     border-color: hsl(204 4% 24%);
     background-color: hsl(204 4% 16%);
     color: hsl(204 20% 100%);
@@ -113,7 +113,7 @@ responsible for the majority of the styling. */
             0 4px 6px -4px rgb(0 0 0 / 0.1);
 }
 
-.bn-aria-kit .bn-ak-menu-item {
+.bn-ak-menu-item {
     display: flex;
     cursor: default;
     scroll-margin: 0.5rem;
@@ -124,41 +124,39 @@ responsible for the majority of the styling. */
     outline: none !important;
 }
 
-.bn-aria-kit .bn-ak-menu-item[aria-disabled="true"] {
+.bn-ak-menu-item[aria-disabled="true"] {
     opacity: 0.25;
 }
 
-.bn-aria-kit .bn-ak-menu-item[data-active-item] {
+.bn-ak-menu-item[data-active-item] {
     background-color: hsl(204 100% 40%);
     color: hsl(204 20% 100%);
 }
 
-.bn-aria-kit .bn-ak-menu-item:active,
-.bn-aria-kit .bn-ak-menu-item[data-active] {
+.bn-ak-menu-item:active,
+.bn-ak-menu-item[data-active] {
     background-color: hsl(204 100% 32%);
     padding-top: 9px;
     padding-bottom: 7px;
 }
 
-.bn-aria-kit .bn-ak-menu:not(:focus)
-.bn-aria-kit .bn-ak-menu-item:not(:focus)[aria-expanded="true"] {
+.bn-ak-menu:not(:focus)
+.bn-ak-menu-item:not(:focus)[aria-expanded="true"] {
     background-color: hsl(204 4% 0% / 7.5%);
     color: currentColor;
 }
 
-.bn-aria-kit
 .bn-ak-menu:not(:focus)
-.bn-aria-kit
 .bn-ak-menu-item:not(:focus)[aria-expanded="true"]:where(.dark, .dark *) {
     background-color: hsl(204 20% 100% / 0.1);
 }
 
-.bn-aria-kit .bn-ak-menu-item .label {
+.bn-ak-menu-item .label {
     flex: 1 1 0%;
 }
 
 /* https://ariakit.org/examples/form-select */
-.bn-aria-kit .bn-ak-button {
+.bn-ak-button {
     --border: rgb(0 0 0/13%);
     --highlight: rgb(255 255 255/20%);
     --shadow: rgb(0 0 0/10%);
@@ -189,7 +187,7 @@ responsible for the majority of the styling. */
     border-radius: 0.375rem;
 }
 
-.bn-aria-kit .bn-ak-button:where(.dark, .dark *) {
+.bn-ak-button:where(.dark, .dark *) {
     --border: rgb(255 255 255/10%);
     --highlight: rgb(255 255 255/5%);
     --shadow: rgb(0 0 0/25%);
@@ -201,15 +199,15 @@ responsible for the majority of the styling. */
             inset 0 1px 0 var(--highlight);
 }
 
-.bn-aria-kit .bn-ak-button:not(:active):hover {
+.bn-ak-button:not(:active):hover {
     --border: rgb(0 0 0/33%);
 }
 
-.bn-aria-kit .bn-ak-button:where(.dark, .dark *):not(:active):hover {
+.bn-ak-button:where(.dark, .dark *):not(:active):hover {
     --border: rgb(255 255 255/25%);
 }
 
-.bn-aria-kit .bn-ak-primary {
+.bn-ak-primary {
     --border: rgba(0, 0, 0, 0.15);
     --highlight: rgba(255, 255, 255, 0.25);
     --shadow: rgba(0, 0, 0, 0.15);
@@ -218,33 +216,33 @@ responsible for the majority of the styling. */
     justify-content: center;
 }
 
-.bn-aria-kit .bn-ak-primary:hover {
+.bn-ak-primary:hover {
     --border: rgba(0, 0, 0, 0.35);
     background-color: hsl(204 100% 35%);
 }
 
-.bn-aria-kit .bn-ak-primary:where(.dark, .dark *) {
+.bn-ak-primary:where(.dark, .dark *) {
     --border: rgba(255, 255, 255, 0.25);
     --highlight: rgba(255, 255, 255, 0.1);
     --shadow: rgba(0, 0, 0, 0.25);
     background-color: hsl(204 100% 35%);
 }
 
-.bn-aria-kit .bn-ak-primary:hover:where(.dark, .dark *) {
+.bn-ak-primary:hover:where(.dark, .dark *) {
     --border: rgba(255, 255, 255, 0.45);
     background-color: hsl(204 100% 40%);
 }
 
-.bn-aria-kit .bn-ak-button[aria-disabled="true"] {
+.bn-ak-button[aria-disabled="true"] {
     opacity: 0.5;
 }
 
-.bn-aria-kit .bn-ak-button[data-focus-visible] {
+.bn-ak-button[data-focus-visible] {
     outline-style: solid;
 }
 
-.bn-aria-kit .bn-ak-button:active,
-.bn-aria-kit .bn-ak-button[data-active] {
+.bn-ak-button:active,
+.bn-ak-button[data-active] {
     padding-top: 0.125rem;
     box-shadow:
             inset 0 0 0 1px var(--border),
@@ -252,19 +250,19 @@ responsible for the majority of the styling. */
 }
 
 @media (min-width: 640px) {
-    .bn-aria-kit .bn-ak-button {
+    .bn-ak-button {
         gap: 0.5rem;
     }
 }
 
-.bn-aria-kit .bn-ak-button:active:where(.dark, .dark *),
-.bn-aria-kit .bn-ak-button[data-active]:where(.dark, .dark *) {
+.bn-ak-button:active:where(.dark, .dark *),
+.bn-ak-button[data-active]:where(.dark, .dark *) {
     box-shadow:
             inset 0 0 0 1px var(--border),
             inset 0 1px 1px 1px var(--shadow);
 }
 
-.bn-aria-kit .bn-ak-wrapper {
+.bn-ak-wrapper {
     display: flex;
     width: 320px;
     max-width: 100%;
@@ -278,11 +276,11 @@ responsible for the majority of the styling. */
             0 1px 2px -1px rgb(0 0 0 / 0.1);
 }
 
-.bn-aria-kit .bn-ak-label {
+.bn-ak-label {
     padding-left: 1rem;
 }
 
-.bn-aria-kit .bn-ak-popover {
+.bn-ak-popover {
     z-index: 50;
     display: flex;
     max-height: min(var(--popover-available-height, 300px), 300px);
@@ -301,7 +299,7 @@ responsible for the majority of the styling. */
             0 4px 6px -4px rgb(0 0 0 / 0.1);
 }
 
-.bn-aria-kit .bn-ak-popover:where(.dark, .dark *) {
+.bn-ak-popover:where(.dark, .dark *) {
     border-color: hsl(204 4% 24%);
     background-color: hsl(204 4% 16%);
     color: hsl(204 20% 100%);
@@ -310,7 +308,7 @@ responsible for the majority of the styling. */
             0 4px 6px -4px rgb(0 0 0 / 0.1);
 }
 
-.bn-aria-kit .bn-ak-select-item {
+.bn-ak-select-item {
     display: flex;
     cursor: default;
     scroll-margin: 0.5rem;
@@ -321,29 +319,29 @@ responsible for the majority of the styling. */
     outline: none !important;
 }
 
-.bn-aria-kit .bn-ak-select-item[aria-disabled="true"] {
+.bn-ak-select-item[aria-disabled="true"] {
     opacity: 0.5;
 }
 
-.bn-aria-kit .bn-ak-select-item[data-active-item] {
+.bn-ak-select-item[data-active-item] {
     background-color: hsl(204 100% 40%);
     color: hsl(204 20% 100%);
 }
 
-.bn-aria-kit .bn-ak-wrapper:where(.dark, .dark *) {
+.bn-ak-wrapper:where(.dark, .dark *) {
     background-color: hsl(204 4% 16%);
     box-shadow:
             0 1px 3px 0 rgb(0 0 0 / 0.25),
             0 1px 2px -1px rgb(0 0 0 / 0.1);
 }
 
-.bn-aria-kit .bn-ak-field {
+.bn-ak-field {
     display: flex;
     flex-direction: column;
     gap: 0.5rem;
 }
 
-.bn-aria-kit .bn-ak-input {
+.bn-ak-input {
     height: 2.5rem;
     width: 100%;
     border-radius: 0.375rem;
@@ -359,23 +357,23 @@ responsible for the majority of the styling. */
             inset 0 2px 5px 0 rgba(0 0 0 / 0.05);
 }
 
-.bn-aria-kit .bn-ak-input::placeholder {
+.bn-ak-input::placeholder {
     color: hsl(204 4% 0% / 0.6);
 }
 
-.bn-aria-kit .bn-ak-input:hover {
+.bn-ak-input:hover {
     background-color: hsl(204 20% 94%);
 }
 
-.bn-aria-kit .bn-ak-popover:focus-visible,
-.bn-aria-kit .bn-ak-popover[data-focus-visible],
-.bn-aria-kit .bn-ak-input:focus-visible,
-.bn-aria-kit .bn-ak-input[data-focus-visible] {
+.bn-ak-popover:focus-visible,
+.bn-ak-popover[data-focus-visible],
+.bn-ak-input:focus-visible,
+.bn-ak-input[data-focus-visible] {
     outline: 2px solid hsl(204 100% 40%);
     outline-offset: -1px;
 }
 
-.bn-aria-kit .bn-ak-input:where(.dark, .dark *) {
+.bn-ak-input:where(.dark, .dark *) {
     background-color: hsl(204 4% 10%);
     color: hsl(204 20% 100%);
     box-shadow:
@@ -384,15 +382,15 @@ responsible for the majority of the styling. */
             inset 0 2px 5px 0 rgba(0 0 0 / 0.15);
 }
 
-.bn-aria-kit .bn-ak-input:where(.dark, .dark *)::placeholder {
+.bn-ak-input:where(.dark, .dark *)::placeholder {
     color: hsl(204 20% 100% / 46%);
 }
 
-.bn-aria-kit .bn-ak-input:hover:where(.dark, .dark *) {
+.bn-ak-input:hover:where(.dark, .dark *) {
     background-color: hsl(204 4% 8%);
 }
 
-.bn-aria-kit .bn-ak-error {
+.bn-ak-error {
     width: fit-content;
     border-radius: 0.375rem;
     border-width: 1px;
@@ -405,24 +403,24 @@ responsible for the majority of the styling. */
     color: hsl(357 100% 30%);
 }
 
-.bn-aria-kit .bn-ak-error:empty {
+.bn-ak-error:empty {
     display: none;
 }
 
-.bn-aria-kit .bn-ak-error:where(.dark, .dark *) {
+.bn-ak-error:where(.dark, .dark *) {
     border-color: hsl(357 56% 50% / 0.4);
     background-color: hsl(357 56% 42% / 0.25);
     color: hsl(357 100% 90%);
 }
 
-.bn-aria-kit .bn-ak-buttons {
+.bn-ak-buttons {
     display: flex;
     gap: 1rem;
     padding-top: 1rem;
 }
 
 /* https://ariakit.org/components/menu */
-.bn-aria-kit .bn-ak-button {
+.bn-ak-button {
     --border: rgb(0 0 0/13%);
     --highlight: rgb(255 255 255/20%);
     --shadow: rgb(0 0 0/10%);
@@ -453,7 +451,7 @@ responsible for the majority of the styling. */
     font-weight: 500;
 }
 
-.bn-aria-kit .bn-ak-button:where(.dark, .dark *) {
+.bn-ak-button:where(.dark, .dark *) {
     --border: rgb(255 255 255/10%);
     --highlight: rgb(255 255 255/5%);
     --shadow: rgb(0 0 0/25%);
@@ -465,24 +463,24 @@ responsible for the majority of the styling. */
             inset 0 1px 0 var(--highlight);
 }
 
-.bn-aria-kit .bn-ak-button:not(:active):hover {
+.bn-ak-button:not(:active):hover {
     --border: rgb(0 0 0/33%);
 }
 
-.bn-aria-kit .bn-ak-button:where(.dark, .dark *):not(:active):hover {
+.bn-ak-button:where(.dark, .dark *):not(:active):hover {
     --border: rgb(255 255 255/25%);
 }
 
-.bn-aria-kit .bn-ak-button[aria-disabled="true"] {
+.bn-ak-button[aria-disabled="true"] {
     opacity: 0.5;
 }
 
-.bn-aria-kit .bn-ak-button[data-focus-visible] {
+.bn-ak-button[data-focus-visible] {
     outline-style: solid;
 }
 
-.bn-aria-kit .bn-ak-button:active,
-.bn-aria-kit .bn-ak-button[data-active] {
+.bn-ak-button:active,
+.bn-ak-button[data-active] {
     padding-top: 0.125rem;
     box-shadow:
             inset 0 0 0 1px var(--border),
@@ -490,19 +488,19 @@ responsible for the majority of the styling. */
 }
 
 @media (min-width: 640px) {
-    .bn-aria-kit .bn-ak-button {
+    .bn-ak-button {
         gap: 0.5rem;
     }
 }
 
-.bn-aria-kit .bn-ak-button:active:where(.dark, .dark *),
-.bn-aria-kit .bn-ak-button[data-active]:where(.dark, .dark *) {
+.bn-ak-button:active:where(.dark, .dark *),
+.bn-ak-button[data-active]:where(.dark, .dark *) {
     box-shadow:
             inset 0 0 0 1px var(--border),
             inset 0 1px 1px 1px var(--shadow);
 }
 
-.bn-aria-kit .bn-ak-separator {
+.bn-ak-separator {
     margin-top: 0.5rem;
     margin-bottom: 0.5rem;
     height: 0px;
@@ -511,11 +509,11 @@ responsible for the majority of the styling. */
     border-color: hsl(204 20% 88%);
 }
 
-.bn-aria-kit .bn-ak-separator:where(.dark, .dark *) {
+.bn-ak-separator:where(.dark, .dark *) {
     border-color: hsl(204 4% 28%);
 }
 
-.bn-aria-kit .bn-ak-menu {
+.bn-ak-menu {
     position: relative;
     z-index: 50;
     display: flex;
@@ -537,7 +535,7 @@ responsible for the majority of the styling. */
     outline: none !important;
 }
 
-.bn-aria-kit .bn-ak-menu:where(.dark, .dark *) {
+.bn-ak-menu:where(.dark, .dark *) {
     border-color: hsl(204 4% 24%);
     background-color: hsl(204 4% 16%);
     color: hsl(204 20% 100%);
@@ -546,7 +544,7 @@ responsible for the majority of the styling. */
             0 4px 6px -4px rgb(0 0 0 / 0.1);
 }
 
-.bn-aria-kit .bn-ak-menu-item {
+.bn-ak-menu-item {
     display: flex;
     cursor: default;
     scroll-margin: 0.5rem;
@@ -557,24 +555,24 @@ responsible for the majority of the styling. */
     outline: none !important;
 }
 
-.bn-aria-kit .bn-ak-menu-item[aria-disabled="true"] {
+.bn-ak-menu-item[aria-disabled="true"] {
     opacity: 0.25;
 }
 
-.bn-aria-kit .bn-ak-menu-item[data-active-item] {
+.bn-ak-menu-item[data-active-item] {
     background-color: hsl(204 100% 40%);
     color: hsl(204 20% 100%);
 }
 
-.bn-aria-kit .bn-ak-menu-item:active,
-.bn-aria-kit .bn-ak-menu-item[data-active] {
+.bn-ak-menu-item:active,
+.bn-ak-menu-item[data-active] {
     background-color: hsl(204 100% 32%);
     padding-top: 9px;
     padding-bottom: 7px;
 }
 
 /* https://ariakit.org/examples/select-group */
-.bn-aria-kit .bn-ak-button {
+.bn-ak-button {
     --border: rgb(0 0 0/13%);
     --highlight: rgb(255 255 255/20%);
     --shadow: rgb(0 0 0/10%);
@@ -605,7 +603,7 @@ responsible for the majority of the styling. */
     justify-content: space-between;
 }
 
-.bn-aria-kit .bn-ak-button:where(.dark, .dark *) {
+.bn-ak-button:where(.dark, .dark *) {
     --border: rgb(255 255 255/10%);
     --highlight: rgb(255 255 255/5%);
     --shadow: rgb(0 0 0/25%);
@@ -617,24 +615,24 @@ responsible for the majority of the styling. */
             inset 0 1px 0 var(--highlight);
 }
 
-.bn-aria-kit .bn-ak-button:not(:active):hover {
+.bn-ak-button:not(:active):hover {
     --border: rgb(0 0 0/33%);
 }
 
-.bn-aria-kit .bn-ak-button:where(.dark, .dark *):not(:active):hover {
+.bn-ak-button:where(.dark, .dark *):not(:active):hover {
     --border: rgb(255 255 255/25%);
 }
 
-.bn-aria-kit .bn-ak-button[aria-disabled="true"] {
+.bn-ak-button[aria-disabled="true"] {
     opacity: 0.5;
 }
 
-.bn-aria-kit .bn-ak-button[data-focus-visible] {
+.bn-ak-button[data-focus-visible] {
     outline-style: solid;
 }
 
-.bn-aria-kit .bn-ak-button:active,
-.bn-aria-kit .bn-ak-button[data-active] {
+.bn-ak-button:active,
+.bn-ak-button[data-active] {
     padding-top: 0.125rem;
     box-shadow:
             inset 0 0 0 1px var(--border),
@@ -642,26 +640,26 @@ responsible for the majority of the styling. */
 }
 
 @media (min-width: 640px) {
-    .bn-aria-kit .bn-ak-button {
+    .bn-ak-button {
         gap: 0.5rem;
     }
 }
 
-.bn-aria-kit .bn-ak-button:active:where(.dark, .dark *),
-.bn-aria-kit .bn-ak-button[data-active]:where(.dark, .dark *) {
+.bn-ak-button:active:where(.dark, .dark *),
+.bn-ak-button[data-active]:where(.dark, .dark *) {
     box-shadow:
             inset 0 0 0 1px var(--border),
             inset 0 1px 1px 1px var(--shadow);
 }
 
-.bn-aria-kit .bn-ak-wrapper {
+.bn-ak-wrapper {
     display: flex;
     flex-direction: column;
     gap: 0.5rem;
     padding: 1rem;
 }
 
-.bn-aria-kit .bn-ak-popover {
+.bn-ak-popover {
     z-index: 50;
     display: flex;
     max-height: min(var(--popover-available-height, 300px), 300px);
@@ -680,13 +678,13 @@ responsible for the majority of the styling. */
             0 4px 6px -4px rgb(0 0 0 / 0.1);
 }
 
-.bn-aria-kit .bn-ak-popover:focus-visible,
-.bn-aria-kit .bn-ak-popover[data-focus-visible] {
+.bn-ak-popover:focus-visible,
+.bn-ak-popover[data-focus-visible] {
     outline: 2px solid hsl(204 100% 40%);
     outline-offset: -1px;
 }
 
-.bn-aria-kit .bn-ak-popover:where(.dark, .dark *) {
+.bn-ak-popover:where(.dark, .dark *) {
     border-color: hsl(204 4% 24%);
     background-color: hsl(204 4% 16%);
     color: hsl(204 20% 100%);
@@ -695,7 +693,7 @@ responsible for the majority of the styling. */
             0 4px 6px -4px rgb(0 0 0 / 0.1);
 }
 
-.bn-aria-kit .bn-ak-select-item {
+.bn-ak-select-item {
     display: flex;
     cursor: default;
     scroll-margin: 0.5rem;
@@ -706,16 +704,16 @@ responsible for the majority of the styling. */
     outline: none !important;
 }
 
-.bn-aria-kit .bn-ak-select-item[aria-disabled="true"] {
+.bn-ak-select-item[aria-disabled="true"] {
     opacity: 0.5;
 }
 
-.bn-aria-kit .bn-ak-select-item[data-active-item] {
+.bn-ak-select-item[data-active-item] {
     background-color: hsl(204 100% 40%);
     color: hsl(204 20% 100%);
 }
 
-.bn-aria-kit .bn-ak-separator {
+.bn-ak-separator {
     margin-top: 0.5rem;
     margin-bottom: 0.5rem;
     height: 0px;
@@ -724,11 +722,11 @@ responsible for the majority of the styling. */
     border-color: hsl(204 20% 88%);
 }
 
-.bn-aria-kit .bn-ak-separator:where(.dark, .dark *) {
+.bn-ak-separator:where(.dark, .dark *) {
     border-color: hsl(204 4% 28%);
 }
 
-.bn-aria-kit .bn-ak-group-label {
+.bn-ak-group-label {
     cursor: default;
     padding: 0.5rem;
     font-size: 0.875rem;
@@ -737,12 +735,12 @@ responsible for the majority of the styling. */
     opacity: 0.6;
 }
 
-.bn-aria-kit .bn-ak-group-label + * {
+.bn-ak-group-label + * {
     scroll-margin-top: 2.5rem;
 }
 
 /* https://ariakit.org/components/tab */
-.bn-aria-kit .bn-ak-wrapper {
+.bn-ak-wrapper {
     display: flex;
     flex-direction: column;
     gap: 0.5rem;
@@ -754,19 +752,19 @@ responsible for the majority of the styling. */
             0 1px 2px -1px rgb(0 0 0 / 0.1);
 }
 
-.bn-aria-kit .bn-ak-wrapper:where(.dark, .dark *) {
+.bn-ak-wrapper:where(.dark, .dark *) {
     background-color: hsl(204 4% 16%);
     box-shadow:
             0 1px 3px 0 rgb(0 0 0 / 0.25),
             0 1px 2px -1px rgb(0 0 0 / 0.1);
 }
 
-.bn-aria-kit .bn-ak-tab-list {
+.bn-ak-tab-list {
     display: flex;
     gap: 0.5rem;
 }
 
-.bn-aria-kit .bn-ak-tab {
+.bn-ak-tab {
     display: flex;
     height: 2.5rem;
     user-select: none;
@@ -786,51 +784,51 @@ responsible for the majority of the styling. */
     outline-color: hsl(204 100% 40%);
 }
 
-.bn-aria-kit .bn-ak-tab:hover {
+.bn-ak-tab:hover {
     background-color: hsl(204 4% 0% / 7.5%);
 }
 
-.bn-aria-kit .bn-ak-tab[aria-disabled="true"] {
+.bn-ak-tab[aria-disabled="true"] {
     opacity: 0.5;
 }
 
-.bn-aria-kit .bn-ak-tab[aria-selected="true"] {
+.bn-ak-tab[aria-selected="true"] {
     background-color: hsl(204 100% 40%);
     color: hsl(204 20% 100%);
 }
 
-.bn-aria-kit .bn-ak-tab:hover[aria-selected="true"] {
+.bn-ak-tab:hover[aria-selected="true"] {
     background-color: hsl(204 100% 32%);
 }
 
-.bn-aria-kit .bn-ak-tab[data-focus-visible] {
+.bn-ak-tab[data-focus-visible] {
     outline-style: solid;
 }
 
-.bn-aria-kit .bn-ak-tab:active,
-.bn-aria-kit .bn-ak-tab[data-active] {
+.bn-ak-tab:active,
+.bn-ak-tab[data-active] {
     padding-top: 0.125rem;
 }
 
-.bn-aria-kit .bn-ak-tab:hover:where(.dark, .dark *) {
+.bn-ak-tab:hover:where(.dark, .dark *) {
     background-color: hsl(204 20% 100% / 0.1);
 }
 
-.bn-aria-kit .bn-ak-tab[aria-selected="true"]:where(.dark, .dark *) {
+.bn-ak-tab[aria-selected="true"]:where(.dark, .dark *) {
     background-color: hsl(204 100% 40%);
     color: hsl(204 20% 100%);
 }
 
-.bn-aria-kit .bn-ak-tab:hover[aria-selected="true"]:where(.dark, .dark *) {
+.bn-ak-tab:hover[aria-selected="true"]:where(.dark, .dark *) {
     background-color: hsl(204 100% 32%);
 }
 
-.bn-aria-kit .bn-ak-panels {
+.bn-ak-panels {
     padding: 0.5rem;
 }
 
 /* https://ariakit.org/components/toolbar */
-.bn-aria-kit .bn-ak-button {
+.bn-ak-button {
     --border: rgb(0 0 0/13%);
     --highlight: rgb(255 255 255/20%);
     --shadow: rgb(0 0 0/10%);
@@ -862,7 +860,7 @@ responsible for the majority of the styling. */
     border-radius: 0.25rem;
 }
 
-.bn-aria-kit .bn-ak-button:where(.dark, .dark *) {
+.bn-ak-button:where(.dark, .dark *) {
     --border: rgb(255 255 255/10%);
     --highlight: rgb(255 255 255/5%);
     --shadow: rgb(0 0 0/25%);
@@ -874,24 +872,24 @@ responsible for the majority of the styling. */
             inset 0 1px 0 var(--highlight);
 }
 
-.bn-aria-kit .bn-ak-button:not(:active):hover {
+.bn-ak-button:not(:active):hover {
     --border: rgb(0 0 0/33%);
 }
 
-.bn-aria-kit .bn-ak-button:where(.dark, .dark *):not(:active):hover {
+.bn-ak-button:where(.dark, .dark *):not(:active):hover {
     --border: rgb(255 255 255/25%);
 }
 
-.bn-aria-kit .bn-ak-button[aria-disabled="true"] {
+.bn-ak-button[aria-disabled="true"] {
     opacity: 0.5;
 }
 
-.bn-aria-kit .bn-ak-button[data-focus-visible] {
+.bn-ak-button[data-focus-visible] {
     outline-style: solid;
 }
 
-.bn-aria-kit .bn-ak-button:active,
-.bn-aria-kit .bn-ak-button[data-active] {
+.bn-ak-button:active,
+.bn-ak-button[data-active] {
     padding-top: 0.125rem;
     box-shadow:
             inset 0 0 0 1px var(--border),
@@ -899,43 +897,43 @@ responsible for the majority of the styling. */
 }
 
 @media (min-width: 640px) {
-    .bn-aria-kit .bn-ak-button {
+    .bn-ak-button {
         gap: 0.5rem;
     }
 }
 
-.bn-aria-kit .bn-ak-button:active:where(.dark, .dark *),
-.bn-aria-kit .bn-ak-button[data-active]:where(.dark, .dark *) {
+.bn-ak-button:active:where(.dark, .dark *),
+.bn-ak-button[data-active]:where(.dark, .dark *) {
     box-shadow:
             inset 0 0 0 1px var(--border),
             inset 0 1px 1px 1px var(--shadow);
 }
 
-.bn-aria-kit .bn-ak-secondary {
+.bn-ak-secondary {
     background-color: transparent;
     color: currentColor;
     box-shadow: none;
 }
 
-.bn-aria-kit .bn-ak-secondary:hover {
+.bn-ak-secondary:hover {
     background-color: hsl(204 4% 0% / 0.05);
 }
 
-.bn-aria-kit .bn-ak-secondary:where(.dark, .dark *) {
+.bn-ak-secondary:where(.dark, .dark *) {
     background-color: transparent;
     box-shadow: none;
 }
 
-.bn-aria-kit .bn-ak-secondary:hover:where(.dark, .dark *) {
+.bn-ak-secondary:hover:where(.dark, .dark *) {
     background-color: hsl(204 20% 100% / 0.05);
 }
 
-.bn-aria-kit .bn-ak-secondary:active:where(.dark, .dark *),
-.bn-aria-kit .bn-ak-secondary[data-active]:where(.dark, .dark *) {
+.bn-ak-secondary:active:where(.dark, .dark *),
+.bn-ak-secondary[data-active]:where(.dark, .dark *) {
     box-shadow: none;
 }
 
-.bn-aria-kit .bn-ak-toolbar {
+.bn-ak-toolbar {
     display: flex;
     max-width: 100%;
     align-items: center;
@@ -949,25 +947,25 @@ responsible for the majority of the styling. */
             0 1px 2px -1px rgb(0 0 0 / 0.1);
 }
 
-.bn-aria-kit .bn-ak-toolbar:where(.dark, .dark *) {
+.bn-ak-toolbar:where(.dark, .dark *) {
     background-color: hsl(204 4% 16%);
     box-shadow:
             0 1px 3px 0 rgb(0 0 0 / 0.25),
             0 1px 2px -1px rgb(0 0 0 / 0.1);
 }
 
-.bn-aria-kit .bn-ak-separator {
+.bn-ak-separator {
     height: 2rem;
     border-right-width: 1px;
     border-color: hsl(204 20% 88%);
 }
 
-.bn-aria-kit .bn-ak-separator:where(.dark, .dark *) {
+.bn-ak-separator:where(.dark, .dark *) {
     border-color: hsl(204 4% 28%);
 }
 
 /* https://ariakit.org/components/tooltip */
-.bn-aria-kit .bn-ak-tooltip {
+.bn-ak-tooltip {
     z-index: 50;
     cursor: default;
     border-radius: 0.375rem;
@@ -984,14 +982,14 @@ responsible for the majority of the styling. */
     box-shadow: 0 1px 2px 0 rgb(0 0 0 / 0.05);
 }
 
-.bn-aria-kit .bn-ak-tooltip:where(.dark, .dark *) {
+.bn-ak-tooltip:where(.dark, .dark *) {
     border-color: hsl(204 4% 24%);
     background-color: hsl(204 4% 16%);
     color: white;
     box-shadow: 0 1px 2px 0 rgb(0 0 0 / 0.15);
 }
 
-.bn-aria-kit .bn-ak-link {
+.bn-ak-link {
     font-weight: 500;
     color: hsl(204 100% 35%);
     text-decoration-line: underline;
@@ -999,10 +997,10 @@ responsible for the majority of the styling. */
     text-underline-offset: 0.25em;
 }
 
-.bn-aria-kit .bn-ak-link:hover {
+.bn-ak-link:hover {
     text-decoration-thickness: 3px;
 }
 
-.bn-aria-kit .bn-ak-link:where(.dark, .dark *) {
+.bn-ak-link:where(.dark, .dark *) {
     color: hsl(204 100% 64%);
 }

--- a/packages/ariakit/src/index.tsx
+++ b/packages/ariakit/src/index.tsx
@@ -105,7 +105,7 @@ export const BlockNoteView = <
   return (
     <ComponentsContext.Provider value={components}>
       <BlockNoteViewRaw
-        className={mergeCSSClasses("bn-aria-kit", className || "")}
+        className={mergeCSSClasses("bn-ariakit", className || "")}
         {...rest}
       />
     </ComponentsContext.Provider>

--- a/packages/ariakit/src/index.tsx
+++ b/packages/ariakit/src/index.tsx
@@ -1,4 +1,9 @@
-import { BlockSchema, InlineContentSchema, StyleSchema } from "@blocknote/core";
+import {
+  BlockSchema,
+  InlineContentSchema,
+  mergeCSSClasses,
+  StyleSchema,
+} from "@blocknote/core";
 import {
   BlockNoteViewRaw,
   Components,
@@ -95,9 +100,14 @@ export const BlockNoteView = <
 >(
   props: ComponentProps<typeof BlockNoteViewRaw<BSchema, ISchema, SSchema>>
 ) => {
+  const { className, ...rest } = props;
+
   return (
     <ComponentsContext.Provider value={components}>
-      <BlockNoteViewRaw {...props} />
+      <BlockNoteViewRaw
+        className={mergeCSSClasses("bn-aria-kit", className || "")}
+        {...rest}
+      />
     </ComponentsContext.Provider>
   );
 };

--- a/packages/ariakit/src/style.css
+++ b/packages/ariakit/src/style.css
@@ -5,76 +5,74 @@
 
 @import "./ariakitStyles.css";
 
-.bn-aria-kit .bn-ak-input-wrapper {
+.bn-ak-input-wrapper {
   align-items: center;
   display: flex;
   gap: 0.5rem;
 }
 
-.bn-aria-kit .bn-toolbar .bn-ak-button {
+.bn-toolbar .bn-ak-button {
   width: unset;
 }
 
-.bn-aria-kit .bn-toolbar .bn-ak-button[data-selected] {
+.bn-toolbar .bn-ak-button[data-selected] {
   padding-top: 0.125rem;
   box-shadow: inset 0 0 0 1px var(--border), inset 0 2px 0 var(--border);
 }
 
-.bn-aria-kit .bn-toolbar .bn-ak-button[data-selected]:where(.dark, .dark *) {
+.bn-toolbar .bn-ak-button[data-selected]:where(.dark, .dark *) {
   box-shadow: inset 0 0 0 1px var(--border), inset 0 1px 1px 1px var(--shadow);
 }
 
-.bn-aria-kit .bn-toolbar .bn-ak-popover {
+.bn-toolbar .bn-ak-popover {
   gap: 0.5rem;
 }
 
-.bn-aria-kit .bn-tab-panel {
+.bn-ariakit .bn-tab-panel {
   align-items: center;
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
 }
 
-.bn-aria-kit .bn-file-input {
+.bn-ariakit .bn-file-input {
   max-width: 100%;
 }
 
-.bn-aria-kit .bn-ak-button {
+.bn-ak-button {
   outline-style: none;
 }
 
-.bn-aria-kit .bn-ak-menu-item[aria-selected="true"],
-.bn-aria-kit .bn-ak-menu-item:hover {
+.bn-ak-menu-item[aria-selected="true"], .bn-ak-menu-item:hover {
   background-color: hsl(204 100% 40%);
   color: hsl(204 20% 100%);
 }
 
-.bn-aria-kit .bn-ak-menu-item {
+.bn-ak-menu-item {
   display: flex;
 }
 
-.bn-aria-kit .bn-dropdown {
+.bn-ariakit .bn-dropdown {
   overflow: visible;
 }
 
-.bn-aria-kit .bn-suggestion-menu,
-.bn-aria-kit .bn-color-picker-dropdown {
+.bn-ariakit .bn-suggestion-menu, .bn-ariakit .bn-color-picker-dropdown {
   overflow: scroll;
 }
 
-.bn-aria-kit .bn-ak-suggestion-menu-item-body {
+.bn-ak-suggestion-menu-item-body {
   flex: 1;
 }
 
-.bn-aria-kit .bn-ak-suggestion-menu-item-subtitle {
+.bn-ak-suggestion-menu-item-subtitle {
   font-size: 0.7rem;
 }
 
-.bn-aria-kit .bn-ak-suggestion-menu-item-section[data-position="left"] {
+.bn-ak-suggestion-menu-item-section[data-position="left"] {
   padding: 8px;
 }
 
-.bn-aria-kit .bn-ak-suggestion-menu-item-section[data-position="right"] {
+.bn-ak-suggestion-menu-item-section[data-position="right"] {
   --border: rgb(0 0 0/13%);
   --highlight: rgb(255 255 255/20%);
   --shadow: rgb(0 0 0/10%);
@@ -85,51 +83,50 @@
   padding-inline: 4px;
 }
 
-.bn-aria-kit .bn-side-menu {
+.bn-ariakit .bn-side-menu {
   align-items: center;
   display: flex;
   justify-content: center;
 }
 
-.bn-aria-kit .bn-side-menu .bn-ak-button {
+.bn-side-menu .bn-ak-button {
   height: fit-content;
   padding: 0;
   width: fit-content;
 }
 
-.bn-aria-kit .bn-panel-popover {
+.bn-ariakit .bn-panel-popover {
   background-color: transparent;
   border: none;
   box-shadow: none;
 }
 
-.bn-aria-kit .bn-table-handle {
+.bn-ariakit .bn-table-handle {
   height: fit-content;
   padding: 0;
   width: fit-content;
 }
 
-.bn-aria-kit .bn-side-menu,
-.bn-aria-kit .bn-table-handle {
+.bn-ariakit .bn-side-menu,
+.bn-ariakit .bn-table-handle {
   color: gray;
 }
 
-.bn-aria-kit .bn-ak-button:where(.dark, .dark *) {
+.bn-ak-button:where(.dark, .dark *) {
   color: hsl(204 20% 100%);
 }
 
-.bn-aria-kit .bn-ak-tab,
-.bn-aria-kit .bn-file-input {
+.bn-ak-tab, .bn-ariakit .bn-file-input {
   background-color: transparent;
   color: black;
 }
 
-.bn-aria-kit .bn-ak-tab:where(.dark, .dark *),
-.bn-aria-kit .bn-file-input:where(.dark, .dark *) {
+.bn-ak-tab:where(.dark, .dark *),
+.bn-ariakit .bn-file-input:where(.dark, .dark *) {
   color: white;
 }
 
-.bn-aria-kit .bn-ak-tooltip {
+.bn-ak-tooltip {
   align-items: center;
   display: flex;
   flex-direction: column;

--- a/packages/ariakit/src/style.css
+++ b/packages/ariakit/src/style.css
@@ -5,76 +5,76 @@
 
 @import "./ariakitStyles.css";
 
-.bn-ak-input-wrapper {
+.bn-aria-kit .bn-ak-input-wrapper {
   align-items: center;
   display: flex;
   gap: 0.5rem;
 }
 
-.bn-toolbar .bn-ak-button {
+.bn-aria-kit .bn-toolbar .bn-ak-button {
   width: unset;
 }
 
-.bn-toolbar .bn-ak-button[data-selected] {
+.bn-aria-kit .bn-toolbar .bn-ak-button[data-selected] {
   padding-top: 0.125rem;
   box-shadow: inset 0 0 0 1px var(--border), inset 0 2px 0 var(--border);
 }
 
-.bn-toolbar .bn-ak-button[data-selected]:where(.dark, .dark *) {
+.bn-aria-kit .bn-toolbar .bn-ak-button[data-selected]:where(.dark, .dark *) {
   box-shadow: inset 0 0 0 1px var(--border), inset 0 1px 1px 1px var(--shadow);
 }
 
-.bn-toolbar .bn-ak-popover {
+.bn-aria-kit .bn-toolbar .bn-ak-popover {
   gap: 0.5rem;
 }
 
-.bn-tab-panel {
+.bn-aria-kit .bn-tab-panel {
   align-items: center;
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
 }
 
-.bn-file-input {
+.bn-aria-kit .bn-file-input {
   max-width: 100%;
 }
 
-.bn-ak-button {
+.bn-aria-kit .bn-ak-button {
   outline-style: none;
 }
 
-.bn-ak-menu-item[aria-selected="true"],
-.bn-ak-menu-item:hover {
+.bn-aria-kit .bn-ak-menu-item[aria-selected="true"],
+.bn-aria-kit .bn-ak-menu-item:hover {
   background-color: hsl(204 100% 40%);
   color: hsl(204 20% 100%);
 }
 
-.bn-ak-menu-item {
+.bn-aria-kit .bn-ak-menu-item {
   display: flex;
 }
 
-.bn-dropdown {
+.bn-aria-kit .bn-dropdown {
   overflow: visible;
 }
 
-.bn-suggestion-menu,
-.bn-color-picker-dropdown {
+.bn-aria-kit .bn-suggestion-menu,
+.bn-aria-kit .bn-color-picker-dropdown {
   overflow: scroll;
 }
 
-.bn-ak-suggestion-menu-item-body {
+.bn-aria-kit .bn-ak-suggestion-menu-item-body {
   flex: 1;
 }
 
-.bn-ak-suggestion-menu-item-subtitle {
+.bn-aria-kit .bn-ak-suggestion-menu-item-subtitle {
   font-size: 0.7rem;
 }
 
-.bn-ak-suggestion-menu-item-section[data-position="left"] {
+.bn-aria-kit .bn-ak-suggestion-menu-item-section[data-position="left"] {
   padding: 8px;
 }
 
-.bn-ak-suggestion-menu-item-section[data-position="right"] {
+.bn-aria-kit .bn-ak-suggestion-menu-item-section[data-position="right"] {
   --border: rgb(0 0 0/13%);
   --highlight: rgb(255 255 255/20%);
   --shadow: rgb(0 0 0/10%);
@@ -85,51 +85,51 @@
   padding-inline: 4px;
 }
 
-.bn-side-menu {
+.bn-aria-kit .bn-side-menu {
   align-items: center;
   display: flex;
   justify-content: center;
 }
 
-.bn-side-menu .bn-ak-button {
+.bn-aria-kit .bn-side-menu .bn-ak-button {
   height: fit-content;
   padding: 0;
   width: fit-content;
 }
 
-.bn-panel-popover {
+.bn-aria-kit .bn-panel-popover {
   background-color: transparent;
   border: none;
   box-shadow: none;
 }
 
-.bn-table-handle {
+.bn-aria-kit .bn-table-handle {
   height: fit-content;
   padding: 0;
   width: fit-content;
 }
 
-.bn-side-menu,
-.bn-table-handle {
+.bn-aria-kit .bn-side-menu,
+.bn-aria-kit .bn-table-handle {
   color: gray;
 }
 
-.bn-ak-button:where(.dark, .dark *) {
+.bn-aria-kit .bn-ak-button:where(.dark, .dark *) {
   color: hsl(204 20% 100%);
 }
 
-.bn-ak-tab,
-.bn-file-input {
+.bn-aria-kit .bn-ak-tab,
+.bn-aria-kit .bn-file-input {
   background-color: transparent;
   color: black;
 }
 
-.bn-ak-tab:where(.dark, .dark *),
-.bn-file-input:where(.dark, .dark *) {
+.bn-aria-kit .bn-ak-tab:where(.dark, .dark *),
+.bn-aria-kit .bn-file-input:where(.dark, .dark *) {
   color: white;
 }
 
-.bn-ak-tooltip {
+.bn-aria-kit .bn-ak-tooltip {
   align-items: center;
   display: flex;
   flex-direction: column;

--- a/packages/mantine/src/index.tsx
+++ b/packages/mantine/src/index.tsx
@@ -1,4 +1,9 @@
-import { BlockSchema, InlineContentSchema, StyleSchema } from "@blocknote/core";
+import {
+  BlockSchema,
+  InlineContentSchema,
+  mergeCSSClasses,
+  StyleSchema,
+} from "@blocknote/core";
 import {
   BlockNoteViewRaw,
   Components,
@@ -122,7 +127,7 @@ export const BlockNoteView = <
         };
   }
 ) => {
-  const { theme, ...rest } = props;
+  const { className, theme, ...rest } = props;
 
   const existingContext = useBlockNoteContext();
   const systemColorScheme = usePrefersColorScheme();
@@ -160,12 +165,13 @@ export const BlockNoteView = <
       {/* as proposed here:  https://github.com/orgs/mantinedev/discussions/5685 */}
       <MantineProvider
         theme={mantineTheme}
-        cssVariablesSelector=".bn-container"
+        cssVariablesSelector=".bn-mantine"
         // This gets the element to set `data-mantine-color-scheme` on. Since we
         // don't need this attribute (we use our own theming API), we return
         // undefined here.
         getRootElement={() => undefined}>
         <BlockNoteViewRaw
+          className={mergeCSSClasses("bn-mantine", className || "")}
           theme={typeof theme === "object" ? undefined : theme}
           {...rest}
           ref={ref}

--- a/packages/mantine/src/mantineStyles.css
+++ b/packages/mantine/src/mantineStyles.css
@@ -89,50 +89,50 @@
  (src: https://github.com/mantinedev/mantine/blob/master/packages/%40mantine/core/src/core/MantineProvider/global.css)
  but with styles set on `body` and `html` instead set on `bn-container`, as
  well as other minor changes. */
-.bn-container *, .bn-container :after, .bn-container :before {
+.bn-mantine *, .bn-mantine :after, .bn-mantine :before {
     box-sizing: border-box
 }
 
-.bn-container button,
-.bn-container select {
+.bn-mantine button,
+.bn-mantine select {
     text-transform: none
 }
 
 @media screen and (max-device-width: 500px) {
-    .bn-container {
+    .bn-mantine {
         -webkit-text-size-adjust: 100%
     }
 }
 
 @media (prefers-reduced-motion: reduce) {
-    .bn-container [data-respect-reduced-motion] [data-reduce-motion] {
+    .bn-mantine [data-respect-reduced-motion] [data-reduce-motion] {
         animation: none;
         transition: none
     }
 }
 
-.bn-container [data-mantine-color-scheme=dark] .mantine-dark-hidden, .bn-container [data-mantine-color-scheme=light] .mantine-light-hidden {
+.bn-mantine [data-mantine-color-scheme=dark] .mantine-dark-hidden, .bn-mantine [data-mantine-color-scheme=light] .mantine-light-hidden {
     display: none
 }
 
-.bn-container .mantine-focus-auto:focus-visible {
+.bn-mantine .mantine-focus-auto:focus-visible {
     outline: calc(.125rem * var(--mantine-scale)) solid var(--mantine-primary-color-filled);
     outline-offset: calc(.125rem * var(--mantine-scale))
 }
 
-.bn-container .mantine-focus-always:focus {
+.bn-mantine .mantine-focus-always:focus {
     outline: calc(.125rem * var(--mantine-scale)) solid var(--mantine-primary-color-filled);
     outline-offset: calc(.125rem * var(--mantine-scale))
 }
 
-.bn-container .mantine-focus-never:focus {
+.bn-mantine .mantine-focus-never:focus {
     outline: none
 }
 
-.bn-container .mantine-active:active {
+.bn-mantine .mantine-active:active {
     transform: translateY(calc(.0625rem * var(--mantine-scale)))
 }
 
-.bn-container[dir=rtl] .mantine-rotate-rtl {
+.bn-mantine[dir=rtl] .mantine-rotate-rtl {
     transform: rotate(180deg)
 }

--- a/packages/mantine/src/style.css
+++ b/packages/mantine/src/style.css
@@ -4,13 +4,13 @@
 /* Mantine base styles*/
 
 /* Mantine Badge component base styles */
-.bn-container .mantine-Badge-root {
+.bn-mantine .mantine-Badge-root {
   background-color: var(--bn-colors-tooltip-background);
   color: var(--bn-colors-tooltip-text);
 }
 
 /* Mantine FileInput component base styles */
-.bn-container .mantine-FileInput-input {
+.bn-mantine .mantine-FileInput-input {
   align-items: center;
   background-color: var(--bn-colors-menu-background);
   border: none;
@@ -21,22 +21,22 @@
   justify-content: center;
 }
 
-.bn-container .mantine-FileInput-input:hover {
+.bn-mantine .mantine-FileInput-input:hover {
   background-color: var(--bn-colors-hovered-background);
 }
 
-.bn-container .mantine-FileInput-wrapper {
+.bn-mantine .mantine-FileInput-wrapper {
   border: solid var(--bn-colors-border) 1px;
   border-radius: 4px;
 }
 
-.bn-container .mantine-InputPlaceholder-placeholder {
+.bn-mantine .mantine-InputPlaceholder-placeholder {
   color: var(--bn-colors-menu-text);
   font-weight: 600;
 }
 
 /* Mantine Menu component base styles */
-.bn-container .mantine-Menu-dropdown {
+.bn-mantine .mantine-Menu-dropdown {
   background-color: var(--bn-colors-menu-background);
   border: var(--bn-border);
   border-radius: var(--bn-border-radius-medium);
@@ -47,27 +47,27 @@
   overflow: auto;
 }
 
-.bn-container .mantine-Menu-label {
+.bn-mantine .mantine-Menu-label {
   background-color: var(--bn-colors-menu-background);
   color: var(--bn-colors-menu-text);
 }
 
-.bn-container .mantine-Menu-item {
+.bn-mantine .mantine-Menu-item {
   background-color: var(--bn-colors-menu-background);
   border: none;
   border-radius: var(--bn-border-radius-small);
   color: var(--bn-colors-menu-text);
 }
 
-.bn-container .mantine-Menu-item[aria-selected="true"],
-.bn-container .mantine-Menu-item:hover {
+.bn-mantine .mantine-Menu-item[aria-selected="true"],
+.bn-mantine .mantine-Menu-item:hover {
   background-color: var(--bn-colors-hovered-background);
   border: none;
   color: var(--bn-colors-hovered-text);
 }
 
 /* Mantine Popover component base styles */
-.bn-container .mantine-Popover-dropdown {
+.bn-mantine .mantine-Popover-dropdown {
   background-color: transparent;
   border: none;
   border-radius: 0;
@@ -76,38 +76,38 @@
 }
 
 /* Mantine Tabs component base styles */
-.bn-container .mantine-Tabs-root {
+.bn-mantine .mantine-Tabs-root {
   width: 100%;
   background-color: var(--bn-colors-menu-background);
 }
 
-.bn-container .mantine-Tabs-list:before {
+.bn-mantine .mantine-Tabs-list:before {
   border-color: var(--bn-colors-hovered-background);
 }
 
-.bn-container .mantine-Tabs-tab {
+.bn-mantine .mantine-Tabs-tab {
   color: var(--bn-colors-menu-text);
   border-color: var(--bn-colors-hovered-background);
 }
 
-.bn-container .mantine-Tabs-tab:hover {
+.bn-mantine .mantine-Tabs-tab:hover {
   background-color: var(--bn-colors-hovered-background);
   border-color: var(--bn-colors-hovered-background);
   color: var(--bn-colors-hovered-text);
 }
 
-.bn-container .mantine-Tabs-tab[data-active],
-.bn-container .mantine-Tabs-tab[data-active]:hover {
+.bn-mantine .mantine-Tabs-tab[data-active],
+.bn-mantine .mantine-Tabs-tab[data-active]:hover {
   border-color: var(--bn-colors-menu-text);
   color: var(--bn-colors-menu-text);
 }
 
-.bn-container .mantine-Tabs-panel {
+.bn-mantine .mantine-Tabs-panel {
   padding: 8px;
 }
 
 /* Mantine TextInput component base styles */
-.bn-container .mantine-TextInput-input {
+.bn-mantine .mantine-TextInput-input {
   background-color: var(--bn-colors-menu-background);
   border: solid var(--bn-colors-border) 1px;
   border-radius: 4px;
@@ -116,7 +116,7 @@
 }
 
 /* Mantine Tooltip component base styles */
-.bn-container .mantine-Tooltip-tooltip {
+.bn-mantine .mantine-Tooltip-tooltip {
   background-color: transparent;
   border: none;
   border-radius: 0;
@@ -127,12 +127,12 @@
 /* UI element styling */
 
 /* Select styling */
-.bn-select {
+.bn-mantine .bn-select {
   overflow: auto;
 }
 
 /* Toolbar styling */
-.bn-toolbar {
+.bn-mantine .bn-toolbar {
   background-color: var(--bn-colors-menu-background);
   border: var(--bn-border);
   border-radius: var(--bn-border-radius-medium);
@@ -143,49 +143,49 @@
   width: fit-content;
 }
 
-.bn-toolbar:empty {
+.bn-mantine .bn-toolbar:empty {
   display: none;
 }
 
-.bn-toolbar .mantine-Button-root,
-.bn-toolbar .mantine-ActionIcon-root {
+.bn-mantine .bn-toolbar .mantine-Button-root,
+.bn-mantine .bn-toolbar .mantine-ActionIcon-root {
   background-color: var(--bn-colors-menu-background);
   border: none;
   border-radius: var(--bn-border-radius-small);
   color: var(--bn-colors-menu-text);
 }
 
-.bn-toolbar .mantine-Button-root:hover,
-.bn-toolbar .mantine-ActionIcon-root:hover {
+.bn-mantine .bn-toolbar .mantine-Button-root:hover,
+.bn-mantine .bn-toolbar .mantine-ActionIcon-root:hover {
   background-color: var(--bn-colors-hovered-background);
   border: none;
   color: var(--bn-colors-hovered-text);
 }
 
-.bn-toolbar .mantine-Button-root[data-selected],
-.bn-toolbar .mantine-ActionIcon-root[data-selected] {
+.bn-mantine .bn-toolbar .mantine-Button-root[data-selected],
+.bn-mantine .bn-toolbar .mantine-ActionIcon-root[data-selected] {
   background-color: var(--bn-colors-selected-background);
   border: none;
   color: var(--bn-colors-selected-text);
 }
 
-.bn-toolbar .mantine-Button-root[data-disabled],
-.bn-toolbar .mantine-ActionIcon-root[data-disabled] {
+.bn-mantine .bn-toolbar .mantine-Button-root[data-disabled],
+.bn-mantine .bn-toolbar .mantine-ActionIcon-root[data-disabled] {
   background-color: var(--bn-colors-disabled-background);
   border: none;
   color: var(--bn-colors-disabled-text);
 }
 
-.bn-toolbar .mantine-Menu-item {
+.bn-mantine .bn-toolbar .mantine-Menu-item {
   font-size: 12px;
   height: 30px;
 }
 
-.bn-toolbar .mantine-Menu-item:hover {
+.bn-mantine .bn-toolbar .mantine-Menu-item:hover {
   background-color: var(--bn-colors-hovered-background);
 }
 
-.bn-container .bn-form-popover {
+.bn-mantine .bn-form-popover {
   background-color: var(--bn-colors-menu-background);
   border: var(--bn-border);
   border-radius: var(--bn-border-radius-medium);
@@ -196,36 +196,36 @@
   padding: 2px;
 }
 
-.bn-form-popover .mantine-TextInput-root,
-.bn-form-popover .mantine-FileInput-root {
+.bn-mantine .bn-form-popover .mantine-TextInput-root,
+.bn-mantine .bn-form-popover .mantine-FileInput-root {
   width: 300px;
 }
 
-.bn-form-popover .mantine-TextInput-wrapper,
-.bn-form-popover .mantine-FileInput-wrapper {
+.bn-mantine .bn-form-popover .mantine-TextInput-wrapper,
+.bn-mantine .bn-form-popover .mantine-FileInput-wrapper {
   padding: 0;
   border-radius: 4px;
 }
 
-.bn-form-popover .mantine-TextInput-wrapper:hover {
+.bn-mantine .bn-form-popover .mantine-TextInput-wrapper:hover {
   background-color: var(--bn-colors-hovered-background);
 }
 
-.bn-form-popover .mantine-TextInput-input,
-.bn-form-popover .mantine-FileInput-input {
+.bn-mantine .bn-form-popover .mantine-TextInput-input,
+.bn-mantine .bn-form-popover .mantine-FileInput-input {
   border: none;
   font-size: 12px;
 }
 
-.bn-form-popover .mantine-FileInput-input:hover {
+.bn-mantine .bn-form-popover .mantine-FileInput-input:hover {
   background-color: var(--bn-colors-hovered-background);
 }
 
-.bn-form-popover .mantine-FileInput-section[data-position="left"] {
+.bn-mantine .bn-form-popover .mantine-FileInput-section[data-position="left"] {
   color: var(--bn-colors-menu-text);
 }
 
-.bn-form-popover .mantine-FileInput-placeholder {
+.bn-mantine .bn-form-popover .mantine-FileInput-placeholder {
   color: var(--bn-colors-menu-text);
 }
 
@@ -235,7 +235,7 @@
 /* Unfortunately necessary, as we can't use a Menu.Dropdown component on its
  own. */
 /* https://github.com/mantinedev/mantine/blob/e3e3bb834de1f2f75a27dbc757dc0a2fc6a6cba8/packages/%40mantine/core/src/components/Menu/Menu.module.css */
-.bn-suggestion-menu {
+.bn-mantine .bn-suggestion-menu {
   max-height: 100%;
   position: relative;
   box-shadow: var(--mantine-shadow-md);
@@ -245,7 +245,7 @@
   padding: 4px;
 }
 
-.bn-suggestion-menu-label {
+.bn-mantine .bn-suggestion-menu-label {
   color: var(--mantine-color-dimmed);
   font-weight: 500;
   font-size: var(--mantine-font-size-xs);
@@ -253,7 +253,7 @@
   cursor: default;
 }
 
-.bn-suggestion-menu-item {
+.bn-mantine .bn-suggestion-menu-item {
   font-size: var(--mantine-font-size-sm);
   width: 100%;
   padding: calc(var(--mantine-spacing-xs) / 1.5) var(--mantine-spacing-sm);
@@ -271,11 +271,11 @@
 }
 
 /* Additional Suggestion Menu styling*/
-.bn-mt-suggestion-menu-item-body {
+.bn-mantine .bn-mt-suggestion-menu-item-body {
   flex: 1;
 }
 
-.bn-mt-suggestion-menu-item-section {
+.bn-mantine .bn-mt-suggestion-menu-item-section {
   display: flex;
   justify-content: center;
   align-items: center;
@@ -289,7 +289,7 @@
   }
 }
 
-.bn-suggestion-menu {
+.bn-mantine .bn-suggestion-menu {
   background-color: var(--bn-colors-menu-background);
   border: var(--bn-border);
   border-radius: var(--bn-border-radius-medium);
@@ -300,27 +300,27 @@
   padding: 2px;
 }
 
-.bn-suggestion-menu-item {
+.bn-mantine .bn-suggestion-menu-item {
   cursor: pointer;
   height: 52px;
 }
 
-.bn-suggestion-menu-item[aria-selected="true"],
-.bn-suggestion-menu-item:hover {
+.bn-mantine .bn-suggestion-menu-item[aria-selected="true"],
+.bn-mantine .bn-suggestion-menu-item:hover {
   background-color: var(--bn-colors-hovered-background);
 }
 
-.bn-mt-suggestion-menu-item-section {
+.bn-mantine .bn-mt-suggestion-menu-item-section {
   color: var(--bn-colors-tooltip-text);
 }
 
-.bn-mt-suggestion-menu-item-section[data-position="left"] {
+.bn-mantine .bn-mt-suggestion-menu-item-section[data-position="left"] {
   background-color: var(--bn-colors-tooltip-background);
   border-radius: var(--bn-border-radius-small);
   padding: 8px;
 }
 
-.bn-mt-suggestion-menu-item-body {
+.bn-mantine .bn-mt-suggestion-menu-item-body {
   align-items: stretch;
   display: flex;
   flex: 1;
@@ -329,7 +329,7 @@
   padding-right: 16px;
 }
 
-.bn-mt-suggestion-menu-item-title {
+.bn-mantine .bn-mt-suggestion-menu-item-title {
   color: var(--bn-colors-menu-text);
   line-height: 20px;
   font-weight: 500;
@@ -338,7 +338,7 @@
   padding: 0;
 }
 
-.bn-mt-suggestion-menu-item-subtitle {
+.bn-mantine .bn-mt-suggestion-menu-item-subtitle {
   color: var(--bn-colors-menu-text);
   line-height: 16px;
   font-size: 10px;
@@ -346,58 +346,58 @@
   padding: 0;
 }
 
-.bn-suggestion-menu-label {
+.bn-mantine .bn-suggestion-menu-label {
   color: var(--bn-colors-hovered-text);
 }
 
-.bn-suggestion-menu-loader {
+.bn-mantine .bn-suggestion-menu-loader {
   height: 20px;
   width: 100%;
 }
 
-.bn-suggestion-menu-loader span {
+.bn-mantine .bn-suggestion-menu-loader span {
   background-color: var(--bn-colors-side-menu);
 }
 
 /* Side Menu styling */
-.bn-side-menu {
+.bn-mantine .bn-side-menu {
   background-color: transparent;
   overflow: visible;
 }
 
-.bn-side-menu .mantine-Menu-item,
-.bn-table-handle-menu .mantine-Menu-item {
+.bn-mantine .bn-side-menu .mantine-Menu-item,
+.bn-mantine .bn-table-handle-menu .mantine-Menu-item {
   font-size: 12px;
   height: 30px;
 }
 
-.bn-side-menu .mantine-UnstyledButton-root:not(.mantine-Menu-item) {
+.bn-mantine .bn-side-menu .mantine-UnstyledButton-root:not(.mantine-Menu-item) {
   background-color: transparent;
 }
 
-.bn-side-menu .mantine-UnstyledButton-root:hover {
+.bn-mantine .bn-side-menu .mantine-UnstyledButton-root:hover {
   background-color: var(--bn-colors-hovered-background);
 }
 
-.bn-side-menu .mantine-UnstyledButton-root:not(.mantine-Menu-item) svg {
+.bn-mantine .bn-side-menu .mantine-UnstyledButton-root:not(.mantine-Menu-item) svg {
   background-color: transparent;
   color: var(--bn-colors-side-menu);
   height: 22px;
   width: 22px;
 }
 
-.bn-side-menu > [draggable="true"] {
+.bn-mantine .bn-side-menu > [draggable="true"] {
   display: flex;
 }
 
-.bn-side-menu .mantine-Menu-dropdown {
+.bn-mantine .bn-side-menu .mantine-Menu-dropdown {
   min-width: 100px;
   padding: 2px;
   position: absolute;
 }
 
 /* Image Panel styling*/
-.bn-panel {
+.bn-mantine .bn-panel {
   background-color: var(--bn-colors-menu-background);
   border: var(--bn-border);
   border-radius: var(--bn-border-radius-medium);
@@ -406,7 +406,7 @@
   width: 500px;
 }
 
-.bn-panel .bn-tab-panel {
+.bn-mantine .bn-panel .bn-tab-panel {
   align-items: center;
   display: flex;
   flex-direction: column;
@@ -414,12 +414,12 @@
   width: 100%;
 }
 
-.bn-panel .mantine-TextInput-root,
-.bn-panel .mantine-FileInput-root {
+.bn-mantine .bn-panel .mantine-TextInput-root,
+.bn-mantine .bn-panel .mantine-FileInput-root {
   width: 100%;
 }
 
-.bn-panel .mantine-Button-root {
+.bn-mantine .bn-panel .mantine-Button-root {
   background-color: var(--bn-colors-menu-background);
   border: solid var(--bn-colors-border) 1px;
   border-radius: var(--bn-border-radius-small);
@@ -428,16 +428,16 @@
   width: 60%;
 }
 
-.bn-panel .mantine-Button-root:hover {
+.bn-mantine .bn-panel .mantine-Button-root:hover {
   background-color: var(--bn-colors-hovered-background);
 }
 
-.bn-panel.mantine-Text-root {
+.bn-mantine .bn-panel.mantine-Text-root {
   text-align: center;
 }
 
 /* Table Handle styling */
-.bn-table-handle {
+.bn-mantine .bn-table-handle {
   align-items: center;
   background-color: var(--bn-colors-menu-background);
   border: var(--bn-border);
@@ -452,22 +452,22 @@
   padding: 0;
 }
 
-.bn-table-handle svg {
+.bn-mantine .bn-table-handle svg {
   margin-inline: -4px;
 }
 
-.bn-table-handle:hover,
-.bn-table-handle-dragging {
+.bn-mantine .bn-table-handle:hover,
+.bn-mantine .bn-table-handle-dragging {
   background-color: var(--bn-colors-hovered-background);
 }
 
 /* Drag Handle & Table Handle Menu styling */
-.bn-container .bn-drag-handle-menu {
+.bn-mantine .bn-drag-handle-menu {
   overflow: visible;
 }
 
 /* Tooltip styling */
-.bn-tooltip {
+.bn-mantine .bn-tooltip {
   background-color: var(--bn-colors-tooltip-background);
   border: var(--bn-border);
   border-radius: var(--bn-border-radius-medium);
@@ -478,7 +478,7 @@
 }
 
 /* Additional menu styles */
-.bn-tick-space {
+.bn-mantine .bn-tick-space {
   padding: 0;
   width: 20px;
 }

--- a/packages/mantine/src/style.css
+++ b/packages/mantine/src/style.css
@@ -4,13 +4,13 @@
 /* Mantine base styles*/
 
 /* Mantine Badge component base styles */
-.bn-mantine .mantine-Badge-root {
+.mantine-Badge-root {
   background-color: var(--bn-colors-tooltip-background);
   color: var(--bn-colors-tooltip-text);
 }
 
 /* Mantine FileInput component base styles */
-.bn-mantine .mantine-FileInput-input {
+.mantine-FileInput-input {
   align-items: center;
   background-color: var(--bn-colors-menu-background);
   border: none;
@@ -21,22 +21,22 @@
   justify-content: center;
 }
 
-.bn-mantine .mantine-FileInput-input:hover {
+.mantine-FileInput-input:hover {
   background-color: var(--bn-colors-hovered-background);
 }
 
-.bn-mantine .mantine-FileInput-wrapper {
+.mantine-FileInput-wrapper {
   border: solid var(--bn-colors-border) 1px;
   border-radius: 4px;
 }
 
-.bn-mantine .mantine-InputPlaceholder-placeholder {
+.mantine-InputPlaceholder-placeholder {
   color: var(--bn-colors-menu-text);
   font-weight: 600;
 }
 
 /* Mantine Menu component base styles */
-.bn-mantine .mantine-Menu-dropdown {
+.mantine-Menu-dropdown {
   background-color: var(--bn-colors-menu-background);
   border: var(--bn-border);
   border-radius: var(--bn-border-radius-medium);
@@ -47,27 +47,27 @@
   overflow: auto;
 }
 
-.bn-mantine .mantine-Menu-label {
+.mantine-Menu-label {
   background-color: var(--bn-colors-menu-background);
   color: var(--bn-colors-menu-text);
 }
 
-.bn-mantine .mantine-Menu-item {
+.mantine-Menu-item {
   background-color: var(--bn-colors-menu-background);
   border: none;
   border-radius: var(--bn-border-radius-small);
   color: var(--bn-colors-menu-text);
 }
 
-.bn-mantine .mantine-Menu-item[aria-selected="true"],
-.bn-mantine .mantine-Menu-item:hover {
+.mantine-Menu-item[aria-selected="true"],
+.mantine-Menu-item:hover {
   background-color: var(--bn-colors-hovered-background);
   border: none;
   color: var(--bn-colors-hovered-text);
 }
 
 /* Mantine Popover component base styles */
-.bn-mantine .mantine-Popover-dropdown {
+.mantine-Popover-dropdown {
   background-color: transparent;
   border: none;
   border-radius: 0;
@@ -76,38 +76,38 @@
 }
 
 /* Mantine Tabs component base styles */
-.bn-mantine .mantine-Tabs-root {
+.mantine-Tabs-root {
   width: 100%;
   background-color: var(--bn-colors-menu-background);
 }
 
-.bn-mantine .mantine-Tabs-list:before {
+.mantine-Tabs-list:before {
   border-color: var(--bn-colors-hovered-background);
 }
 
-.bn-mantine .mantine-Tabs-tab {
+.mantine-Tabs-tab {
   color: var(--bn-colors-menu-text);
   border-color: var(--bn-colors-hovered-background);
 }
 
-.bn-mantine .mantine-Tabs-tab:hover {
+.mantine-Tabs-tab:hover {
   background-color: var(--bn-colors-hovered-background);
   border-color: var(--bn-colors-hovered-background);
   color: var(--bn-colors-hovered-text);
 }
 
-.bn-mantine .mantine-Tabs-tab[data-active],
-.bn-mantine .mantine-Tabs-tab[data-active]:hover {
+.mantine-Tabs-tab[data-active],
+.mantine-Tabs-tab[data-active]:hover {
   border-color: var(--bn-colors-menu-text);
   color: var(--bn-colors-menu-text);
 }
 
-.bn-mantine .mantine-Tabs-panel {
+.mantine-Tabs-panel {
   padding: 8px;
 }
 
 /* Mantine TextInput component base styles */
-.bn-mantine .mantine-TextInput-input {
+.mantine-TextInput-input {
   background-color: var(--bn-colors-menu-background);
   border: solid var(--bn-colors-border) 1px;
   border-radius: 4px;
@@ -116,7 +116,7 @@
 }
 
 /* Mantine Tooltip component base styles */
-.bn-mantine .mantine-Tooltip-tooltip {
+.mantine-Tooltip-tooltip {
   background-color: transparent;
   border: none;
   border-radius: 0;
@@ -147,41 +147,41 @@
   display: none;
 }
 
-.bn-mantine .bn-toolbar .mantine-Button-root,
-.bn-mantine .bn-toolbar .mantine-ActionIcon-root {
+.bn-toolbar .mantine-Button-root,
+.bn-toolbar .mantine-ActionIcon-root {
   background-color: var(--bn-colors-menu-background);
   border: none;
   border-radius: var(--bn-border-radius-small);
   color: var(--bn-colors-menu-text);
 }
 
-.bn-mantine .bn-toolbar .mantine-Button-root:hover,
-.bn-mantine .bn-toolbar .mantine-ActionIcon-root:hover {
+.bn-toolbar .mantine-Button-root:hover,
+.bn-toolbar .mantine-ActionIcon-root:hover {
   background-color: var(--bn-colors-hovered-background);
   border: none;
   color: var(--bn-colors-hovered-text);
 }
 
-.bn-mantine .bn-toolbar .mantine-Button-root[data-selected],
-.bn-mantine .bn-toolbar .mantine-ActionIcon-root[data-selected] {
+.bn-toolbar .mantine-Button-root[data-selected],
+.bn-toolbar .mantine-ActionIcon-root[data-selected] {
   background-color: var(--bn-colors-selected-background);
   border: none;
   color: var(--bn-colors-selected-text);
 }
 
-.bn-mantine .bn-toolbar .mantine-Button-root[data-disabled],
-.bn-mantine .bn-toolbar .mantine-ActionIcon-root[data-disabled] {
+.bn-toolbar .mantine-Button-root[data-disabled],
+.bn-toolbar .mantine-ActionIcon-root[data-disabled] {
   background-color: var(--bn-colors-disabled-background);
   border: none;
   color: var(--bn-colors-disabled-text);
 }
 
-.bn-mantine .bn-toolbar .mantine-Menu-item {
+.bn-toolbar .mantine-Menu-item {
   font-size: 12px;
   height: 30px;
 }
 
-.bn-mantine .bn-toolbar .mantine-Menu-item:hover {
+.bn-toolbar .mantine-Menu-item:hover {
   background-color: var(--bn-colors-hovered-background);
 }
 
@@ -196,36 +196,36 @@
   padding: 2px;
 }
 
-.bn-mantine .bn-form-popover .mantine-TextInput-root,
-.bn-mantine .bn-form-popover .mantine-FileInput-root {
+.bn-form-popover .mantine-TextInput-root,
+.bn-form-popover .mantine-FileInput-root {
   width: 300px;
 }
 
-.bn-mantine .bn-form-popover .mantine-TextInput-wrapper,
-.bn-mantine .bn-form-popover .mantine-FileInput-wrapper {
+.bn-form-popover .mantine-TextInput-wrapper,
+.bn-form-popover .mantine-FileInput-wrapper {
   padding: 0;
   border-radius: 4px;
 }
 
-.bn-mantine .bn-form-popover .mantine-TextInput-wrapper:hover {
+.bn-form-popover .mantine-TextInput-wrapper:hover {
   background-color: var(--bn-colors-hovered-background);
 }
 
-.bn-mantine .bn-form-popover .mantine-TextInput-input,
-.bn-mantine .bn-form-popover .mantine-FileInput-input {
+.bn-form-popover .mantine-TextInput-input,
+.bn-form-popover .mantine-FileInput-input {
   border: none;
   font-size: 12px;
 }
 
-.bn-mantine .bn-form-popover .mantine-FileInput-input:hover {
+.bn-form-popover .mantine-FileInput-input:hover {
   background-color: var(--bn-colors-hovered-background);
 }
 
-.bn-mantine .bn-form-popover .mantine-FileInput-section[data-position="left"] {
+.bn-form-popover .mantine-FileInput-section[data-position="left"] {
   color: var(--bn-colors-menu-text);
 }
 
-.bn-mantine .bn-form-popover .mantine-FileInput-placeholder {
+.bn-form-popover .mantine-FileInput-placeholder {
   color: var(--bn-colors-menu-text);
 }
 
@@ -271,11 +271,11 @@
 }
 
 /* Additional Suggestion Menu styling*/
-.bn-mantine .bn-mt-suggestion-menu-item-body {
+.bn-mt-suggestion-menu-item-body {
   flex: 1;
 }
 
-.bn-mantine .bn-mt-suggestion-menu-item-section {
+.bn-mt-suggestion-menu-item-section {
   display: flex;
   justify-content: center;
   align-items: center;
@@ -310,17 +310,17 @@
   background-color: var(--bn-colors-hovered-background);
 }
 
-.bn-mantine .bn-mt-suggestion-menu-item-section {
+.bn-mt-suggestion-menu-item-section {
   color: var(--bn-colors-tooltip-text);
 }
 
-.bn-mantine .bn-mt-suggestion-menu-item-section[data-position="left"] {
+.bn-mt-suggestion-menu-item-section[data-position="left"] {
   background-color: var(--bn-colors-tooltip-background);
   border-radius: var(--bn-border-radius-small);
   padding: 8px;
 }
 
-.bn-mantine .bn-mt-suggestion-menu-item-body {
+.bn-mt-suggestion-menu-item-body {
   align-items: stretch;
   display: flex;
   flex: 1;
@@ -329,7 +329,7 @@
   padding-right: 16px;
 }
 
-.bn-mantine .bn-mt-suggestion-menu-item-title {
+.bn-mt-suggestion-menu-item-title {
   color: var(--bn-colors-menu-text);
   line-height: 20px;
   font-weight: 500;
@@ -338,7 +338,7 @@
   padding: 0;
 }
 
-.bn-mantine .bn-mt-suggestion-menu-item-subtitle {
+.bn-mt-suggestion-menu-item-subtitle {
   color: var(--bn-colors-menu-text);
   line-height: 16px;
   font-size: 10px;
@@ -365,21 +365,21 @@
   overflow: visible;
 }
 
-.bn-mantine .bn-side-menu .mantine-Menu-item,
-.bn-mantine .bn-table-handle-menu .mantine-Menu-item {
+.bn-side-menu .mantine-Menu-item,
+.bn-table-handle-menu .mantine-Menu-item {
   font-size: 12px;
   height: 30px;
 }
 
-.bn-mantine .bn-side-menu .mantine-UnstyledButton-root:not(.mantine-Menu-item) {
+.bn-side-menu .mantine-UnstyledButton-root:not(.mantine-Menu-item) {
   background-color: transparent;
 }
 
-.bn-mantine .bn-side-menu .mantine-UnstyledButton-root:hover {
+.bn-side-menu .mantine-UnstyledButton-root:hover {
   background-color: var(--bn-colors-hovered-background);
 }
 
-.bn-mantine .bn-side-menu .mantine-UnstyledButton-root:not(.mantine-Menu-item) svg {
+.bn-side-menu .mantine-UnstyledButton-root:not(.mantine-Menu-item) svg {
   background-color: transparent;
   color: var(--bn-colors-side-menu);
   height: 22px;
@@ -390,7 +390,7 @@
   display: flex;
 }
 
-.bn-mantine .bn-side-menu .mantine-Menu-dropdown {
+.bn-side-menu .mantine-Menu-dropdown {
   min-width: 100px;
   padding: 2px;
   position: absolute;
@@ -414,12 +414,12 @@
   width: 100%;
 }
 
-.bn-mantine .bn-panel .mantine-TextInput-root,
-.bn-mantine .bn-panel .mantine-FileInput-root {
+.bn-panel .mantine-TextInput-root,
+.bn-panel .mantine-FileInput-root {
   width: 100%;
 }
 
-.bn-mantine .bn-panel .mantine-Button-root {
+.bn-panel .mantine-Button-root {
   background-color: var(--bn-colors-menu-background);
   border: solid var(--bn-colors-border) 1px;
   border-radius: var(--bn-border-radius-small);
@@ -428,11 +428,11 @@
   width: 60%;
 }
 
-.bn-mantine .bn-panel .mantine-Button-root:hover {
+.bn-panel .mantine-Button-root:hover {
   background-color: var(--bn-colors-hovered-background);
 }
 
-.bn-mantine .bn-panel.mantine-Text-root {
+.bn-panel .mantine-Text-root {
   text-align: center;
 }
 

--- a/packages/shadcn/components.json
+++ b/packages/shadcn/components.json
@@ -8,7 +8,7 @@
     "css": "src/style.css",
     "baseColor": "slate",
     "cssVariables": true,
-    "prefix": ""
+    "prefix": "bn-"
   },
   "aliases": {
     "components": "@/components",

--- a/packages/shadcn/package.json
+++ b/packages/shadcn/package.json
@@ -51,7 +51,7 @@
   "dependencies": {
     "@blocknote/core": "^0.14.1",
     "@blocknote/react": "^0.14.1",
-    "@hookform/resolvers": "^3.3.4",
+    "@hookform/resolvers": "^3.6.0",
     "@radix-ui/react-dropdown-menu": "^2.0.6",
     "@radix-ui/react-label": "^2.0.2",
     "@radix-ui/react-popover": "^1.0.7",
@@ -67,11 +67,11 @@
     "postcss": "^8.4.38",
     "react": "^18",
     "react-dom": "^18",
-    "react-hook-form": "^7.51.3",
+    "react-hook-form": "^7.52.0",
     "tailwind-merge": "^2.3.0",
     "tailwindcss": "^3.4.3",
     "tailwindcss-animate": "^1.0.7",
-    "zod": "^3.22.4"
+    "zod": "^3.23.8"
   },
   "devDependencies": {
     "@radix-ui/colors": "^3.0.0",

--- a/packages/shadcn/src/components/ui/badge.tsx
+++ b/packages/shadcn/src/components/ui/badge.tsx
@@ -4,17 +4,17 @@ import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "../../lib/utils";
 
 const badgeVariants = cva(
-  "inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",
+  "bn-inline-flex bn-items-center bn-rounded-full bn-border bn-px-2.5 bn-py-0.5 bn-text-xs bn-font-semibold bn-transition-colors focus:bn-outline-none focus:bn-ring-2 focus:bn-ring-ring focus:bn-ring-offset-2",
   {
     variants: {
       variant: {
         default:
-          "border-transparent bg-primary text-primary-foreground hover:bg-primary/80",
+          "bn-border-transparent bn-bg-primary bn-text-primary-foreground hover:bn-bg-primary/80",
         secondary:
-          "border-transparent bg-secondary text-secondary-foreground hover:bg-secondary/80",
+          "bn-border-transparent bn-bg-secondary bn-text-secondary-foreground hover:bn-bg-secondary/80",
         destructive:
-          "border-transparent bg-destructive text-destructive-foreground hover:bg-destructive/80",
-        outline: "text-foreground",
+          "bn-border-transparent bn-bg-destructive bn-text-destructive-foreground hover:bn-bg-destructive/80",
+        outline: "bn-text-foreground",
       },
     },
     defaultVariants: {

--- a/packages/shadcn/src/components/ui/button.tsx
+++ b/packages/shadcn/src/components/ui/button.tsx
@@ -5,25 +5,26 @@ import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "../../lib/utils";
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50",
+  "bn-inline-flex bn-items-center bn-justify-center bn-whitespace-nowrap bn-rounded-md bn-text-sm bn-font-medium bn-ring-offset-background bn-transition-colors focus-visible:bn-outline-none focus-visible:bn-ring-2 focus-visible:bn-ring-ring focus-visible:bn-ring-offset-2 disabled:bn-pointer-events-none disabled:bn-opacity-50",
   {
     variants: {
       variant: {
-        default: "bg-primary text-primary-foreground hover:bg-primary/90",
+        default:
+          "bn-bg-primary bn-text-primary-foreground hover:bn-bg-primary/90",
         destructive:
-          "bg-destructive text-destructive-foreground hover:bg-destructive/90",
+          "bn-bg-destructive bn-text-destructive-foreground hover:bn-bg-destructive/90",
         outline:
-          "border border-input bg-background hover:bg-accent hover:text-accent-foreground",
+          "bn-border bn-border-input bn-bg-background hover:bn-bg-accent hover:bn-text-accent-foreground",
         secondary:
-          "bg-secondary text-secondary-foreground hover:bg-secondary/80",
-        ghost: "hover:bg-accent hover:text-accent-foreground",
-        link: "text-primary underline-offset-4 hover:underline",
+          "bn-bg-secondary bn-text-secondary-foreground hover:bn-bg-secondary/80",
+        ghost: "hover:bn-bg-accent hover:bn-text-accent-foreground",
+        link: "bn-text-primary bn-underline-offset-4 hover:bn-underline",
       },
       size: {
-        default: "h-10 px-4 py-2",
-        sm: "h-9 rounded-md px-3",
-        lg: "h-11 rounded-md px-8",
-        icon: "h-10 w-10",
+        default: "bn-h-10 bn-px-4 bn-py-2",
+        sm: "bn-h-9 bn-rounded-md bn-px-3",
+        lg: "bn-h-11 bn-rounded-md bn-px-8",
+        icon: "bn-h-10 bn-w-10",
       },
     },
     defaultVariants: {

--- a/packages/shadcn/src/components/ui/card.tsx
+++ b/packages/shadcn/src/components/ui/card.tsx
@@ -9,7 +9,7 @@ const Card = React.forwardRef<
   <div
     ref={ref}
     className={cn(
-      "rounded-lg border bg-card text-card-foreground shadow-sm",
+      "bn-rounded-lg bn-border bn-bg-card bn-text-card-foreground bn-shadow-sm",
       className
     )}
     {...props}
@@ -23,7 +23,7 @@ const CardHeader = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <div
     ref={ref}
-    className={cn("flex flex-col space-y-1.5 p-6", className)}
+    className={cn("bn-flex bn-flex-col bn-space-y-1.5 bn-p-6", className)}
     {...props}
   />
 ));
@@ -36,7 +36,7 @@ const CardTitle = React.forwardRef<
   <h3
     ref={ref}
     className={cn(
-      "text-2xl font-semibold leading-none tracking-tight",
+      "bn-text-2xl bn-font-semibold bn-leading-none bn-tracking-tight",
       className
     )}
     {...props}
@@ -50,7 +50,7 @@ const CardDescription = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <p
     ref={ref}
-    className={cn("text-sm text-muted-foreground", className)}
+    className={cn("bn-text-sm bn-text-muted-foreground", className)}
     {...props}
   />
 ));
@@ -60,7 +60,7 @@ const CardContent = React.forwardRef<
   HTMLDivElement,
   React.HTMLAttributes<HTMLDivElement>
 >(({ className, ...props }, ref) => (
-  <div ref={ref} className={cn("p-6 pt-0", className)} {...props} />
+  <div ref={ref} className={cn("bn-p-6 bn-pt-0", className)} {...props} />
 ));
 CardContent.displayName = "CardContent";
 
@@ -70,7 +70,7 @@ const CardFooter = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <div
     ref={ref}
-    className={cn("flex items-center p-6 pt-0", className)}
+    className={cn("bn-flex bn-items-center bn-p-6 bn-pt-0", className)}
     {...props}
   />
 ));

--- a/packages/shadcn/src/components/ui/dropdown-menu.tsx
+++ b/packages/shadcn/src/components/ui/dropdown-menu.tsx
@@ -25,13 +25,13 @@ const DropdownMenuSubTrigger = React.forwardRef<
   <DropdownMenuPrimitive.SubTrigger
     ref={ref}
     className={cn(
-      "flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-accent data-[state=open]:bg-accent",
-      inset && "pl-8",
+      "bn-flex bn-cursor-default bn-select-none bn-items-center bn-rounded-sm bn-px-2 bn-py-1.5 bn-text-sm bn-outline-none focus:bn-bg-accent data-[state=open]:bn-bg-accent",
+      inset && "bn-pl-8",
       className
     )}
     {...props}>
     {children}
-    <ChevronRight className="ml-auto h-4 w-4" />
+    <ChevronRight className="bn-ml-auto bn-h-4 bn-w-4" />
   </DropdownMenuPrimitive.SubTrigger>
 ));
 DropdownMenuSubTrigger.displayName =
@@ -44,7 +44,7 @@ const DropdownMenuSubContent = React.forwardRef<
   <DropdownMenuPrimitive.SubContent
     ref={ref}
     className={cn(
-      "z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+      "bn-z-50 bn-min-w-[8rem] bn-overflow-hidden bn-rounded-md bn-border bn-bg-popover bn-p-1 bn-text-popover-foreground bn-shadow-lg data-[state=open]:bn-animate-in data-[state=closed]:bn-animate-out data-[state=closed]:bn-fade-out-0 data-[state=open]:bn-fade-in-0 data-[state=closed]:bn-zoom-out-95 data-[state=open]:bn-zoom-in-95 data-[side=bottom]:bn-slide-in-from-top-2 data-[side=left]:bn-slide-in-from-right-2 data-[side=right]:bn-slide-in-from-left-2 data-[side=top]:bn-slide-in-from-bottom-2",
       className
     )}
     {...props}
@@ -62,7 +62,7 @@ const DropdownMenuContent = React.forwardRef<
     ref={ref}
     sideOffset={sideOffset}
     className={cn(
-      "z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+      "bn-z-50 bn-min-w-[8rem] bn-overflow-hidden bn-rounded-md bn-border bn-bg-popover bn-p-1 bn-text-popover-foreground bn-shadow-md data-[state=open]:bn-animate-in data-[state=closed]:bn-animate-out data-[state=closed]:bn-fade-out-0 data-[state=open]:bn-fade-in-0 data-[state=closed]:bn-zoom-out-95 data-[state=open]:bn-zoom-in-95 data-[side=bottom]:bn-slide-in-from-top-2 data-[side=left]:bn-slide-in-from-right-2 data-[side=right]:bn-slide-in-from-left-2 data-[side=top]:bn-slide-in-from-bottom-2",
       className
     )}
     {...props}
@@ -80,8 +80,8 @@ const DropdownMenuItem = React.forwardRef<
   <DropdownMenuPrimitive.Item
     ref={ref}
     className={cn(
-      "relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
-      inset && "pl-8",
+      "bn-relative bn-flex bn-cursor-default bn-select-none bn-items-center bn-rounded-sm bn-px-2 bn-py-1.5 bn-text-sm bn-outline-none bn-transition-colors focus:bn-bg-accent focus:bn-text-accent-foreground data-[disabled]:bn-pointer-events-none data-[disabled]:bn-opacity-50",
+      inset && "bn-pl-8",
       className
     )}
     {...props}
@@ -96,14 +96,14 @@ const DropdownMenuCheckboxItem = React.forwardRef<
   <DropdownMenuPrimitive.CheckboxItem
     ref={ref}
     className={cn(
-      "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      "bn-relative bn-flex bn-cursor-default bn-select-none bn-items-center bn-rounded-sm bn-py-1.5 bn-pl-8 bn-pr-2 bn-text-sm bn-outline-none bn-transition-colors focus:bn-bg-accent focus:bn-text-accent-foreground data-[disabled]:bn-pointer-events-none data-[disabled]:bn-opacity-50",
       className
     )}
     checked={checked}
     {...props}>
-    <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
+    <span className="bn-absolute bn-left-2 bn-flex bn-h-3.5 bn-w-3.5 bn-items-center bn-justify-center">
       <DropdownMenuPrimitive.ItemIndicator>
-        <Check className="h-4 w-4" />
+        <Check className="bn-h-4 bn-w-4" />
       </DropdownMenuPrimitive.ItemIndicator>
     </span>
     {children}
@@ -119,13 +119,13 @@ const DropdownMenuRadioItem = React.forwardRef<
   <DropdownMenuPrimitive.RadioItem
     ref={ref}
     className={cn(
-      "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      "bn-relative bn-flex bn-cursor-default bn-select-none bn-items-center bn-rounded-sm bn-py-1.5 bn-pl-8 bn-pr-2 bn-text-sm bn-outline-none bn-transition-colors focus:bn-bg-accent focus:bn-text-accent-foreground data-[disabled]:bn-pointer-events-none data-[disabled]:bn-opacity-50",
       className
     )}
     {...props}>
-    <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
+    <span className="bn-absolute bn-left-2 bn-flex bn-h-3.5 bn-w-3.5 bn-items-center bn-justify-center">
       <DropdownMenuPrimitive.ItemIndicator>
-        <Circle className="h-2 w-2 fill-current" />
+        <Circle className="bn-h-2 bn-w-2 bn-fill-current" />
       </DropdownMenuPrimitive.ItemIndicator>
     </span>
     {children}
@@ -142,8 +142,8 @@ const DropdownMenuLabel = React.forwardRef<
   <DropdownMenuPrimitive.Label
     ref={ref}
     className={cn(
-      "px-2 py-1.5 text-sm font-semibold",
-      inset && "pl-8",
+      "bn-px-2 bn-py-1.5 bn-text-sm bn-font-semibold",
+      inset && "bn-pl-8",
       className
     )}
     {...props}
@@ -157,7 +157,7 @@ const DropdownMenuSeparator = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <DropdownMenuPrimitive.Separator
     ref={ref}
-    className={cn("-mx-1 my-1 h-px bg-muted", className)}
+    className={cn("bn--mx-1 bn-my-1 bn-h-px bn-bg-muted", className)}
     {...props}
   />
 ));
@@ -169,7 +169,10 @@ const DropdownMenuShortcut = ({
 }: React.HTMLAttributes<HTMLSpanElement>) => {
   return (
     <span
-      className={cn("ml-auto text-xs tracking-widest opacity-60", className)}
+      className={cn(
+        "bn-ml-auto bn-text-xs bn-tracking-widest bn-opacity-60",
+        className
+      )}
       {...props}
     />
   );

--- a/packages/shadcn/src/components/ui/form.tsx
+++ b/packages/shadcn/src/components/ui/form.tsx
@@ -78,7 +78,7 @@ const FormItem = React.forwardRef<
 
   return (
     <FormItemContext.Provider value={{ id }}>
-      <div ref={ref} className={cn("space-y-2", className)} {...props} />
+      <div ref={ref} className={cn("bn-space-y-2", className)} {...props} />
     </FormItemContext.Provider>
   );
 });
@@ -93,7 +93,7 @@ const FormLabel = React.forwardRef<
   return (
     <Label
       ref={ref}
-      className={cn(error && "text-destructive", className)}
+      className={cn(error && "bn-text-destructive", className)}
       htmlFor={formItemId}
       {...props}
     />
@@ -134,7 +134,7 @@ const FormDescription = React.forwardRef<
     <p
       ref={ref}
       id={formDescriptionId}
-      className={cn("text-sm text-muted-foreground", className)}
+      className={cn("bn-text-sm bn-text-muted-foreground", className)}
       {...props}
     />
   );
@@ -156,7 +156,7 @@ const FormMessage = React.forwardRef<
     <p
       ref={ref}
       id={formMessageId}
-      className={cn("text-sm font-medium text-destructive", className)}
+      className={cn("bn-text-sm bn-font-medium bn-text-destructive", className)}
       {...props}>
       {body}
     </p>

--- a/packages/shadcn/src/components/ui/input.tsx
+++ b/packages/shadcn/src/components/ui/input.tsx
@@ -2,7 +2,8 @@ import * as React from "react";
 
 import { cn } from "../../lib/utils";
 
-export type InputProps = React.InputHTMLAttributes<HTMLInputElement>;
+export interface InputProps
+  extends React.InputHTMLAttributes<HTMLInputElement> {}
 
 const Input = React.forwardRef<HTMLInputElement, InputProps>(
   ({ className, type, ...props }, ref) => {
@@ -10,7 +11,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
       <input
         type={type}
         className={cn(
-          "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+          "bn-flex bn-h-10 bn-w-full bn-rounded-md bn-border bn-border-input bn-bg-background bn-px-3 bn-py-2 bn-text-sm bn-ring-offset-background file:bn-border-0 file:bn-bg-transparent file:bn-text-sm file:bn-font-medium placeholder:bn-text-muted-foreground focus-visible:bn-outline-none focus-visible:bn-ring-2 focus-visible:bn-ring-ring focus-visible:bn-ring-offset-2 disabled:bn-cursor-not-allowed disabled:bn-opacity-50",
           className
         )}
         ref={ref}

--- a/packages/shadcn/src/components/ui/label.tsx
+++ b/packages/shadcn/src/components/ui/label.tsx
@@ -5,7 +5,7 @@ import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "../../lib/utils";
 
 const labelVariants = cva(
-  "text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
+  "bn-text-sm bn-font-medium bn-leading-none peer-disabled:bn-cursor-not-allowed peer-disabled:bn-opacity-70"
 );
 
 const Label = React.forwardRef<

--- a/packages/shadcn/src/components/ui/popover.tsx
+++ b/packages/shadcn/src/components/ui/popover.tsx
@@ -17,7 +17,7 @@ const PopoverContent = React.forwardRef<
     align={align}
     sideOffset={sideOffset}
     className={cn(
-      "z-50 w-72 rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+      "bn-z-50 bn-w-72 bn-rounded-md bn-border bn-bg-popover bn-p-4 bn-text-popover-foreground bn-shadow-md bn-outline-none data-[state=open]:bn-animate-in data-[state=closed]:bn-animate-out data-[state=closed]:bn-fade-out-0 data-[state=open]:bn-fade-in-0 data-[state=closed]:bn-zoom-out-95 data-[state=open]:bn-zoom-in-95 data-[side=bottom]:bn-slide-in-from-top-2 data-[side=left]:bn-slide-in-from-right-2 data-[side=right]:bn-slide-in-from-left-2 data-[side=top]:bn-slide-in-from-bottom-2",
       className
     )}
     {...props}

--- a/packages/shadcn/src/components/ui/select.tsx
+++ b/packages/shadcn/src/components/ui/select.tsx
@@ -17,13 +17,13 @@ const SelectTrigger = React.forwardRef<
   <SelectPrimitive.Trigger
     ref={ref}
     className={cn(
-      "flex h-10 w-full items-center justify-between rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1",
+      "bn-flex bn-h-10 bn-w-full bn-items-center bn-justify-between bn-rounded-md bn-border bn-border-input bn-bg-background bn-px-3 bn-py-2 bn-text-sm bn-ring-offset-background placeholder:bn-text-muted-foreground focus:bn-outline-none focus:bn-ring-2 focus:bn-ring-ring focus:bn-ring-offset-2 disabled:bn-cursor-not-allowed disabled:bn-opacity-50 [&>span]:bn-line-clamp-1",
       className
     )}
     {...props}>
     {children}
     <SelectPrimitive.Icon asChild>
-      <ChevronDown className="h-4 w-4 opacity-50" />
+      <ChevronDown className="bn-h-4 bn-w-4 bn-opacity-50" />
     </SelectPrimitive.Icon>
   </SelectPrimitive.Trigger>
 ));
@@ -36,11 +36,11 @@ const SelectScrollUpButton = React.forwardRef<
   <SelectPrimitive.ScrollUpButton
     ref={ref}
     className={cn(
-      "flex cursor-default items-center justify-center py-1",
+      "bn-flex bn-cursor-default bn-items-center bn-justify-center bn-py-1",
       className
     )}
     {...props}>
-    <ChevronUp className="h-4 w-4" />
+    <ChevronUp className="bn-h-4 bn-w-4" />
   </SelectPrimitive.ScrollUpButton>
 ));
 SelectScrollUpButton.displayName = SelectPrimitive.ScrollUpButton.displayName;
@@ -52,11 +52,11 @@ const SelectScrollDownButton = React.forwardRef<
   <SelectPrimitive.ScrollDownButton
     ref={ref}
     className={cn(
-      "flex cursor-default items-center justify-center py-1",
+      "bn-flex bn-cursor-default bn-items-center bn-justify-center bn-py-1",
       className
     )}
     {...props}>
-    <ChevronDown className="h-4 w-4" />
+    <ChevronDown className="bn-h-4 bn-w-4" />
   </SelectPrimitive.ScrollDownButton>
 ));
 SelectScrollDownButton.displayName =
@@ -70,9 +70,9 @@ const SelectContent = React.forwardRef<
   <SelectPrimitive.Content
     ref={ref}
     className={cn(
-      "relative z-50 max-h-96 min-w-[8rem] overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+      "bn-relative bn-z-50 bn-max-h-96 bn-min-w-[8rem] bn-overflow-hidden bn-rounded-md bn-border bn-bg-popover bn-text-popover-foreground bn-shadow-md data-[state=open]:bn-animate-in data-[state=closed]:bn-animate-out data-[state=closed]:bn-fade-out-0 data-[state=open]:bn-fade-in-0 data-[state=closed]:bn-zoom-out-95 data-[state=open]:bn-zoom-in-95 data-[side=bottom]:bn-slide-in-from-top-2 data-[side=left]:bn-slide-in-from-right-2 data-[side=right]:bn-slide-in-from-left-2 data-[side=top]:bn-slide-in-from-bottom-2",
       position === "popper" &&
-        "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
+        "data-[side=bottom]:bn-translate-y-1 data-[side=left]:bn--translate-x-1 data-[side=right]:bn-translate-x-1 data-[side=top]:bn--translate-y-1",
       className
     )}
     position={position}
@@ -80,9 +80,9 @@ const SelectContent = React.forwardRef<
     <SelectScrollUpButton />
     <SelectPrimitive.Viewport
       className={cn(
-        "p-1",
+        "bn-p-1",
         position === "popper" &&
-          "h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)]"
+          "bn-h-[var(--radix-select-trigger-height)] bn-w-full bn-min-w-[var(--radix-select-trigger-width)]"
       )}>
       {children}
     </SelectPrimitive.Viewport>
@@ -98,7 +98,10 @@ const SelectLabel = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <SelectPrimitive.Label
     ref={ref}
-    className={cn("py-1.5 pl-8 pr-2 text-sm font-semibold", className)}
+    className={cn(
+      "bn-py-1.5 bn-pl-8 bn-pr-2 bn-text-sm bn-font-semibold",
+      className
+    )}
     {...props}
   />
 ));
@@ -111,13 +114,13 @@ const SelectItem = React.forwardRef<
   <SelectPrimitive.Item
     ref={ref}
     className={cn(
-      "relative flex w-full cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      "bn-relative bn-flex bn-w-full bn-cursor-default bn-select-none bn-items-center bn-rounded-sm bn-py-1.5 bn-pl-8 bn-pr-2 bn-text-sm bn-outline-none focus:bn-bg-accent focus:bn-text-accent-foreground data-[disabled]:bn-pointer-events-none data-[disabled]:bn-opacity-50",
       className
     )}
     {...props}>
-    <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
+    <span className="bn-absolute bn-left-2 bn-flex bn-h-3.5 bn-w-3.5 bn-items-center bn-justify-center">
       <SelectPrimitive.ItemIndicator>
-        <Check className="h-4 w-4" />
+        <Check className="bn-h-4 bn-w-4" />
       </SelectPrimitive.ItemIndicator>
     </span>
 
@@ -132,7 +135,7 @@ const SelectSeparator = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <SelectPrimitive.Separator
     ref={ref}
-    className={cn("-mx-1 my-1 h-px bg-muted", className)}
+    className={cn("bn--mx-1 bn-my-1 bn-h-px bn-bg-muted", className)}
     {...props}
   />
 ));

--- a/packages/shadcn/src/components/ui/tabs.tsx
+++ b/packages/shadcn/src/components/ui/tabs.tsx
@@ -12,7 +12,7 @@ const TabsList = React.forwardRef<
   <TabsPrimitive.List
     ref={ref}
     className={cn(
-      "inline-flex h-10 items-center justify-center rounded-md bg-muted p-1 text-muted-foreground",
+      "bn-inline-flex bn-h-10 bn-items-center bn-justify-center bn-rounded-md bn-bg-muted bn-p-1 bn-text-muted-foreground",
       className
     )}
     {...props}
@@ -27,7 +27,7 @@ const TabsTrigger = React.forwardRef<
   <TabsPrimitive.Trigger
     ref={ref}
     className={cn(
-      "inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm",
+      "bn-inline-flex bn-items-center bn-justify-center bn-whitespace-nowrap bn-rounded-sm bn-px-3 bn-py-1.5 bn-text-sm bn-font-medium bn-ring-offset-background bn-transition-all focus-visible:bn-outline-none focus-visible:bn-ring-2 focus-visible:bn-ring-ring focus-visible:bn-ring-offset-2 disabled:bn-pointer-events-none disabled:bn-opacity-50 data-[state=active]:bn-bg-background data-[state=active]:bn-text-foreground data-[state=active]:bn-shadow-sm",
       className
     )}
     {...props}
@@ -42,7 +42,7 @@ const TabsContent = React.forwardRef<
   <TabsPrimitive.Content
     ref={ref}
     className={cn(
-      "mt-2 ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+      "bn-mt-2 bn-ring-offset-background focus-visible:bn-outline-none focus-visible:bn-ring-2 focus-visible:bn-ring-ring focus-visible:bn-ring-offset-2",
       className
     )}
     {...props}

--- a/packages/shadcn/src/components/ui/toggle.tsx
+++ b/packages/shadcn/src/components/ui/toggle.tsx
@@ -5,18 +5,18 @@ import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "../../lib/utils";
 
 const toggleVariants = cva(
-  "inline-flex items-center justify-center rounded-md text-sm font-medium ring-offset-background transition-colors hover:bg-muted hover:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=on]:bg-accent data-[state=on]:text-accent-foreground",
+  "bn-inline-flex bn-items-center bn-justify-center bn-rounded-md bn-text-sm bn-font-medium bn-ring-offset-background bn-transition-colors hover:bn-bg-muted hover:bn-text-muted-foreground focus-visible:bn-outline-none focus-visible:bn-ring-2 focus-visible:bn-ring-ring focus-visible:bn-ring-offset-2 disabled:bn-pointer-events-none disabled:bn-opacity-50 data-[state=on]:bn-bg-accent data-[state=on]:bn-text-accent-foreground",
   {
     variants: {
       variant: {
-        default: "bg-transparent",
+        default: "bn-bg-transparent",
         outline:
-          "border border-input bg-transparent hover:bg-accent hover:text-accent-foreground",
+          "bn-border bn-border-input bn-bg-transparent hover:bn-bg-accent hover:bn-text-accent-foreground",
       },
       size: {
-        default: "h-10 px-3",
-        sm: "h-9 px-2.5",
-        lg: "h-11 px-5",
+        default: "bn-h-10 bn-px-3",
+        sm: "bn-h-9 bn-px-2.5",
+        lg: "bn-h-11 bn-px-5",
       },
     },
     defaultVariants: {

--- a/packages/shadcn/src/components/ui/tooltip.tsx
+++ b/packages/shadcn/src/components/ui/tooltip.tsx
@@ -17,7 +17,7 @@ const TooltipContent = React.forwardRef<
     ref={ref}
     sideOffset={sideOffset}
     className={cn(
-      "z-50 overflow-hidden rounded-md border bg-popover px-3 py-1.5 text-sm text-popover-foreground shadow-md animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+      "bn-z-50 bn-overflow-hidden bn-rounded-md bn-border bn-bg-popover bn-px-3 bn-py-1.5 bn-text-sm bn-text-popover-foreground bn-shadow-md bn-animate-in bn-fade-in-0 bn-zoom-in-95 data-[state=closed]:bn-animate-out data-[state=closed]:bn-fade-out-0 data-[state=closed]:bn-zoom-out-95 data-[side=bottom]:bn-slide-in-from-top-2 data-[side=left]:bn-slide-in-from-right-2 data-[side=right]:bn-slide-in-from-left-2 data-[side=top]:bn-slide-in-from-bottom-2",
       className
     )}
     {...props}

--- a/packages/shadcn/src/index.tsx
+++ b/packages/shadcn/src/index.tsx
@@ -121,7 +121,7 @@ export const BlockNoteView = <
     <ShadCNComponentsContext.Provider value={componentsValue}>
       <ComponentsContext.Provider value={components}>
         <BlockNoteViewRaw
-          className={mergeCSSClasses("bn-shad-cn", className || "")}
+          className={mergeCSSClasses("bn-shadcn", className || "")}
           {...rest}
         />
       </ComponentsContext.Provider>

--- a/packages/shadcn/src/index.tsx
+++ b/packages/shadcn/src/index.tsx
@@ -107,8 +107,8 @@ export const BlockNoteView = <
 
   const componentsValue = useMemo(() => {
     return {
-      ...shadCNComponents,
       ...ShadCNDefaultComponents,
+      ...shadCNComponents,
     };
   }, [shadCNComponents]);
 

--- a/packages/shadcn/src/index.tsx
+++ b/packages/shadcn/src/index.tsx
@@ -1,4 +1,9 @@
-import { BlockSchema, InlineContentSchema, StyleSchema } from "@blocknote/core";
+import {
+  BlockSchema,
+  InlineContentSchema,
+  mergeCSSClasses,
+  StyleSchema,
+} from "@blocknote/core";
 import {
   BlockNoteViewRaw,
   Components,
@@ -103,7 +108,7 @@ export const BlockNoteView = <
     shadCNComponents?: Partial<ShadCNComponents>;
   }
 ) => {
-  const { shadCNComponents, ...rest } = props;
+  const { className, shadCNComponents, ...rest } = props;
 
   const componentsValue = useMemo(() => {
     return {
@@ -115,7 +120,10 @@ export const BlockNoteView = <
   return (
     <ShadCNComponentsContext.Provider value={componentsValue}>
       <ComponentsContext.Provider value={components}>
-        <BlockNoteViewRaw {...rest} />
+        <BlockNoteViewRaw
+          className={mergeCSSClasses("bn-shad-cn", className || "")}
+          {...rest}
+        />
       </ComponentsContext.Provider>
     </ShadCNComponentsContext.Provider>
   );

--- a/packages/shadcn/src/lib/utils.ts
+++ b/packages/shadcn/src/lib/utils.ts
@@ -1,5 +1,9 @@
 import { type ClassValue, clsx } from "clsx";
-import { twMerge } from "tailwind-merge";
+import { extendTailwindMerge } from "tailwind-merge";
+
+const twMerge = extendTailwindMerge({
+  prefix: "bn-",
+});
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));

--- a/packages/shadcn/src/lib/utils.ts
+++ b/packages/shadcn/src/lib/utils.ts
@@ -1,6 +1,8 @@
 import { type ClassValue, clsx } from "clsx";
 import { extendTailwindMerge } from "tailwind-merge";
 
+// Ensures that `bn-` prefixed Tailwind classes are recognized as Tailwind
+// classes, so they can be merged correctly.
 const twMerge = extendTailwindMerge({
   prefix: "bn-",
 });

--- a/packages/shadcn/src/menu/Menu.tsx
+++ b/packages/shadcn/src/menu/Menu.tsx
@@ -147,7 +147,7 @@ export const MenuItem = forwardRef<
   if (checked !== undefined) {
     return (
       <ShadCNComponents.DropdownMenu.DropdownMenuCheckboxItem
-        className={cn(className, "gap-1")}
+        className={cn(className, "bn-gap-1")}
         ref={ref}
         checked={checked}
         onClick={onClick}
@@ -166,7 +166,7 @@ export const MenuItem = forwardRef<
       {...rest}>
       {icon}
       {children}
-      {subTrigger && <ChevronRight className="ml-auto h-4 w-4" />}
+      {subTrigger && <ChevronRight className="bn-ml-auto bn-h-4 bn-w-4" />}
     </ShadCNComponents.DropdownMenu.DropdownMenuItem>
   );
 });

--- a/packages/shadcn/src/panel/Panel.tsx
+++ b/packages/shadcn/src/panel/Panel.tsx
@@ -25,7 +25,7 @@ export const Panel = forwardRef<
 
   return (
     <ShadCNComponents.Tabs.Tabs
-      className={cn(className, "bg-popover p-2 rounded-lg")}
+      className={cn(className, "bn-bg-popover bn-p-2 bn-rounded-lg")}
       ref={ref}
       value={openTab}
       defaultValue={defaultOpenTab}
@@ -43,7 +43,7 @@ export const Panel = forwardRef<
       {tabs.map((tab) => (
         <ShadCNComponents.Tabs.TabsContent value={tab.name} key={tab.name}>
           <ShadCNComponents.Card.Card>
-            <ShadCNComponents.Card.CardContent className={"p-4"}>
+            <ShadCNComponents.Card.CardContent className={"bn-p-4"}>
               {tab.tabPanel}
             </ShadCNComponents.Card.CardContent>
           </ShadCNComponents.Card.Card>

--- a/packages/shadcn/src/panel/PanelTab.tsx
+++ b/packages/shadcn/src/panel/PanelTab.tsx
@@ -16,7 +16,7 @@ export const PanelTab = forwardRef<
     <div
       className={cn(
         className,
-        "flex flex-col gap-2 items-start justify-center"
+        "bn-flex bn-flex-col bn-gap-2 bn-items-start bn-justify-center"
       )}
       ref={ref}>
       {children}

--- a/packages/shadcn/src/panel/PanelTextInput.tsx
+++ b/packages/shadcn/src/panel/PanelTextInput.tsx
@@ -18,7 +18,7 @@ export const PanelTextInput = forwardRef<
   return (
     <ShadCNComponents.Input.Input
       data-test={"embed-input"}
-      className={cn(className, "w-80")}
+      className={cn(className, "bn-w-80")}
       ref={ref}
       value={value}
       placeholder={placeholder}

--- a/packages/shadcn/src/popover/popover.tsx
+++ b/packages/shadcn/src/popover/popover.tsx
@@ -57,9 +57,9 @@ export const PopoverContent = forwardRef<
       sideOffset={8}
       className={cn(
         className,
-        "flex flex-col gap-2",
+        "bn-flex bn-flex-col bn-gap-2",
         variant === "panel-popover"
-          ? "p-0 border-none shadow-none max-w-none w-fit"
+          ? "bn-p-0 bn-border-none bn-shadow-none bn-max-w-none bn-w-fit"
           : ""
       )}
       ref={ref}>

--- a/packages/shadcn/src/sideMenu/SideMenuButton.tsx
+++ b/packages/shadcn/src/sideMenu/SideMenuButton.tsx
@@ -30,7 +30,7 @@ export const SideMenuButton = forwardRef<
   return (
     <ShadCNComponents.Button.Button
       variant={"ghost"}
-      className={cn(className, "text-gray-400")}
+      className={cn(className, "bn-text-gray-400")}
       ref={ref}
       aria-label={label}
       onClick={onClick}

--- a/packages/shadcn/src/style.css
+++ b/packages/shadcn/src/style.css
@@ -4,7 +4,7 @@
 @tailwind components;
 @tailwind utilities;
 
-.bn-container {
+.bn-shad-cn {
   --background: 0 0% 100%;
   --foreground: 222.2 84% 4.9%;
 
@@ -36,7 +36,7 @@
   --radius: 0.5rem;
 }
 
-.bn-container.dark {
+.bn-shad-cn.dark {
   --background: 222.2 84% 4.9%;
   --foreground: 210 40% 98%;
 
@@ -66,45 +66,45 @@
   --ring: 212.7 26.8% 83.9%;
 }
 
-.bn-container * {
+.bn-shadcn * {
   @apply bn-border-border;
 }
-.bn-editor {
+.bn-shad-cn .bn-editor {
   @apply bn-bg-background bn-text-foreground;
 }
 
-[data-radix-popper-content-wrapper] {
+.bn-shad-cn [data-radix-popper-content-wrapper] {
   z-index: 99999 !important;
 }
 
-.bn-editor:focus-visible {
+.bn-shad-cn .bn-editor:focus-visible {
   outline: none;
 }
 
-.bn-side-menu {
+.bn-shad-cn .bn-side-menu {
   align-items: center;
   display: flex;
   justify-content: center;
 }
 
-.bn-side-menu .bn-button {
+.bn-shad-cn .bn-side-menu .bn-button {
   padding: 0;
   height: 24px;
 }
 
-.bn-select {
+.bn-shad-cn .bn-select {
   max-height: var(--radix-select-content-available-height);
 }
 
-.bn-menu-dropdown {
+.bn-shad-cn .bn-menu-dropdown {
   max-height: var(--radix-dropdown-menu-content-available-height);
 }
 
-.bn-color-picker-dropdown {
+.bn-shad-cn .bn-color-picker-dropdown {
   overflow: auto;
 }
 
-.bn-suggestion-menu-item[aria-selected="true"],
-.bn-suggestion-menu-item:hover {
+.bn-shad-cn .bn-suggestion-menu-item[aria-selected="true"],
+.bn-shad-cn .bn-suggestion-menu-item:hover {
   background-color: hsl(var(--accent));
 }

--- a/packages/shadcn/src/style.css
+++ b/packages/shadcn/src/style.css
@@ -67,10 +67,10 @@
 }
 
 .bn-container * {
-  @apply border-border;
+  @apply bn-border-border;
 }
 .bn-editor {
-  @apply bg-background text-foreground;
+  @apply bn-bg-background bn-text-foreground;
 }
 
 [data-radix-popper-content-wrapper] {

--- a/packages/shadcn/src/style.css
+++ b/packages/shadcn/src/style.css
@@ -4,7 +4,7 @@
 @tailwind components;
 @tailwind utilities;
 
-.bn-shad-cn {
+.bn-shadcn {
   --background: 0 0% 100%;
   --foreground: 222.2 84% 4.9%;
 
@@ -36,7 +36,7 @@
   --radius: 0.5rem;
 }
 
-.bn-shad-cn.dark {
+.bn-shadcn.dark {
   --background: 222.2 84% 4.9%;
   --foreground: 210 40% 98%;
 
@@ -69,42 +69,42 @@
 .bn-shadcn * {
   @apply bn-border-border;
 }
-.bn-shad-cn .bn-editor {
+.bn-shadcn .bn-editor {
   @apply bn-bg-background bn-text-foreground;
 }
 
-.bn-shad-cn [data-radix-popper-content-wrapper] {
+.bn-shadcn [data-radix-popper-content-wrapper] {
   z-index: 99999 !important;
 }
 
-.bn-shad-cn .bn-editor:focus-visible {
+.bn-shadcn .bn-editor:focus-visible {
   outline: none;
 }
 
-.bn-shad-cn .bn-side-menu {
+.bn-shadcn .bn-side-menu {
   align-items: center;
   display: flex;
   justify-content: center;
 }
 
-.bn-shad-cn .bn-side-menu .bn-button {
+.bn-shadcn .bn-side-menu .bn-button {
   padding: 0;
   height: 24px;
 }
 
-.bn-shad-cn .bn-select {
+.bn-shadcn .bn-select {
   max-height: var(--radix-select-content-available-height);
 }
 
-.bn-shad-cn .bn-menu-dropdown {
+.bn-shadcn .bn-menu-dropdown {
   max-height: var(--radix-dropdown-menu-content-available-height);
 }
 
-.bn-shad-cn .bn-color-picker-dropdown {
+.bn-shadcn .bn-color-picker-dropdown {
   overflow: auto;
 }
 
-.bn-shad-cn .bn-suggestion-menu-item[aria-selected="true"],
-.bn-shad-cn .bn-suggestion-menu-item:hover {
+.bn-shadcn .bn-suggestion-menu-item[aria-selected="true"],
+.bn-shadcn .bn-suggestion-menu-item:hover {
   background-color: hsl(var(--accent));
 }

--- a/packages/shadcn/src/suggestionMenu/SuggestionMenu.tsx
+++ b/packages/shadcn/src/suggestionMenu/SuggestionMenu.tsx
@@ -18,7 +18,7 @@ export const SuggestionMenu = forwardRef<
       role="listbox"
       // Styles from ShadCN DropdownMenuContent component
       className={cn(
-        "z-50 min-w-[8rem] overflow-auto rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        "bn-z-50 bn-min-w-[8rem] bn-overflow-auto bn-rounded-md bn-border bn-bg-popover bn-p-1 bn-text-popover-foreground bn-shadow-md data-[state=open]:bn-animate-in data-[state=closed]:bn-animate-out data-[state=closed]:bn-fade-out-0 data-[state=open]:bn-fade-in-0 data-[state=closed]:bn-zoom-out-95 data-[state=open]:bn-zoom-in-95 data-[side=bottom]:bn-slide-in-from-top-2 data-[side=left]:bn-slide-in-from-right-2 data-[side=right]:bn-slide-in-from-left-2 data-[side=top]:bn-slide-in-from-bottom-2",
         className
       )}
       ref={ref}>

--- a/packages/shadcn/src/suggestionMenu/SuggestionMenuEmptyItem.tsx
+++ b/packages/shadcn/src/suggestionMenu/SuggestionMenuEmptyItem.tsx
@@ -16,7 +16,7 @@ export const SuggestionMenuEmptyItem = forwardRef<
     <div
       // Styles from ShadCN DropdownMenuItem component
       className={cn(
-        "relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+        "bn-relative bn-flex bn-cursor-default bn-select-none bn-items-center bn-rounded-sm bn-px-2 bn-py-1.5 bn-text-sm bn-outline-none bn-transition-colors focus:bn-bg-accent focus:bn-text-accent-foreground data-[disabled]:bn-pointer-events-none data-[disabled]:bn-opacity-50",
         className
       )}
       ref={ref}>

--- a/packages/shadcn/src/suggestionMenu/SuggestionMenuItem.tsx
+++ b/packages/shadcn/src/suggestionMenu/SuggestionMenuItem.tsx
@@ -35,7 +35,7 @@ export const SuggestionMenuItem = forwardRef<
     <div
       // Styles from ShadCN DropdownMenuItem component
       className={cn(
-        "relative flex cursor-pointer select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+        "bn-relative bn-flex bn-cursor-pointer bn-select-none bn-items-center bn-rounded-sm bn-px-2 bn-py-1.5 bn-text-sm bn-outline-none bn-transition-colors focus:bn-bg-accent focus:bn-text-accent-foreground data-[disabled]:bn-pointer-events-none data-[disabled]:bn-opacity-50",
         className
       )}
       ref={mergeRefs([ref, itemRef])}
@@ -44,16 +44,16 @@ export const SuggestionMenuItem = forwardRef<
       role="option"
       aria-selected={isSelected || undefined}>
       {item.icon && (
-        <div className="p-3" data-position="left">
+        <div className="bn-p-3" data-position="left">
           {item.icon}
         </div>
       )}
-      <div className="flex-1">
-        <div className="text-base">{item.title}</div>
-        <div className="text-xs">{item.subtext}</div>
+      <div className="bn-flex-1">
+        <div className="bn-text-base">{item.title}</div>
+        <div className="bn-text-xs">{item.subtext}</div>
       </div>
       {item.badge && (
-        <div data-position="right" className="text-xs">
+        <div data-position="right" className="bn-text-xs">
           <ShadCNComponents.Badge.Badge variant={"secondary"}>
             {item.badge}
           </ShadCNComponents.Badge.Badge>

--- a/packages/shadcn/src/suggestionMenu/SuggestionMenuLabel.tsx
+++ b/packages/shadcn/src/suggestionMenu/SuggestionMenuLabel.tsx
@@ -15,7 +15,7 @@ export const SuggestionMenuLabel = forwardRef<
   return (
     <div
       // Styles from ShadCN DropdownMenuLabel component
-      className={cn("px-2 py-1.5 text-sm font-semibold", className)}
+      className={cn("bn-px-2 bn-py-1.5 bn-text-sm bn-font-semibold", className)}
       ref={ref}>
       {children}
     </div>

--- a/packages/shadcn/src/tableHandle/TableHandle.tsx
+++ b/packages/shadcn/src/tableHandle/TableHandle.tsx
@@ -29,7 +29,7 @@ export const TableHandle = forwardRef<
   return (
     <ShadCNComponents.Button.Button
       variant={"ghost"}
-      className={cn(className, "p-0 h-fit w-fit text-gray-400")}
+      className={cn(className, "bn-p-0 bn-h-fit bn-w-fit bn-text-gray-400")}
       ref={ref}
       aria-label={label}
       draggable={draggable}

--- a/packages/shadcn/src/toolbar/Toolbar.tsx
+++ b/packages/shadcn/src/toolbar/Toolbar.tsx
@@ -21,7 +21,7 @@ export const Toolbar = forwardRef<HTMLDivElement, ToolbarProps>(
         <div
           className={cn(
             className,
-            "flex gap-1 p-1 bg-popover text-popover-foreground border rounded-lg shadow-md"
+            "bn-flex bn-gap-1 bn-p-1 bn-bg-popover bn-text-popover-foreground bn-border bn-rounded-lg bn-shadow-md"
           )}
           ref={ref}
           onMouseEnter={onMouseEnter}
@@ -95,7 +95,7 @@ export const ToolbarButton = forwardRef<HTMLButtonElement, ToolbarButtonProps>(
           {trigger}
         </ShadCNComponents.Tooltip.TooltipTrigger>
         <ShadCNComponents.Tooltip.TooltipContent
-          className={"flex flex-col items-center"}>
+          className={"bn-flex bn-flex-col bn-items-center"}>
           <span>{mainTooltip}</span>
           {secondaryTooltip && <span>{secondaryTooltip}</span>}
         </ShadCNComponents.Tooltip.TooltipContent>
@@ -116,7 +116,7 @@ export const ToolbarSelect = forwardRef<
 
   // TODO?
   const SelectItemContent = (props: any) => (
-    <div className={"flex gap-1 items-center"}>
+    <div className={"bn-flex bn-gap-1 bn-items-center"}>
       {props.icon}
       {props.text}
     </div>

--- a/packages/shadcn/src/toolbar/Toolbar.tsx
+++ b/packages/shadcn/src/toolbar/Toolbar.tsx
@@ -135,7 +135,7 @@ export const ToolbarSelect = forwardRef<
         items.find((item) => item.text === value)!.onClick?.()
       }
       disabled={isDisabled}>
-      <ShadCNComponents.Select.SelectTrigger className={"border-none"}>
+      <ShadCNComponents.Select.SelectTrigger className={"bn-border-none"}>
         <ShadCNComponents.Select.SelectValue />
       </ShadCNComponents.Select.SelectTrigger>
       <ShadCNComponents.Select.SelectContent className={className} ref={ref}>

--- a/packages/shadcn/tailwind.config.js
+++ b/packages/shadcn/tailwind.config.js
@@ -3,7 +3,7 @@ const dir = __dirname;
 module.exports = {
   darkMode: ["class"],
   content: [dir + "/**/*.{ts,tsx}"],
-  prefix: "",
+  prefix: "bn-",
   theme: {
     container: {
       center: true,


### PR DESCRIPTION
The `shadcn` package uses TailwindCSS, so when building a project that imports both `@blocknote/shadcn` and Tailwind, it creates duplicate CSS declarations. This isn't a huge problem on its own, but when building projects using TailwindCSS, only the rules that are actually used are included due to optimization. This can lead to cases where the Tailwind classes created by the `shadcn` package take priority over those created by the parent app, and cause styling to break as they don't include certain conditional classes such as `min-width`.

This PR makes the Tailwind classes used by `@blocknote/shadcn` have a `bn-` prefix, which basically scopes them to the editor only and stops them from conflicting with those used outside the editor.

This PR also scopes the styles of each UI library to the corresponding editor instead of to all editors. This fixes a very niche edge case where you have 2 editors using different UI libs, and also the examples, since those can have styles sheets from other examples loaded.

Closes #845 