### PR TITLE
Add option to disable individual built in extensions

### DIFF
--- a/packages/core/src/editor/BlockNoteEditor.ts
+++ b/packages/core/src/editor/BlockNoteEditor.ts
@@ -74,8 +74,8 @@ export type BlockNoteEditorOptions<
   SSchema extends StyleSchema
 > = {
   // TODO: Figure out if enableBlockNoteExtensions/disableHistoryExtension are needed and document them.
-  enableBlockNoteExtensions: boolean | string[];
-
+  enableBlockNoteExtensions: boolean;
+  disableBlockNoteExtensions: string[];
   /**
    * A dictionary object containing translations for the editor.
    */
@@ -280,7 +280,7 @@ export class BlockNoteEditor<
       inlineContentSpecs: this.schema.inlineContentSpecs,
       collaboration: newOptions.collaboration,
       trailingBlock: newOptions.trailingBlock,
-      disabled: newOptions.enableBlockNoteExtensions
+      disabled: newOptions.disableBlockNoteExtensions
     });
 
     const blockNoteUIExtension = Extension.create({

--- a/packages/core/src/editor/BlockNoteEditor.ts
+++ b/packages/core/src/editor/BlockNoteEditor.ts
@@ -74,7 +74,7 @@ export type BlockNoteEditorOptions<
   SSchema extends StyleSchema
 > = {
   // TODO: Figure out if enableBlockNoteExtensions/disableHistoryExtension are needed and document them.
-  enableBlockNoteExtensions: boolean;
+  enableBlockNoteExtensions: boolean | string[];
 
   /**
    * A dictionary object containing translations for the editor.
@@ -280,6 +280,7 @@ export class BlockNoteEditor<
       inlineContentSpecs: this.schema.inlineContentSpecs,
       collaboration: newOptions.collaboration,
       trailingBlock: newOptions.trailingBlock,
+      disabled: newOptions.enableBlockNoteExtensions
     });
 
     const blockNoteUIExtension = Extension.create({

--- a/packages/core/src/editor/BlockNoteExtensions.ts
+++ b/packages/core/src/editor/BlockNoteExtensions.ts
@@ -53,7 +53,7 @@ export const getBlockNoteExtensions = <
     provider: any;
     renderCursor?: (user: any) => HTMLElement;
   };
-  disabled: null | string: []
+  disabled: string: [] | undefined;
 }) => {
   const ret: Extensions = [
     extensions.ClipboardTextSerializer,

--- a/packages/core/src/editor/BlockNoteExtensions.ts
+++ b/packages/core/src/editor/BlockNoteExtensions.ts
@@ -194,5 +194,5 @@ export const getBlockNoteExtensions = <
     ret.push(History);
   }
 
-  return ret.filter(ex => !disabled.includes(ex.name);
+  return disabled ? ret.filter(ex => !disabled.includes(ex.name) : ret;
 };

--- a/packages/core/src/editor/BlockNoteExtensions.ts
+++ b/packages/core/src/editor/BlockNoteExtensions.ts
@@ -53,7 +53,7 @@ export const getBlockNoteExtensions = <
     provider: any;
     renderCursor?: (user: any) => HTMLElement;
   };
-  disabled: string: [] | undefined;
+  disabled: string[] | undefined;
 }) => {
   const ret: Extensions = [
     extensions.ClipboardTextSerializer,

--- a/packages/core/src/editor/BlockNoteExtensions.ts
+++ b/packages/core/src/editor/BlockNoteExtensions.ts
@@ -53,6 +53,7 @@ export const getBlockNoteExtensions = <
     provider: any;
     renderCursor?: (user: any) => HTMLElement;
   };
+  disabled: null | string: []
 }) => {
   const ret: Extensions = [
     extensions.ClipboardTextSerializer,
@@ -193,5 +194,5 @@ export const getBlockNoteExtensions = <
     ret.push(History);
   }
 
-  return ret;
+  return ret.filter(ex => !disabled.includes(ex.name);
 };


### PR DESCRIPTION
Without completely needing to refactor the way tiptap extensions and core blocknote extensions are added, this should be fairly simple approach to just allow a list of extension names to be passed in that will then be removed from the inbuiult extensions before being passed to tiptap.

This will allow you to the override these extensions if you wish without completely disbaling blocknote via 
```
const editor = useCreateBlockNote({
    disableBlockNoteExtensions:['link'],
    _tiptapOptions: {
      extensions: [
        Link,
      ]
    }
  })
```
