### PR TITLE
docs: add `rtl` example

### DIFF
--- a/examples/01-basic/10-rtl-direction/.bnexample.json
+++ b/examples/01-basic/10-rtl-direction/.bnexample.json
@@ -1,0 +1,6 @@
+{
+  "playground": true,
+  "docs": true,
+  "author": "zaaakher",
+  "tags": ["Basic"]
+}

--- a/examples/01-basic/10-rtl-direction/App.tsx
+++ b/examples/01-basic/10-rtl-direction/App.tsx
@@ -1,0 +1,19 @@
+import { locales } from "@blocknote/core";
+import "@blocknote/core/fonts/inter.css";
+import { BlockNoteView } from "@blocknote/mantine";
+import "@blocknote/mantine/style.css";
+import { useCreateBlockNote } from "@blocknote/react";
+// import { useTranslation } from "some-i18n-library"; // You can use any i18n library you like
+
+export default function App() {
+  // const { lang } = useTranslation('common'); // You can get the current language from the i18n library or alternatively from a router
+  // Creates a new editor instance.
+  const editor = useCreateBlockNote();
+
+  // Renders the editor instance using a React component.
+  return (
+    <div dir="rtl">
+      <BlockNoteView editor={editor} />
+    </div>
+  );
+}

--- a/examples/01-basic/10-rtl-direction/README.md
+++ b/examples/01-basic/10-rtl-direction/README.md
@@ -1,0 +1,7 @@
+# RTL Direction
+
+In this example, we set the layout direction to RTL.
+
+**Relevant Docs:**
+
+- [Editor Setup](/docs/editor-basics/setup)

--- a/examples/01-basic/10-rtl-direction/index.html
+++ b/examples/01-basic/10-rtl-direction/index.html
@@ -1,0 +1,14 @@
+<html lang="en">
+  <head>
+    <script>
+      <!-- AUTO-GENERATED FILE, DO NOT EDIT DIRECTLY -->
+    </script>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>RTL Direction</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="./main.tsx"></script>
+  </body>
+</html>

--- a/examples/01-basic/10-rtl-direction/main.tsx
+++ b/examples/01-basic/10-rtl-direction/main.tsx
@@ -1,0 +1,11 @@
+// AUTO-GENERATED FILE, DO NOT EDIT DIRECTLY
+import React from "react";
+import { createRoot } from "react-dom/client";
+import App from "./App";
+
+const root = createRoot(document.getElementById("root")!);
+root.render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/examples/01-basic/10-rtl-direction/package.json
+++ b/examples/01-basic/10-rtl-direction/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "@blocknote/example-rtl-direction",
+  "description": "AUTO-GENERATED FILE, DO NOT EDIT DIRECTLY",
+  "private": true,
+  "version": "0.12.4",
+  "scripts": {
+    "start": "vite",
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "preview": "vite preview",
+    "lint": "eslint . --max-warnings 0"
+  },
+  "dependencies": {
+    "@blocknote/core": "latest",
+    "@blocknote/react": "latest",
+    "@blocknote/ariakit": "latest",
+    "@blocknote/mantine": "latest",
+    "@blocknote/shadcn": "latest",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
+  },
+  "devDependencies": {
+    "@types/react": "^18.0.25",
+    "@types/react-dom": "^18.0.9",
+    "@vitejs/plugin-react": "^4.3.1",
+    "eslint": "^8.10.0",
+    "vite": "^5.3.4"
+  },
+  "eslintConfig": {
+    "extends": [
+      "../../../.eslintrc.js"
+    ]
+  },
+  "eslintIgnore": [
+    "dist"
+  ]
+}

--- a/examples/01-basic/10-rtl-direction/tsconfig.json
+++ b/examples/01-basic/10-rtl-direction/tsconfig.json
@@ -1,0 +1,36 @@
+{
+  "__comment": "AUTO-GENERATED FILE, DO NOT EDIT DIRECTLY",
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": [
+      "DOM",
+      "DOM.Iterable",
+      "ESNext"
+    ],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "composite": true
+  },
+  "include": [
+    "."
+  ],
+  "__ADD_FOR_LOCAL_DEV_references": [
+    {
+      "path": "../../../packages/core/"
+    },
+    {
+      "path": "../../../packages/react/"
+    }
+  ]
+}

--- a/examples/01-basic/10-rtl-direction/vite.config.ts
+++ b/examples/01-basic/10-rtl-direction/vite.config.ts
@@ -1,0 +1,32 @@
+// AUTO-GENERATED FILE, DO NOT EDIT DIRECTLY
+import react from "@vitejs/plugin-react";
+import * as fs from "fs";
+import * as path from "path";
+import { defineConfig } from "vite";
+// import eslintPlugin from "vite-plugin-eslint";
+// https://vitejs.dev/config/
+export default defineConfig((conf) => ({
+  plugins: [react()],
+  optimizeDeps: {},
+  build: {
+    sourcemap: true,
+  },
+  resolve: {
+    alias:
+      conf.command === "build" ||
+      !fs.existsSync(path.resolve(__dirname, "../../packages/core/src"))
+        ? {}
+        : ({
+            // Comment out the lines below to load a built version of blocknote
+            // or, keep as is to load live from sources with live reload working
+            "@blocknote/core": path.resolve(
+              __dirname,
+              "../../packages/core/src/"
+            ),
+            "@blocknote/react": path.resolve(
+              __dirname,
+              "../../packages/react/src/"
+            ),
+          } as any),
+  },
+}));

--- a/playground/src/examples.gen.tsx
+++ b/playground/src/examples.gen.tsx
@@ -175,6 +175,24 @@
         }
       },
       {
+        "projectSlug": "rtl-direction",
+        "fullSlug": "basic/rtl-direction",
+        "pathFromRoot": "examples/01-basic/10-rtl-direction",
+        "config": {
+          "playground": true,
+          "docs": true,
+          "author": "zaaakher",
+          "tags": [
+            "Basic"
+          ]
+        },
+        "title": "RTL Direction",
+        "group": {
+          "pathFromRoot": "examples/01-basic",
+          "slug": "basic"
+        }
+      },
+      {
         "projectSlug": "testing",
         "fullSlug": "basic/testing",
         "pathFromRoot": "examples/01-basic/testing",


### PR DESCRIPTION
This PR simply adds a RTL example.

Note:
This PR should wait on https://github.com/TypeCellOS/BlockNote/pull/922, If the team decides to accept the `dir` prop to `BlockNoteView` then I will update this PR to include passing a `dir='rtl'` 