### PR TITLE
fix: Formatting toolbar opening on drop

### DIFF
--- a/packages/core/src/extensions/FormattingToolbar/FormattingToolbarPlugin.ts
+++ b/packages/core/src/extensions/FormattingToolbar/FormattingToolbarPlugin.ts
@@ -90,6 +90,11 @@ export class FormattingToolbarView implements PluginView {
   };
 
   update(view: EditorView, oldState?: EditorState) {
+    // Delays the update to handle edge case with drag and drop, where the view
+    // is blurred asynchronously and happens only after the state update.
+    // Wrapping in a setTimeout gives enough time to wait for the blur event to
+    // occur before updating the toolbar.
+    // setTimeout(() => {
     const { state, composing } = view;
     const { doc, selection } = state;
     const isSame =
@@ -139,6 +144,7 @@ export class FormattingToolbarView implements PluginView {
 
       return;
     }
+    // });
   }
 
   destroy() {

--- a/packages/core/src/extensions/SideMenu/SideMenuPlugin.ts
+++ b/packages/core/src/extensions/SideMenu/SideMenuPlugin.ts
@@ -436,19 +436,33 @@ export class SideMenuView<
 
     this.isDragging = false;
 
+    const evt = new Event("drop") as any;
+    evt.clientY = event.clientY;
+    evt.dataTransfer = event.dataTransfer;
+    // evt.preventDefault = () => event.preventDefault();
+
+    // Checks if cursor is outside the editor contents
     if (!pos || pos.inside === -1) {
-      const evt = new Event("drop", event) as any;
+      // Creates duplicate event with cursor centered horizontally on the editor
       const editorBoundingBox = (
         this.pmView.dom.firstChild! as HTMLElement
       ).getBoundingClientRect();
       evt.clientX = editorBoundingBox.left + editorBoundingBox.width / 2;
-      evt.clientY = event.clientY;
-      evt.dataTransfer = event.dataTransfer;
-      evt.preventDefault = () => event.preventDefault();
+
       evt.synthetic = true; // prevent recursion
-      // console.log("dispatch fake drop");
-      this.pmView.dom.dispatchEvent(evt);
+    } else {
+      // Creates duplicate event and prevents the original one from firing.
+      evt.clientX = event.clientX;
+
+      event.preventDefault();
+      event.stopPropagation();
     }
+
+    // Works
+    this.pmView.dom.dispatchEvent(evt);
+
+    // Doesn't work
+    // setTimeout(() => this.pmView.dom.dispatchEvent(evt), 1000);
   };
 
   /**

--- a/packages/core/src/extensions/SideMenu/SideMenuPlugin.ts
+++ b/packages/core/src/extensions/SideMenu/SideMenuPlugin.ts
@@ -436,33 +436,19 @@ export class SideMenuView<
 
     this.isDragging = false;
 
-    const evt = new Event("drop") as any;
-    evt.clientY = event.clientY;
-    evt.dataTransfer = event.dataTransfer;
-    // evt.preventDefault = () => event.preventDefault();
-
-    // Checks if cursor is outside the editor contents
     if (!pos || pos.inside === -1) {
-      // Creates duplicate event with cursor centered horizontally on the editor
+      const evt = new Event("drop", event) as any;
       const editorBoundingBox = (
         this.pmView.dom.firstChild! as HTMLElement
       ).getBoundingClientRect();
       evt.clientX = editorBoundingBox.left + editorBoundingBox.width / 2;
-
+      evt.clientY = event.clientY;
+      evt.dataTransfer = event.dataTransfer;
+      evt.preventDefault = () => event.preventDefault();
       evt.synthetic = true; // prevent recursion
-    } else {
-      // Creates duplicate event and prevents the original one from firing.
-      evt.clientX = event.clientX;
-
-      event.preventDefault();
-      event.stopPropagation();
+      // console.log("dispatch fake drop");
+      this.pmView.dom.dispatchEvent(evt);
     }
-
-    // Works
-    this.pmView.dom.dispatchEvent(evt);
-
-    // Doesn't work
-    // setTimeout(() => this.pmView.dom.dispatchEvent(evt), 1000);
   };
 
   /**


### PR DESCRIPTION
When you drag & drop a block, the editor is blurred and its state is updated. However, the blur gets handled async and so the state updates before the editor has actually been blurred. This is a problem for the formatting toolbar, which updates whenever the editor state does but also needs to know if the editor is blurred to decide whether to show. Like the editor state, it also updates before the editor is blurred, and so it shows up on drop. Additionally, the blur doesn't trigger a state update, only a view update, and so doesn't re-trigger an update on the formatting toolbar.

This PR re-adds the blur event listener to the editor, for the formatting toolbar to update whenever the editor loses focus. This is not totally ideal as it gets updated twice on drop, but I think it's cleaner than delaying the update using a `setTimeout` instead which is the alternative approach. Accessibility using the keyboard still works with these changes.

Closes #929 