### PR TITLE
fix: Strikethrough shortcut in formatting toolbar button tooltip

### DIFF
--- a/packages/core/src/i18n/locales/en.ts
+++ b/packages/core/src/i18n/locales/en.ts
@@ -185,7 +185,7 @@ export const en = {
     },
     strike: {
       tooltip: "Strike",
-      secondary_tooltip: "Mod+Shift+X",
+      secondary_tooltip: "Mod+Shift+S",
     },
     code: {
       tooltip: "Code",


### PR DESCRIPTION
Closes #844 