### PR TITLE
fix: position of side menu controllers in `rtl`

### DIFF
--- a/packages/react/src/components/SideMenu/SideMenuController.tsx
+++ b/packages/react/src/components/SideMenu/SideMenuController.tsx
@@ -20,6 +20,7 @@ export const SideMenuController = <
   S extends StyleSchema = DefaultStyleSchema
 >(props: {
   sideMenu?: FC<SideMenuProps<BSchema, I, S>>;
+  dir?: "rtl" | "ltr";
 }) => {
   const editor = useBlockNoteEditor<BSchema, I, S>();
 
@@ -39,7 +40,7 @@ export const SideMenuController = <
     state?.referencePos || null,
     1000,
     {
-      placement: "left-start",
+      placement: props.dir === "rtl" ? "right-start" : "left-start",
     }
   );
 

--- a/packages/react/src/editor/BlockNoteDefaultUI.tsx
+++ b/packages/react/src/editor/BlockNoteDefaultUI.tsx
@@ -7,6 +7,7 @@ import { TableHandlesController } from "../components/TableHandles/TableHandlesC
 import { useBlockNoteEditor } from "../hooks/useBlockNoteEditor";
 
 export type BlockNoteDefaultUIProps = {
+  dir?: "rtl" | "ltr";
   formattingToolbar?: boolean;
   linkToolbar?: boolean;
   slashMenu?: boolean;
@@ -31,7 +32,7 @@ export function BlockNoteDefaultUI(props: BlockNoteDefaultUIProps) {
       {props.slashMenu !== false && (
         <SuggestionMenuController triggerCharacter="/" />
       )}
-      {props.sideMenu !== false && <SideMenuController />}
+      {props.sideMenu !== false && <SideMenuController dir={props.dir} />}
       {editor.filePanel && props.filePanel !== false && <FilePanelController />}
       {editor.tableHandles && props.tableHandles !== false && (
         <TableHandlesController />

--- a/packages/react/src/editor/BlockNoteView.tsx
+++ b/packages/react/src/editor/BlockNoteView.tsx
@@ -112,6 +112,7 @@ function BlockNoteViewComponent<
       <>
         {children}
         <BlockNoteDefaultUI
+          dir={props.dir}
           formattingToolbar={formattingToolbar}
           linkToolbar={linkToolbar}
           slashMenu={slashMenu}


### PR DESCRIPTION
This PR simply makes the side menu buttons to be in the correct position when layout is RTL.

# Before
![blocknote_rtl_before](https://github.com/user-attachments/assets/cc25a915-c5ea-457f-b010-1955f59d382e)


# After
![blocknote_rtl_after](https://github.com/user-attachments/assets/bd5af9f3-3f8e-4101-83a0-172e1cbcdcf5)
