### PR TITLE
fix: Dropping blocks above editor

### DIFF
--- a/packages/core/src/extensions/FormattingToolbar/FormattingToolbarPlugin.ts
+++ b/packages/core/src/extensions/FormattingToolbar/FormattingToolbarPlugin.ts
@@ -58,44 +58,12 @@ export class FormattingToolbarView implements PluginView {
     pmView.dom.addEventListener("mouseup", this.viewMouseupHandler);
     pmView.dom.addEventListener("dragstart", this.dragHandler);
     pmView.dom.addEventListener("dragover", this.dragHandler);
-    pmView.dom.addEventListener("blur", this.blurHandler);
 
     // Setting capture=true ensures that any parent container of the editor that
     // gets scrolled will trigger the scroll event. Scroll events do not bubble
     // and so won't propagate to the document by default.
     pmView.root.addEventListener("scroll", this.scrollHandler, true);
   }
-
-  blurHandler = (event: FocusEvent) => {
-    if (this.preventHide) {
-      this.preventHide = false;
-
-      return;
-    }
-
-    const editorWrapper = this.pmView.dom.parentElement!;
-
-    // Checks if the focus is moving to an element outside the editor. If it is,
-    // the toolbar is hidden.
-    if (
-      // An element is clicked.
-      event &&
-      event.relatedTarget &&
-      // Element is inside the editor.
-      (editorWrapper === (event.relatedTarget as Node) ||
-        editorWrapper.contains(event.relatedTarget as Node) ||
-        (event.relatedTarget as HTMLElement).matches(
-          ".bn-ui-container, .bn-ui-container *"
-        ))
-    ) {
-      return;
-    }
-
-    if (this.state?.show) {
-      this.state.show = false;
-      this.emitUpdate();
-    }
-  };
 
   viewMousedownHandler = () => {
     this.preventShow = true;
@@ -122,10 +90,6 @@ export class FormattingToolbarView implements PluginView {
   };
 
   update(view: EditorView, oldState?: EditorState) {
-    // Delays the update to handle edge case with drag and drop, where the view
-    // is blurred asynchronously and happens only after the state update.
-    // Wrapping in a setTimeout gives enough time to wait for the blur event to
-    // occur before updating the toolbar.
     const { state, composing } = view;
     const { doc, selection } = state;
     const isSame =
@@ -182,7 +146,6 @@ export class FormattingToolbarView implements PluginView {
     this.pmView.dom.removeEventListener("mouseup", this.viewMouseupHandler);
     this.pmView.dom.removeEventListener("dragstart", this.dragHandler);
     this.pmView.dom.removeEventListener("dragover", this.dragHandler);
-    this.pmView.dom.removeEventListener("blur", this.blurHandler);
 
     this.pmView.root.removeEventListener("scroll", this.scrollHandler, true);
   }

--- a/packages/core/src/extensions/FormattingToolbar/FormattingToolbarPlugin.ts
+++ b/packages/core/src/extensions/FormattingToolbar/FormattingToolbarPlugin.ts
@@ -58,7 +58,6 @@ export class FormattingToolbarView implements PluginView {
     pmView.dom.addEventListener("mouseup", this.viewMouseupHandler);
     pmView.dom.addEventListener("dragstart", this.dragHandler);
     pmView.dom.addEventListener("dragover", this.dragHandler);
-    pmView.dom.addEventListener("focus", this.focusHandler);
     pmView.dom.addEventListener("blur", this.blurHandler);
 
     // Setting capture=true ensures that any parent container of the editor that
@@ -66,10 +65,6 @@ export class FormattingToolbarView implements PluginView {
     // and so won't propagate to the document by default.
     pmView.root.addEventListener("scroll", this.scrollHandler, true);
   }
-
-  focusHandler = () => {
-    this.update(this.pmView);
-  };
 
   blurHandler = (event: FocusEvent) => {
     if (this.preventHide) {
@@ -187,7 +182,6 @@ export class FormattingToolbarView implements PluginView {
     this.pmView.dom.removeEventListener("mouseup", this.viewMouseupHandler);
     this.pmView.dom.removeEventListener("dragstart", this.dragHandler);
     this.pmView.dom.removeEventListener("dragover", this.dragHandler);
-    this.pmView.dom.removeEventListener("focus", this.focusHandler);
     this.pmView.dom.removeEventListener("blur", this.blurHandler);
 
     this.pmView.root.removeEventListener("scroll", this.scrollHandler, true);

--- a/packages/core/src/extensions/FormattingToolbar/FormattingToolbarPlugin.ts
+++ b/packages/core/src/extensions/FormattingToolbar/FormattingToolbarPlugin.ts
@@ -90,6 +90,11 @@ export class FormattingToolbarView implements PluginView {
   };
 
   update(view: EditorView, oldState?: EditorState) {
+    // Delays the update to handle edge case with drag and drop, where the view
+    // is blurred asynchronously and happens only after the state update.
+    // Wrapping in a setTimeout gives enough time to wait for the blur event to
+    // occur before updating the toolbar.
+    // setTimeout(() => {
     const { state, composing } = view;
     const { doc, selection } = state;
     const isSame =
@@ -139,6 +144,7 @@ export class FormattingToolbarView implements PluginView {
 
       return;
     }
+    // });
   }
 
   destroy() {

--- a/packages/core/src/extensions/SideMenu/SideMenuPlugin.ts
+++ b/packages/core/src/extensions/SideMenu/SideMenuPlugin.ts
@@ -436,19 +436,33 @@ export class SideMenuView<
 
     this.isDragging = false;
 
+    const evt = new Event("drop") as any;
+    evt.clientY = event.clientY;
+    evt.dataTransfer = event.dataTransfer;
+    // evt.preventDefault = () => event.preventDefault();
+
+    // Checks if cursor is outside the editor contents
     if (!pos || pos.inside === -1) {
-      const evt = new Event("drop", event) as any;
+      // Creates duplicate event with cursor centered horizontally on the editor
       const editorBoundingBox = (
         this.pmView.dom.firstChild! as HTMLElement
       ).getBoundingClientRect();
       evt.clientX = editorBoundingBox.left + editorBoundingBox.width / 2;
-      evt.clientY = event.clientY;
-      evt.dataTransfer = event.dataTransfer;
-      evt.preventDefault = () => event.preventDefault();
+
       evt.synthetic = true; // prevent recursion
-      // console.log("dispatch fake drop");
-      this.pmView.dom.dispatchEvent(evt);
+    } else {
+      // Creates duplicate event and prevents the original one from firing.
+      evt.clientX = event.clientX;
+
+      event.preventDefault();
+      event.stopPropagation();
     }
+
+    // Works
+    this.pmView.dom.dispatchEvent(evt);
+
+    // Doesn't work
+    // setTimeout(() => this.pmView.dom.dispatchEvent(evt), 1000);
   };
 
   /**

--- a/packages/core/src/extensions/SideMenu/SideMenuPlugin.ts
+++ b/packages/core/src/extensions/SideMenu/SideMenuPlugin.ts
@@ -441,8 +441,15 @@ export class SideMenuView<
       const editorBoundingBox = (
         this.pmView.dom.firstChild! as HTMLElement
       ).getBoundingClientRect();
-      evt.clientX = editorBoundingBox.left + editorBoundingBox.width / 2;
-      evt.clientY = event.clientY;
+      evt.clientX =
+        event.clientX < editorBoundingBox.left ||
+        event.clientX > editorBoundingBox.left + editorBoundingBox.width
+          ? editorBoundingBox.left + editorBoundingBox.width / 2
+          : event.clientX;
+      evt.clientY = Math.min(
+        Math.max(event.clientY, editorBoundingBox.top),
+        editorBoundingBox.top + editorBoundingBox.height
+      );
       evt.dataTransfer = event.dataTransfer;
       evt.preventDefault = () => event.preventDefault();
       evt.synthetic = true; // prevent recursion

--- a/packages/core/src/extensions/SideMenu/SideMenuPlugin.ts
+++ b/packages/core/src/extensions/SideMenu/SideMenuPlugin.ts
@@ -436,33 +436,19 @@ export class SideMenuView<
 
     this.isDragging = false;
 
-    const evt = new Event("drop") as any;
-    evt.clientY = event.clientY;
-    evt.dataTransfer = event.dataTransfer;
-    // evt.preventDefault = () => event.preventDefault();
-
-    // Checks if cursor is outside the editor contents
     if (!pos || pos.inside === -1) {
-      // Creates duplicate event with cursor centered horizontally on the editor
+      const evt = new Event("drop", event) as any;
       const editorBoundingBox = (
         this.pmView.dom.firstChild! as HTMLElement
       ).getBoundingClientRect();
       evt.clientX = editorBoundingBox.left + editorBoundingBox.width / 2;
-
+      evt.clientY = event.clientY;
+      evt.dataTransfer = event.dataTransfer;
+      evt.preventDefault = () => event.preventDefault();
       evt.synthetic = true; // prevent recursion
-    } else {
-      // Creates duplicate event and prevents the original one from firing.
-      evt.clientX = event.clientX;
-
-      event.preventDefault();
-      event.stopPropagation();
+      // console.log("dispatch fake drop");
+      this.pmView.dom.dispatchEvent(evt);
     }
-
-    // Works
-    this.pmView.dom.dispatchEvent(evt);
-
-    // Doesn't work
-    // setTimeout(() => this.pmView.dom.dispatchEvent(evt), 1000);
   };
 
   /**


### PR DESCRIPTION
Even though the drop cursor still appears when the mouse cursor is beyond the editor vertically, letting go of the mouse button doesn't actually trigger a drop in the editor. This PR fixes that by restricting the mouse cursor y-coordinate to the editor's bounding box on drop.

Closes #934 