### PR TITLE
fix: make package exports explicit

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,47 +1,255 @@
 import * as locales from "./i18n/locales";
-export * from "./api/exporters/html/externalHTMLExporter";
-export * from "./api/exporters/html/internalHTMLSerializer";
-export * from "./api/testUtil";
-export * from "./blocks/AudioBlockContent/AudioBlockContent";
-export * from "./blocks/FileBlockContent/FileBlockContent";
-export * from "./blocks/ImageBlockContent/ImageBlockContent";
-export * from "./blocks/VideoBlockContent/VideoBlockContent";
+export {
+  type ExternalHTMLExporter,
+  createExternalHTMLExporter,
+} from "./api/exporters/html/externalHTMLExporter";
+export {
+  type InternalHTMLSerializer,
+  createInternalHTMLSerializer,
+} from "./api/exporters/html/internalHTMLSerializer";
+export { EditorTestCases } from "./api/testUtil";
+export {
+  AudioBlock,
+  audioBlockConfig,
+  audioParse,
+  audioPropSchema,
+  audioRender,
+  audioToExternalHTML,
+} from "./blocks/AudioBlockContent/AudioBlockContent";
+export {
+  FileBlock,
+  fileBlockConfig,
+  fileParse,
+  filePropSchema,
+  fileRender,
+  fileToExternalHTML,
+} from "./blocks/FileBlockContent/FileBlockContent";
+export {
+  ImageBlock,
+  imageBlockConfig,
+  imageParse,
+  imagePropSchema,
+  imageRender,
+  imageToExternalHTML,
+} from "./blocks/ImageBlockContent/ImageBlockContent";
+export {
+  VideoBlock,
+  videoBlockConfig,
+  videoParse,
+  videoPropSchema,
+  videoRender,
+  videoToExternalHTML,
+} from "./blocks/VideoBlockContent/VideoBlockContent";
 
-export * from "./blocks/FileBlockContent/fileBlockHelpers";
-export * from "./blocks/FileBlockContent/uploadToTmpFilesDotOrg_DEV_ONLY";
+export {
+  createAddFileButton,
+  createDefaultFilePreview,
+  createFigureWithCaption,
+  createFileAndCaptionWrapper,
+  createLinkWithCaption,
+  createResizeHandlesWrapper,
+  parseEmbedElement,
+  parseFigureElement,
+} from "./blocks/FileBlockContent/fileBlockHelpers";
+export { uploadToTmpFilesDotOrg_DEV_ONLY } from "./blocks/FileBlockContent/uploadToTmpFilesDotOrg_DEV_ONLY";
 export { parseImageElement } from "./blocks/ImageBlockContent/imageBlockHelpers";
-export * from "./blocks/defaultBlockTypeGuards";
-export * from "./blocks/defaultBlocks";
-export * from "./blocks/defaultProps";
-export * from "./editor/BlockNoteEditor";
-export * from "./editor/BlockNoteExtensions";
-export * from "./editor/BlockNoteSchema";
-export * from "./editor/selectionTypes";
-export * from "./extensions-shared/UiElementPosition";
-export * from "./extensions/FilePanel/FilePanelPlugin";
-export * from "./extensions/FormattingToolbar/FormattingToolbarPlugin";
-export * from "./extensions/LinkToolbar/LinkToolbarPlugin";
-export * from "./extensions/SideMenu/SideMenuPlugin";
-export * from "./extensions/SuggestionMenu/DefaultSuggestionItem";
-export * from "./extensions/SuggestionMenu/DefaultGridSuggestionItem";
-export * from "./extensions/SuggestionMenu/SuggestionPlugin";
-export * from "./extensions/SuggestionMenu/getDefaultSlashMenuItems";
-export * from "./extensions/SuggestionMenu/getDefaultEmojiPickerItems";
-export * from "./extensions/TableHandles/TableHandlesPlugin";
-export * from "./i18n/dictionary";
-export * from "./schema";
-export * from "./util/browser";
-export * from "./util/string";
-export * from "./util/typescript";
-export { UnreachableCaseError, assertEmpty } from "./util/typescript";
+export {
+  checkBlockHasDefaultProp,
+  checkBlockIsDefaultType,
+  checkBlockIsFileBlock,
+  checkBlockIsFileBlockWithPlaceholder,
+  checkBlockIsFileBlockWithPreview,
+  checkBlockTypeHasDefaultProp,
+  checkDefaultBlockTypeInSchema,
+  checkDefaultInlineContentTypeInSchema,
+} from "./blocks/defaultBlockTypeGuards";
+export {
+  type Block,
+  type DefaultBlockSchema,
+  type DefaultInlineContentSchema,
+  type DefaultStyleSchema,
+  type PartialBlock,
+  type _DefaultBlockSchema,
+  type _DefaultInlineContentSchema,
+  type _DefaultStyleSchema,
+  defaultBlockSchema,
+  defaultBlockSpecs,
+  defaultInlineContentSchema,
+  defaultInlineContentSpecs,
+  defaultStyleSchema,
+  defaultStyleSpecs,
+} from "./blocks/defaultBlocks";
+export {
+  type DefaultProps,
+  defaultProps,
+  inheritedProps,
+} from "./blocks/defaultProps";
+export {
+  BlockNoteEditor,
+  type BlockNoteEditorOptions,
+} from "./editor/BlockNoteEditor";
+export { getBlockNoteExtensions } from "./editor/BlockNoteExtensions";
+export { BlockNoteSchema } from "./editor/BlockNoteSchema";
+export { Selection } from "./editor/selectionTypes";
+export { UiElementPosition } from "./extensions-shared/UiElementPosition";
+export {
+  FilePanelProsemirrorPlugin,
+  type FilePanelState,
+  FilePanelView,
+} from "./extensions/FilePanel/FilePanelPlugin";
+export {
+  FormattingToolbarProsemirrorPlugin,
+  type FormattingToolbarState,
+  FormattingToolbarView,
+  formattingToolbarPluginKey,
+} from "./extensions/FormattingToolbar/FormattingToolbarPlugin";
+export {
+  LinkToolbarProsemirrorPlugin,
+  type LinkToolbarState,
+  linkToolbarPluginKey,
+} from "./extensions/LinkToolbar/LinkToolbarPlugin";
+export {
+  SideMenuProsemirrorPlugin,
+  type SideMenuState,
+  SideMenuView,
+  sideMenuPluginKey,
+  getDraggableBlockFromElement,
+} from "./extensions/SideMenu/SideMenuPlugin";
+export { DefaultSuggestionItem } from "./extensions/SuggestionMenu/DefaultSuggestionItem";
+export { DefaultGridSuggestionItem } from "./extensions/SuggestionMenu/DefaultGridSuggestionItem";
+export {
+  SuggestionMenuProseMirrorPlugin,
+  type SuggestionMenuState,
+  createSuggestionMenu,
+} from "./extensions/SuggestionMenu/SuggestionPlugin";
+export {
+  filterSuggestionItems,
+  getDefaultSlashMenuItems,
+  insertOrUpdateBlock,
+} from "./extensions/SuggestionMenu/getDefaultSlashMenuItems";
+export { getDefaultEmojiPickerItems } from "./extensions/SuggestionMenu/getDefaultEmojiPickerItems";
+export {
+  TableHandlesProsemirrorPlugin,
+  type TableHandlesState,
+  TableHandlesView,
+  tableHandlesPluginKey,
+} from "./extensions/TableHandles/TableHandlesPlugin";
+export { Dictionary } from "./i18n/dictionary";
+export {
+  type BlockConfig,
+  type BlockFromConfig,
+  type BlockFromConfigNoChildren,
+  type BlockIdentifier,
+  type BlockImplementations,
+  type BlockNoDefaults,
+  type BlockNoteDOMAttributes,
+  type BlockNoteDOMElement,
+  type BlockSchema,
+  type BlockSchemaFromSpecs,
+  type BlockSpecs,
+  type BlockSchemaWithBlock,
+  type BlockSpec,
+  type CustomBlockConfig,
+  type CustomBlockImplementation,
+  type CustomInlineContentConfig,
+  type CustomInlineContentFromConfig,
+  type CustomInlineContentImplementation,
+  type CustomStyleImplementation,
+  type FileBlockConfig,
+  type InlineContent,
+  type InlineContentConfig,
+  type InlineContentFromConfig,
+  type InlineContentImplementation,
+  type InlineContentSchema,
+  type InlineContentSpecs,
+  type InlineContentSchemaFromSpecs,
+  type InlineContentSpec,
+  type Link,
+  type PartialBlockFromConfig,
+  type PartialBlockNoDefaults,
+  type PartialCustomInlineContentFromConfig,
+  type PartialInlineContent,
+  type PartialInlineContentFromConfig,
+  type PartialLink,
+  type PartialTableContent,
+  type PropSchema,
+  type PropSpec,
+  type Props,
+  type SpecificBlock,
+  type SpecificPartialBlock,
+  type StyleConfig,
+  type StyleImplementation,
+  type StylePropSchema,
+  type StyleSchema,
+  type StyleSpec,
+  type StyleSpecs,
+  type StyleSchemaFromSpecs,
+  type StyledText,
+  type Styles,
+  type TableContent,
+  type TiptapBlockImplementation,
+  addInlineContentAttributes,
+  addInlineContentKeyboardShortcuts,
+  addStyleAttributes,
+  createBlockSpec,
+  createBlockSpecFromStronglyTypedTiptapNode,
+  createInlineContentSpec,
+  createInlineContentSpecFromTipTapNode,
+  createInternalBlockSpec,
+  createInternalInlineContentSpec,
+  createInternalStyleSpec,
+  createStronglyTypedTiptapNode,
+  createStyleSpec,
+  createStyleSpecFromTipTapMark,
+  getBlockFromPos,
+  getBlockSchemaFromSpecs,
+  getInlineContentParseRules,
+  getInlineContentSchemaFromSpecs,
+  getParseRules,
+  getStyleParseRules,
+  getStyleSchemaFromSpecs,
+  isLinkInlineContent,
+  isPartialLinkInlineContent,
+  isStyledTextInlineContent,
+  propsToAttributes,
+  stylePropsToAttributes,
+  wrapInBlockStructure,
+} from "./schema";
+export {
+  formatKeyboardShortcut,
+  isAppleOS,
+  isSafari,
+  mergeCSSClasses,
+} from "./util/browser";
+export { camelToDataKebab, filenameFromURL } from "./util/string";
+export {
+  type NoInfer,
+  UnreachableCaseError,
+  assertEmpty,
+} from "./util/typescript";
 export { locales };
 
 // for testing from react (TODO: move):
-export * from "./api/nodeConversions/nodeConversions";
-export * from "./api/testUtil/partialBlockTestUtil";
-export * from "./extensions/UniqueID/UniqueID";
+export {
+  blockToNode,
+  contentNodeToInlineContent,
+  inlineContentToNodes,
+  nodeToBlock,
+  nodeToCustomInlineContent,
+  tableContentToNodes,
+} from "./api/nodeConversions/nodeConversions";
+export {
+  addIdsToBlock,
+  addIdsToBlocks,
+  partialBlockToBlockForTesting,
+  partialBlocksToBlocksForTesting,
+} from "./api/testUtil/partialBlockTestUtil";
+export { UniqueID } from "./extensions/UniqueID/UniqueID";
 
 // for server-util (TODO: maybe move):
-export * from "./api/exporters/markdown/markdownExporter";
-export * from "./api/parsers/html/parseHTML";
-export * from "./api/parsers/markdown/parseMarkdown";
+export {
+  blocksToMarkdown,
+  cleanHTMLToMarkdown,
+} from "./api/exporters/markdown/markdownExporter";
+export { HTMLToBlocks } from "./api/parsers/html/parseHTML";
+export { markdownToBlocks } from "./api/parsers/markdown/parseMarkdown";

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -1,91 +1,160 @@
 // TODO: review directories
-export * from "./editor/BlockNoteContext";
-export * from "./editor/BlockNoteDefaultUI";
-export * from "./editor/BlockNoteView";
-export * from "./editor/ComponentsContext";
-export * from "./i18n/dictionary";
+export {
+  BlockNoteContext,
+  useBlockNoteContext,
+} from "./editor/BlockNoteContext";
+export {
+  BlockNoteDefaultUI,
+  type BlockNoteDefaultUIProps,
+} from "./editor/BlockNoteDefaultUI";
+export { BlockNoteViewProps, BlockNoteViewRaw } from "./editor/BlockNoteView";
+export {
+  type ComponentProps,
+  type Components,
+  ComponentsContext,
+  useComponentsContext,
+} from "./editor/ComponentsContext";
+export { useDictionary } from "./i18n/dictionary";
 
-export * from "./blocks/AudioBlockContent/AudioBlockContent";
-export * from "./blocks/FileBlockContent/FileBlockContent";
-export * from "./blocks/FileBlockContent/fileBlockHelpers";
-export * from "./blocks/FileBlockContent/useResolveUrl";
-export * from "./blocks/ImageBlockContent/ImageBlockContent";
-export * from "./blocks/VideoBlockContent/VideoBlockContent";
+export {
+  AudioPreview,
+  AudioToExternalHTML,
+  ReactAudioBlock,
+} from "./blocks/AudioBlockContent/AudioBlockContent";
+export {
+  FileToExternalHTML,
+  ReactFileBlock,
+} from "./blocks/FileBlockContent/FileBlockContent";
+export {
+  AddFileButton,
+  DefaultFilePreview,
+  FigureWithCaption,
+  FileAndCaptionWrapper,
+  LinkWithCaption,
+  ResizeHandlesWrapper,
+} from "./blocks/FileBlockContent/fileBlockHelpers";
+export { useResolveUrl } from "./blocks/FileBlockContent/useResolveUrl";
+export {
+  ImagePreview,
+  ImageToExternalHTML,
+  ReactImageBlock,
+} from "./blocks/ImageBlockContent/ImageBlockContent";
+export {
+  ReactVideoBlock,
+  VideoPreview,
+  VideoToExternalHTML,
+} from "./blocks/VideoBlockContent/VideoBlockContent";
 
-export * from "./components/FormattingToolbar/DefaultButtons/BasicTextStyleButton";
-export * from "./components/FormattingToolbar/DefaultButtons/ColorStyleButton";
-export * from "./components/FormattingToolbar/DefaultButtons/CreateLinkButton";
-export * from "./components/FormattingToolbar/DefaultButtons/FileCaptionButton";
-export * from "./components/FormattingToolbar/DefaultButtons/NestBlockButtons";
-export * from "./components/FormattingToolbar/DefaultButtons/FileReplaceButton";
-export * from "./components/FormattingToolbar/DefaultButtons/TextAlignButton";
-export * from "./components/FormattingToolbar/DefaultSelects/BlockTypeSelect";
-export * from "./components/FormattingToolbar/FormattingToolbar";
-export * from "./components/FormattingToolbar/FormattingToolbarController";
-export * from "./components/FormattingToolbar/FormattingToolbarProps";
+export { BasicTextStyleButton } from "./components/FormattingToolbar/DefaultButtons/BasicTextStyleButton";
+export { ColorStyleButton } from "./components/FormattingToolbar/DefaultButtons/ColorStyleButton";
+export { CreateLinkButton } from "./components/FormattingToolbar/DefaultButtons/CreateLinkButton";
+export { FileCaptionButton } from "./components/FormattingToolbar/DefaultButtons/FileCaptionButton";
+export {
+  NestBlockButton,
+  UnnestBlockButton,
+} from "./components/FormattingToolbar/DefaultButtons/NestBlockButtons";
+export { FileReplaceButton } from "./components/FormattingToolbar/DefaultButtons/FileReplaceButton";
+export { TextAlignButton } from "./components/FormattingToolbar/DefaultButtons/TextAlignButton";
+export {
+  BlockTypeSelect,
+  type BlockTypeSelectItem,
+  blockTypeSelectItems,
+} from "./components/FormattingToolbar/DefaultSelects/BlockTypeSelect";
+export {
+  FormattingToolbar,
+  getFormattingToolbarItems,
+} from "./components/FormattingToolbar/FormattingToolbar";
+export { FormattingToolbarController } from "./components/FormattingToolbar/FormattingToolbarController";
+export { type FormattingToolbarProps } from "./components/FormattingToolbar/FormattingToolbarProps";
 
-export * from "./components/LinkToolbar/DefaultButtons/DeleteLinkButton";
-export * from "./components/LinkToolbar/DefaultButtons/EditLinkButton";
-export * from "./components/LinkToolbar/DefaultButtons/OpenLinkButton";
-export * from "./components/LinkToolbar/EditLinkMenuItems";
-export * from "./components/LinkToolbar/LinkToolbar";
-export * from "./components/LinkToolbar/LinkToolbarController";
-export * from "./components/LinkToolbar/LinkToolbarProps";
+export { DeleteLinkButton } from "./components/LinkToolbar/DefaultButtons/DeleteLinkButton";
+export { EditLinkButton } from "./components/LinkToolbar/DefaultButtons/EditLinkButton";
+export { OpenLinkButton } from "./components/LinkToolbar/DefaultButtons/OpenLinkButton";
+export { EditLinkMenuItems } from "./components/LinkToolbar/EditLinkMenuItems";
+export { LinkToolbar } from "./components/LinkToolbar/LinkToolbar";
+export { LinkToolbarController } from "./components/LinkToolbar/LinkToolbarController";
+export { type LinkToolbarProps } from "./components/LinkToolbar/LinkToolbarProps";
 
-export * from "./components/SideMenu/DefaultButtons/AddBlockButton";
-export * from "./components/SideMenu/DefaultButtons/DragHandleButton";
-export * from "./components/SideMenu/SideMenu";
-export * from "./components/SideMenu/SideMenuController";
-export * from "./components/SideMenu/SideMenuProps";
+export { AddBlockButton } from "./components/SideMenu/DefaultButtons/AddBlockButton";
+export { DragHandleButton } from "./components/SideMenu/DefaultButtons/DragHandleButton";
+export { SideMenu } from "./components/SideMenu/SideMenu";
+export { SideMenuController } from "./components/SideMenu/SideMenuController";
+export { type SideMenuProps } from "./components/SideMenu/SideMenuProps";
 
-export * from "./components/SideMenu/DragHandleMenu/DefaultItems/BlockColorsItem";
-export * from "./components/SideMenu/DragHandleMenu/DefaultItems/RemoveBlockItem";
-export * from "./components/SideMenu/DragHandleMenu/DragHandleMenu";
-export * from "./components/SideMenu/DragHandleMenu/DragHandleMenuProps";
+export { BlockColorsItem } from "./components/SideMenu/DragHandleMenu/DefaultItems/BlockColorsItem";
+export { RemoveBlockItem } from "./components/SideMenu/DragHandleMenu/DefaultItems/RemoveBlockItem";
+export { DragHandleMenu } from "./components/SideMenu/DragHandleMenu/DragHandleMenu";
+export { type DragHandleMenuProps } from "./components/SideMenu/DragHandleMenu/DragHandleMenuProps";
 
-export * from "./components/SuggestionMenu/SuggestionMenuController";
-export * from "./components/SuggestionMenu/SuggestionMenuWrapper";
-export * from "./components/SuggestionMenu/getDefaultReactSlashMenuItems";
-export * from "./components/SuggestionMenu/hooks/useCloseSuggestionMenuNoItems";
-export * from "./components/SuggestionMenu/hooks/useLoadSuggestionMenuItems";
-export * from "./components/SuggestionMenu/hooks/useSuggestionMenuKeyboardNavigation";
-export * from "./components/SuggestionMenu/types";
+export { SuggestionMenuController } from "./components/SuggestionMenu/SuggestionMenuController";
+export { SuggestionMenuWrapper } from "./components/SuggestionMenu/SuggestionMenuWrapper";
+export { getDefaultReactSlashMenuItems } from "./components/SuggestionMenu/getDefaultReactSlashMenuItems";
+export { useCloseSuggestionMenuNoItems } from "./components/SuggestionMenu/hooks/useCloseSuggestionMenuNoItems";
+export { useLoadSuggestionMenuItems } from "./components/SuggestionMenu/hooks/useLoadSuggestionMenuItems";
+export { useSuggestionMenuKeyboardNavigation } from "./components/SuggestionMenu/hooks/useSuggestionMenuKeyboardNavigation";
+export {
+  type DefaultReactSuggestionItem,
+  type SuggestionMenuProps,
+} from "./components/SuggestionMenu/types";
 
-export * from "./components/SuggestionMenu/GridSuggestionMenu/GridSuggestionMenuController";
-export * from "./components/SuggestionMenu/GridSuggestionMenu/GridSuggestionMenuWrapper";
-export * from "./components/SuggestionMenu/GridSuggestionMenu/getDefaultReactEmojiPickerItems";
-export * from "./components/SuggestionMenu/GridSuggestionMenu/hooks/useGridSuggestionMenuKeyboardNavigation";
-export * from "./components/SuggestionMenu/GridSuggestionMenu/types";
+export { GridSuggestionMenuController } from "./components/SuggestionMenu/GridSuggestionMenu/GridSuggestionMenuController";
+export { GridSuggestionMenuWrapper } from "./components/SuggestionMenu/GridSuggestionMenu/GridSuggestionMenuWrapper";
+export { getDefaultReactEmojiPickerItems } from "./components/SuggestionMenu/GridSuggestionMenu/getDefaultReactEmojiPickerItems";
+export { useGridSuggestionMenuKeyboardNavigation } from "./components/SuggestionMenu/GridSuggestionMenu/hooks/useGridSuggestionMenuKeyboardNavigation";
+export {
+  type DefaultReactGridSuggestionItem,
+  type GridSuggestionMenuProps,
+} from "./components/SuggestionMenu/GridSuggestionMenu/types";
 
-export * from "./components/FilePanel/DefaultTabs/EmbedTab";
-export * from "./components/FilePanel/DefaultTabs/UploadTab";
-export * from "./components/FilePanel/FilePanel";
-export * from "./components/FilePanel/FilePanelController";
-export * from "./components/FilePanel/FilePanelProps";
+export { EmbedTab } from "./components/FilePanel/DefaultTabs/EmbedTab";
+export { UploadTab } from "./components/FilePanel/DefaultTabs/UploadTab";
+export { FilePanel } from "./components/FilePanel/FilePanel";
+export { FilePanelController } from "./components/FilePanel/FilePanelController";
+export { type FilePanelProps } from "./components/FilePanel/FilePanelProps";
 
-export * from "./components/TableHandles/TableHandle";
-export * from "./components/TableHandles/TableHandleProps";
-export * from "./components/TableHandles/TableHandlesController";
-export * from "./components/TableHandles/hooks/useTableHandlesPositioning";
+export { TableHandle } from "./components/TableHandles/TableHandle";
+export { type TableHandleProps } from "./components/TableHandles/TableHandleProps";
+export { TableHandlesController } from "./components/TableHandles/TableHandlesController";
+export { useTableHandlesPositioning } from "./components/TableHandles/hooks/useTableHandlesPositioning";
 
-export * from "./components/TableHandles/TableHandleMenu/DefaultButtons/AddButton";
-export * from "./components/TableHandles/TableHandleMenu/DefaultButtons/DeleteButton";
-export * from "./components/TableHandles/TableHandleMenu/TableHandleMenu";
-export * from "./components/TableHandles/TableHandleMenu/TableHandleMenuProps";
+export {
+  AddButton,
+  AddColumnButton,
+  AddRowButton,
+} from "./components/TableHandles/TableHandleMenu/DefaultButtons/AddButton";
+export {
+  DeleteButton,
+  DeleteColumnButton,
+  DeleteRowButton,
+} from "./components/TableHandles/TableHandleMenu/DefaultButtons/DeleteButton";
+export { TableHandleMenu } from "./components/TableHandles/TableHandleMenu/TableHandleMenu";
+export { type TableHandleMenuProps } from "./components/TableHandles/TableHandleMenu/TableHandleMenuProps";
 
-export * from "./hooks/useActiveStyles";
-export * from "./hooks/useBlockNoteEditor";
-export * from "./hooks/useCreateBlockNote";
-export * from "./hooks/useEditorChange";
-export * from "./hooks/useEditorContentOrSelectionChange";
-export * from "./hooks/useEditorForceUpdate";
-export * from "./hooks/useEditorSelectionChange";
-export * from "./hooks/usePrefersColorScheme";
-export * from "./hooks/useSelectedBlocks";
+export { useActiveStyles } from "./hooks/useActiveStyles";
+export { useBlockNoteEditor } from "./hooks/useBlockNoteEditor";
+export { useCreateBlockNote } from "./hooks/useCreateBlockNote";
+export { useEditorChange } from "./hooks/useEditorChange";
+export { useEditorContentOrSelectionChange } from "./hooks/useEditorContentOrSelectionChange";
+export { useEditorForceUpdate } from "./hooks/useEditorForceUpdate";
+export { useEditorSelectionChange } from "./hooks/useEditorSelectionChange";
+export { usePrefersColorScheme } from "./hooks/usePrefersColorScheme";
+export { useSelectedBlocks } from "./hooks/useSelectedBlocks";
 
-export * from "./schema/ReactBlockSpec";
-export * from "./schema/ReactInlineContentSpec";
-export * from "./schema/ReactStyleSpec";
+export {
+  BlockContentWrapper,
+  type ReactCustomBlockImplementation,
+  type ReactCustomBlockRenderProps,
+  createReactBlockSpec,
+} from "./schema/ReactBlockSpec";
+export {
+  InlineContentWrapper,
+  type ReactInlineContentImplementation,
+  createReactInlineContentSpec,
+} from "./schema/ReactInlineContentSpec";
+export {
+  type ReactCustomStyleImplementation,
+  createReactStyleSpec,
+} from "./schema/ReactStyleSpec";
 
-export * from "./util/mergeRefs";
-export * from "./util/elementOverflow";
+export { mergeRefs } from "./util/mergeRefs";
+export { elementOverflow } from "./util/elementOverflow";

--- a/packages/server-util/src/index.ts
+++ b/packages/server-util/src/index.ts
@@ -1,1 +1,1 @@
-export * from "./context/ServerBlockNoteEditor";
+export { ServerBlockNoteEditor } from "./context/ServerBlockNoteEditor";


### PR DESCRIPTION
This PR makes all the exports explicit for `@blocknote/core`, `@blocknote/react` and `@blocknote/server-util`. Without this change, the packages are not usable inside TypeScript applications that specify `NodeNext` as the `moduleResolution` value in their `tsconfig.json`.

Fixes #952