### PR TITLE
fix: emojimart import

### DIFF
--- a/packages/core/src/extensions/SuggestionMenu/getDefaultEmojiPickerItems.ts
+++ b/packages/core/src/extensions/SuggestionMenu/getDefaultEmojiPickerItems.ts
@@ -1,5 +1,5 @@
 import type { Emoji, EmojiMartData } from "@emoji-mart/data";
-import { SearchIndex, init } from "emoji-mart";
+import emojimart from "emoji-mart";
 import { checkDefaultInlineContentTypeInSchema } from "../../blocks/defaultBlockTypeGuards";
 import { BlockNoteEditor } from "../../editor/BlockNoteEditor";
 import { BlockSchema, InlineContentSchema, StyleSchema } from "../../schema";
@@ -28,7 +28,7 @@ export async function getDefaultEmojiPickerItems<
     // and a smaller initial client bundle size
     data = import("@emoji-mart/data", { assert: { type: "json" } }) as any;
     const emojiMartData = (await data)!.default;
-    await init({ data: emojiMartData });
+    await emojimart.init({ data: emojiMartData });
   }
 
   const emojiMartData = (await data)!.default;
@@ -36,7 +36,7 @@ export async function getDefaultEmojiPickerItems<
   const emojisToShow =
     query.trim() === ""
       ? Object.values(emojiMartData.emojis)
-      : ((await SearchIndex.search(query)) as Emoji[]);
+      : ((await emojimart.SearchIndex.search(query)) as Emoji[]);
 
   return emojisToShow.map((emoji) => ({
     id: emoji.skins[0].native,


### PR DESCRIPTION
temporary fix following this solution: https://stackoverflow.com/questions/76767943/how-to-import-esm-libraries-without-setting-type-module-in-package-json-fil

- root cause in emoji-mart: https://github.com/missive/emoji-mart/pull/929