### PR TITLE
add disableExtensions option to allow disabling built in extensions by name.

### DIFF
--- a/packages/core/src/editor/BlockNoteEditor.ts
+++ b/packages/core/src/editor/BlockNoteEditor.ts
@@ -75,7 +75,7 @@ export type BlockNoteEditorOptions<
 > = {
   // TODO: Figure out if enableBlockNoteExtensions/disableHistoryExtension are needed and document them.
   enableBlockNoteExtensions: boolean;
-
+  disableExtensions: string[];
   /**
    * A dictionary object containing translations for the editor.
    */
@@ -280,6 +280,7 @@ export class BlockNoteEditor<
       inlineContentSpecs: this.schema.inlineContentSpecs,
       collaboration: newOptions.collaboration,
       trailingBlock: newOptions.trailingBlock,
+      disableExtensions: newOptions.disableExtensions
     });
 
     const blockNoteUIExtension = Extension.create({

--- a/packages/core/src/editor/BlockNoteExtensions.ts
+++ b/packages/core/src/editor/BlockNoteExtensions.ts
@@ -53,6 +53,7 @@ export const getBlockNoteExtensions = <
     provider: any;
     renderCursor?: (user: any) => HTMLElement;
   };
+  disableExtensions: string[] | undefined;
 }) => {
   const ret: Extensions = [
     extensions.ClipboardTextSerializer,
@@ -193,5 +194,6 @@ export const getBlockNoteExtensions = <
     ret.push(History);
   }
 
-  return ret;
+  const disableExtensions: string[] = opts.disableExtensions || [];
+  return ret.filter(ex => !disableExtensions.includes(ex.name));
 };


### PR DESCRIPTION
Without completely needing to refactor the way tiptap extensions and core blocknote extensions are added, this should be fairly simple approach to just allow a list of extension names to be passed in that will then be removed from the inbuiult extensions before being passed to tiptap.

This will allow you to the override these extensions if you wish without completely disbaling blocknote via 
```
const editor = useCreateBlockNote({
    disableExtensions:['link'],
    _tiptapOptions: {
      extensions: [
        Link,
      ]
    }
  })
```
