### PR TITLE
fix: Drag preview issues

### DIFF
--- a/packages/core/src/editor/editor.css
+++ b/packages/core/src/editor/editor.css
@@ -62,7 +62,7 @@ Tippy popups that are appended to document.body directly
 
 .bn-drag-preview {
   position: absolute;
-  left: -100000px;
+  z-index: -1;
 }
 
 /* Give a remote user a caret */

--- a/packages/core/src/extensions/SideMenu/SideMenuPlugin.ts
+++ b/packages/core/src/extensions/SideMenu/SideMenuPlugin.ts
@@ -158,7 +158,7 @@ function unsetDragImage(rootEl: Document | ShadowRoot) {
     if (rootEl instanceof ShadowRoot) {
       rootEl.removeChild(dragImageElement);
     } else {
-      rootEl.body.appendChild(dragImageElement);
+      rootEl.body.removeChild(dragImageElement);
     }
 
     dragImageElement = undefined;


### PR DESCRIPTION
This PR fixes 2 issues with the drag preview for blocks:

1. Fixes a regression made in #849 where the preview element was added to the DOM on drop instead of removed, cluttering the DOM with each drop.
2. Fixes an edge case where drag previews were incorrectly displayed due to the preview element being outside of the editor.