### PR TITLE
feat: Table cell/column widths in API

### DIFF
--- a/docs/pages/docs/editor-basics/default-schema.mdx
+++ b/docs/pages/docs/editor-basics/default-schema.mdx
@@ -117,7 +117,7 @@ type TableBlock = {
   id: string;
   type: "table";
   props: DefaultProps;
-  content: TableContent[];
+  content: TableContent;
   children: Block[];
 };
 ```

--- a/docs/pages/docs/editor-basics/document-structure.mdx
+++ b/docs/pages/docs/editor-basics/document-structure.mdx
@@ -73,13 +73,16 @@ The `styles` property is explained below.
 
 While most blocks use an array of `InlineContent` objects to describe their content (e.g.: paragraphs, headings, list items). Some blocks, like [images](/docs/editor-basics/default-schema#image), don't contain any rich text content, so their `content` fields will be `undefined`.
 
-[Tables](/docs/editor-basics/default-schema#table) are also different, as they contain `TableContent`. Here, each table cell is represented as an array of `InlineContent` objects:
+[Tables](/docs/editor-basics/default-schema#table) are also different, as they contain `TableContent`. Here, each table cell is represented as an array of `InlineContent` objects with a width:
 
 ```typescript
 type TableContent = {
   type: "tableContent";
   rows: {
-    cells: InlineContent[][];
+    cells: {
+      content: InlineContent,
+      width?: number
+    }[][];
   }[];
 };
 ```

--- a/examples/01-basic/03-all-blocks/App.tsx
+++ b/examples/01-basic/03-all-blocks/App.tsx
@@ -50,13 +50,25 @@ export default function App() {
           type: "tableContent",
           rows: [
             {
-              cells: ["Table Cell", "Table Cell", "Table Cell"],
+              cells: [
+                { content: "Table Cell" },
+                { content: "Table Cell" },
+                { content: "Table Cell" },
+              ],
             },
             {
-              cells: ["Table Cell", "Table Cell", "Table Cell"],
+              cells: [
+                { content: "Table Cell" },
+                { content: "Table Cell" },
+                { content: "Table Cell" },
+              ],
             },
             {
-              cells: ["Table Cell", "Table Cell", "Table Cell"],
+              cells: [
+                { content: "Table Cell" },
+                { content: "Table Cell" },
+                { content: "Table Cell" },
+              ],
             },
           ],
         },

--- a/packages/core/src/api/parsers/html/__snapshots__/paste/parse-notion-html.json
+++ b/packages/core/src/api/parsers/html/__snapshots__/paste/parse-notion-html.json
@@ -373,77 +373,95 @@
       "rows": [
         {
           "cells": [
-            [
-              {
-                "type": "text",
-                "text": "Cell 1",
-                "styles": {}
-              }
-            ],
-            [
-              {
-                "type": "text",
-                "text": "Cell 2",
-                "styles": {}
-              }
-            ],
-            [
-              {
-                "type": "text",
-                "text": "Cell 3",
-                "styles": {}
-              }
-            ]
+            {
+              "content": [
+                {
+                  "type": "text",
+                  "text": "Cell 1",
+                  "styles": {}
+                }
+              ]
+            },
+            {
+              "content": [
+                {
+                  "type": "text",
+                  "text": "Cell 2",
+                  "styles": {}
+                }
+              ]
+            },
+            {
+              "content": [
+                {
+                  "type": "text",
+                  "text": "Cell 3",
+                  "styles": {}
+                }
+              ]
+            }
           ]
         },
         {
           "cells": [
-            [
-              {
-                "type": "text",
-                "text": "Cell 4",
-                "styles": {}
-              }
-            ],
-            [
-              {
-                "type": "text",
-                "text": "Cell 5",
-                "styles": {}
-              }
-            ],
-            [
-              {
-                "type": "text",
-                "text": "Cell 6",
-                "styles": {}
-              }
-            ]
+            {
+              "content": [
+                {
+                  "type": "text",
+                  "text": "Cell 4",
+                  "styles": {}
+                }
+              ]
+            },
+            {
+              "content": [
+                {
+                  "type": "text",
+                  "text": "Cell 5",
+                  "styles": {}
+                }
+              ]
+            },
+            {
+              "content": [
+                {
+                  "type": "text",
+                  "text": "Cell 6",
+                  "styles": {}
+                }
+              ]
+            }
           ]
         },
         {
           "cells": [
-            [
-              {
-                "type": "text",
-                "text": "Cell 7",
-                "styles": {}
-              }
-            ],
-            [
-              {
-                "type": "text",
-                "text": "Cell 8",
-                "styles": {}
-              }
-            ],
-            [
-              {
-                "type": "text",
-                "text": "Cell 9",
-                "styles": {}
-              }
-            ]
+            {
+              "content": [
+                {
+                  "type": "text",
+                  "text": "Cell 7",
+                  "styles": {}
+                }
+              ]
+            },
+            {
+              "content": [
+                {
+                  "type": "text",
+                  "text": "Cell 8",
+                  "styles": {}
+                }
+              ]
+            },
+            {
+              "content": [
+                {
+                  "type": "text",
+                  "text": "Cell 9",
+                  "styles": {}
+                }
+              ]
+            }
           ]
         }
       ]

--- a/packages/core/src/blocks/TableBlockContent/TableBlockContent.ts
+++ b/packages/core/src/blocks/TableBlockContent/TableBlockContent.ts
@@ -1,4 +1,4 @@
-import { Node } from "@tiptap/core";
+import { mergeAttributes, Node } from "@tiptap/core";
 import { TableCell } from "@tiptap/extension-table-cell";
 import { TableHeader } from "@tiptap/extension-table-header";
 import { TableRow } from "@tiptap/extension-table-row";
@@ -44,16 +44,8 @@ const TableParagraph = Node.create({
   group: "tableContent",
   content: "inline*",
 
-  addAttributes() {
-    return {
-      width: {
-        default: "default",
-      },
-    };
-  },
   parseHTML() {
     return [
-      { tag: "td" },
       {
         tag: "p",
         getAttrs: (element) => {
@@ -78,17 +70,11 @@ const TableParagraph = Node.create({
   },
 
   renderHTML({ HTMLAttributes }) {
-    const p = document.createElement("p");
-    p.style.setProperty("min-width", "100px", "important");
-
-    if (HTMLAttributes.width && HTMLAttributes.width !== "default") {
-      p.style.width = HTMLAttributes.width;
-    }
-
-    return {
-      dom: p,
-      contentDOM: p,
-    };
+    return [
+      "p",
+      mergeAttributes(this.options.HTMLAttributes, HTMLAttributes),
+      0,
+    ];
   },
 });
 

--- a/packages/core/src/blocks/TableBlockContent/TableBlockContent.ts
+++ b/packages/core/src/blocks/TableBlockContent/TableBlockContent.ts
@@ -1,4 +1,4 @@
-import { mergeAttributes, Node } from "@tiptap/core";
+import { Node } from "@tiptap/core";
 import { TableCell } from "@tiptap/extension-table-cell";
 import { TableHeader } from "@tiptap/extension-table-header";
 import { TableRow } from "@tiptap/extension-table-row";
@@ -44,6 +44,13 @@ const TableParagraph = Node.create({
   group: "tableContent",
   content: "inline*",
 
+  addAttributes() {
+    return {
+      width: {
+        default: "default",
+      },
+    };
+  },
   parseHTML() {
     return [
       { tag: "td" },
@@ -71,11 +78,17 @@ const TableParagraph = Node.create({
   },
 
   renderHTML({ HTMLAttributes }) {
-    return [
-      "p",
-      mergeAttributes(this.options.HTMLAttributes, HTMLAttributes),
-      0,
-    ];
+    const p = document.createElement("p");
+    p.style.setProperty("min-width", "100px", "important");
+
+    if (HTMLAttributes.width && HTMLAttributes.width !== "default") {
+      p.style.width = HTMLAttributes.width;
+    }
+
+    return {
+      dom: p,
+      contentDOM: p,
+    };
   },
 });
 

--- a/packages/core/src/extensions/SuggestionMenu/getDefaultSlashMenuItems.ts
+++ b/packages/core/src/extensions/SuggestionMenu/getDefaultSlashMenuItems.ts
@@ -179,10 +179,10 @@ export function getDefaultSlashMenuItems<
             type: "tableContent",
             rows: [
               {
-                cells: ["", "", ""],
+                cells: [{ content: "" }, { content: "" }, { content: "" }],
               },
               {
-                cells: ["", "", ""],
+                cells: [{ content: "" }, { content: "" }, { content: "" }],
               },
             ],
           },

--- a/packages/core/src/extensions/TableHandles/TableHandlesPlugin.ts
+++ b/packages/core/src/extensions/TableHandles/TableHandlesPlugin.ts
@@ -6,7 +6,6 @@ import type { BlockNoteEditor } from "../../editor/BlockNoteEditor";
 import {
   BlockFromConfigNoChildren,
   BlockSchemaWithBlock,
-  CellContent,
   InlineContentSchema,
   StyleSchema,
 } from "../../schema";
@@ -117,8 +116,6 @@ export class TableHandlesView<
     };
 
     pmView.dom.addEventListener("mousemove", this.mouseMoveHandler);
-    pmView.dom.addEventListener("mouseup", this.mouseUpHandler);
-    pmView.dom.addEventListener("mousedown", this.mouseDownHandler);
 
     document.addEventListener("dragover", this.dragOverHandler);
     document.addEventListener("drop", this.dropHandler);
@@ -362,110 +359,8 @@ export class TableHandlesView<
     }
   };
 
-  mouseDownHandler = (event: MouseEvent) => {
-    if (this.state === undefined) {
-      return;
-    }
-
-    if (this.state.block.type !== "table") {
-      return;
-    }
-
-    this.resizingTable = (event.target as any)?.closest("table") || undefined;
-    return;
-  };
-
-  mouseUpHandler = (event: MouseEvent) => {
-    if (this.state === undefined) {
-      return;
-    }
-
-    event.preventDefault();
-    if (this.state.block.type !== "table" || !this.resizingTable) {
-      return;
-    }
-    const rows = this.state.block.content.rows;
-
-    const cols = this.resizingTable.querySelectorAll("col") ?? [];
-    const colWidth = Array.from(cols).map((col) => col.style.width);
-    let columnWidthChanged = false;
-
-    const emptyCell = {
-      type: "text",
-      text: "",
-      styles: {},
-    };
-    const newRows = rows.map((row) => {
-      return {
-        cells: row.cells.map((cell, index) => {
-          if (typeof cell === "string") {
-            if (!colWidth[index]) {
-              return [
-                {
-                  ...emptyCell,
-                  text: cell,
-                },
-              ];
-            }
-            columnWidthChanged = true;
-            return [
-              {
-                ...emptyCell,
-                text: cell,
-                width: colWidth[index],
-              },
-            ];
-          }
-          if (cell.length === 0) {
-            if (!colWidth[index]) {
-              return [];
-            }
-            columnWidthChanged = true;
-            return [
-              {
-                ...emptyCell,
-                width: colWidth[index],
-              },
-            ];
-          }
-          return cell.map((c) => {
-            if (!colWidth[index]) {
-              return c;
-            }
-            if (c.width !== colWidth[index]) {
-              columnWidthChanged = true;
-            }
-            return {
-              ...c,
-              width: colWidth[index],
-            };
-          });
-        }),
-      };
-    }) as {
-      cells: CellContent<I, S>[];
-    }[];
-
-    if (!columnWidthChanged) {
-      return;
-    }
-    const savedState = this.state;
-    // wait for proseMirror to update the DOM
-    setTimeout(() => {
-      this.editor.updateBlock(savedState.block, {
-        type: "table",
-        content: {
-          type: "tableContent",
-          rows: newRows,
-        },
-      });
-    }, 10);
-  };
-
   destroy() {
     this.pmView.dom.removeEventListener("mousemove", this.mouseMoveHandler);
-    this.pmView.dom.removeEventListener("mousedown", this.mouseDownHandler);
-    this.pmView.dom.removeEventListener("mouseup", this.mouseUpHandler);
 
     document.removeEventListener("dragover", this.dragOverHandler);
     document.removeEventListener("drop", this.dropHandler);

--- a/packages/core/src/schema/blocks/types.ts
+++ b/packages/core/src/schema/blocks/types.ts
@@ -6,6 +6,7 @@ import type {
   InlineContent,
   InlineContentSchema,
   PartialInlineContent,
+  PartialInlineContentElement,
 } from "../inlineContent/types";
 import type { PropSchema, Props } from "../propTypes";
 import type { StyleSchema } from "../styles/types";
@@ -148,9 +149,13 @@ export type TableContent<
 > = {
   type: "tableContent";
   rows: {
-    cells: InlineContent<I, S>[][];
+    cells: CellContent<I, S>[];
   }[];
 };
+
+export type CellContent<I extends InlineContentSchema, T extends StyleSchema> =
+  | (InlineContent<I, T> & { width?: string })[]
+  | string;
 
 // A BlockConfig has all the information to get the type of a Block (which is a specific instance of the BlockConfig.
 // i.e.: paragraphConfig: BlockConfig defines what a "paragraph" is / supports, and BlockFromConfigNoChildren<paragraphConfig> is the shape of a specific paragraph block.
@@ -223,9 +228,14 @@ export type PartialTableContent<
 > = {
   type: "tableContent";
   rows: {
-    cells: PartialInlineContent<I, S>[];
+    cells: PartialCellContent<I, S>[];
   }[];
 };
+
+export type PartialCellContent<
+  I extends InlineContentSchema,
+  T extends StyleSchema
+> = (PartialInlineContentElement<I, T> & { width: string })[] | string;
 
 type PartialBlockFromConfigNoChildren<
   B extends BlockConfig,

--- a/packages/core/src/schema/blocks/types.ts
+++ b/packages/core/src/schema/blocks/types.ts
@@ -6,7 +6,6 @@ import type {
   InlineContent,
   InlineContentSchema,
   PartialInlineContent,
-  PartialInlineContentElement,
 } from "../inlineContent/types";
 import type { PropSchema, Props } from "../propTypes";
 import type { StyleSchema } from "../styles/types";
@@ -153,9 +152,13 @@ export type TableContent<
   }[];
 };
 
-export type CellContent<I extends InlineContentSchema, T extends StyleSchema> =
-  | (InlineContent<I, T> & { width?: string })[]
-  | string;
+export type CellContent<
+  I extends InlineContentSchema,
+  T extends StyleSchema
+> = {
+  content: InlineContent<I, T>[];
+  width?: number;
+};
 
 // A BlockConfig has all the information to get the type of a Block (which is a specific instance of the BlockConfig.
 // i.e.: paragraphConfig: BlockConfig defines what a "paragraph" is / supports, and BlockFromConfigNoChildren<paragraphConfig> is the shape of a specific paragraph block.
@@ -235,7 +238,10 @@ export type PartialTableContent<
 export type PartialCellContent<
   I extends InlineContentSchema,
   T extends StyleSchema
-> = (PartialInlineContentElement<I, T> & { width: string })[] | string;
+> = {
+  content: PartialInlineContent<I, T>;
+  width?: number;
+};
 
 type PartialBlockFromConfigNoChildren<
   B extends BlockConfig,

--- a/packages/core/src/schema/inlineContent/types.ts
+++ b/packages/core/src/schema/inlineContent/types.ts
@@ -115,7 +115,7 @@ export type InlineContent<
   T extends StyleSchema
 > = InlineContentFromConfig<I[keyof I], T>;
 
-type PartialInlineContentElement<
+export type PartialInlineContentElement<
   I extends InlineContentSchema,
   T extends StyleSchema
 > = PartialInlineContentFromConfig<I[keyof I], T>;

--- a/packages/react/src/components/TableHandles/TableHandleMenu/DefaultButtons/AddButton.tsx
+++ b/packages/react/src/components/TableHandles/TableHandleMenu/DefaultButtons/AddButton.tsx
@@ -31,7 +31,9 @@ export const AddRowButton = <
     <Components.Generic.Menu.Item
       onClick={() => {
         const emptyCol = props.block.content.rows[props.index].cells.map(
-          () => []
+          () => ({
+            content: [],
+          })
         );
         const rows = [...props.block.content.rows];
         rows.splice(props.index + (props.side === "below" ? 1 : 0), 0, {
@@ -73,7 +75,9 @@ export const AddColumnButton = <
           type: "tableContent",
           rows: props.block.content.rows.map((row) => {
             const cells = [...row.cells];
-            cells.splice(props.index + (props.side === "right" ? 1 : 0), 0, []);
+            cells.splice(props.index + (props.side === "right" ? 1 : 0), 0, {
+              content: [],
+            });
             return { cells };
           }),
         };


### PR DESCRIPTION
You can already resize table cells in BlockNote, but these use premade TipTap nodes and so their widths are not really accessible to get/set via the BlockNote API. This PR modifies the typing of `TableContent` so that you can now read and update table cell widths. Additionally, it fixes a small bug that was preventing the cell widths from being parsed correctly.

The changes I made are based on #846, but I don't have push rights to that remote repo so this PR replaces that one.

Closes #655 