### PR TITLE
Fix: [#860] TypeError: use_prefers_color_scheme__ is not a function

### DIFF
--- a/packages/mantine/src/index.tsx
+++ b/packages/mantine/src/index.tsx
@@ -12,7 +12,7 @@ import {
 } from "@blocknote/react";
 import { MantineProvider } from "@mantine/core";
 import { ComponentProps, useCallback } from "react";
-import usePrefersColorScheme from "use-prefers-color-scheme";
+import { usePrefersColorScheme } from "use-prefers-color-scheme";
 
 import {
   Theme,

--- a/packages/react/src/editor/BlockNoteView.tsx
+++ b/packages/react/src/editor/BlockNoteView.tsx
@@ -15,7 +15,7 @@ import React, {
   useMemo,
   useState,
 } from "react";
-import usePrefersColorScheme from "use-prefers-color-scheme";
+import { usePrefersColorScheme } from "use-prefers-color-scheme";
 import { useEditorChange } from "../hooks/useEditorChange";
 import { useEditorSelectionChange } from "../hooks/useEditorSelectionChange";
 import { BlockNoteContext, useBlockNoteContext } from "./BlockNoteContext";


### PR DESCRIPTION
usePrefersColorScheme is exported from use-prefers-color-scheme as named function and default

importing usePrefersColorScheme as named function will help in fixing the webpack 5 issue #860