### PR TITLE
fix: Side menu not actually freezing

### DIFF
--- a/packages/core/src/extensions/SideMenu/SideMenuPlugin.ts
+++ b/packages/core/src/extensions/SideMenu/SideMenuPlugin.ts
@@ -493,11 +493,16 @@ export class SideMenuView<
     if (this.state && this.state.show && this.menuFrozen) {
       this.menuFrozen = false;
       this.state.show = false;
+      console.log("hide click");
       this.emitUpdate(this.state);
     }
   };
 
   onMouseMove = (event: MouseEvent) => {
+    if (this.menuFrozen) {
+      return;
+    }
+
     this.mousePos = { x: event.clientX, y: event.clientY };
 
     // We want the full area of the editor to check if the cursor is hovering
@@ -526,7 +531,9 @@ export class SideMenuView<
       )
     ) {
       if (this.state?.show) {
+        // debugger;
         this.state.show = false;
+        // console.log("hide");
         this.emitUpdate(this.state);
       }
 

--- a/packages/core/src/extensions/SideMenu/SideMenuPlugin.ts
+++ b/packages/core/src/extensions/SideMenu/SideMenuPlugin.ts
@@ -493,7 +493,6 @@ export class SideMenuView<
     if (this.state && this.state.show && this.menuFrozen) {
       this.menuFrozen = false;
       this.state.show = false;
-      console.log("hide click");
       this.emitUpdate(this.state);
     }
   };
@@ -531,9 +530,7 @@ export class SideMenuView<
       )
     ) {
       if (this.state?.show) {
-        // debugger;
         this.state.show = false;
-        // console.log("hide");
         this.emitUpdate(this.state);
       }
 


### PR DESCRIPTION
Seems like `freezeMenu` was not actually fully freezing the side menu, as `mousemove` events were still being handled as normal and dispatching updates when they should be ignored.

Closes #911 