### PR TITLE
fix: asset json import for emoji-mart data import

### DIFF
--- a/packages/core/src/extensions/SuggestionMenu/getDefaultEmojiPickerItems.ts
+++ b/packages/core/src/extensions/SuggestionMenu/getDefaultEmojiPickerItems.ts
@@ -1,4 +1,6 @@
-import data, { Emoji, EmojiMartData } from "@emoji-mart/data";
+import data from "@emoji-mart/data/sets/15/native.json" assert { type: "json" };
+
+import { Emoji, EmojiMartData } from "@emoji-mart/data";
 import { init, SearchIndex } from "emoji-mart";
 
 import { BlockSchema, InlineContentSchema, StyleSchema } from "../../schema";


### PR DESCRIPTION
fixes #930 (hopefully)

---

Not sure if there's a better way to import `native.json` from a general unspecified emoji set so that we don't have to increment the emoji set version every couple of years.