### PR TITLE
fix: Drag preview visibility

### DIFF
--- a/packages/core/src/editor/editor.css
+++ b/packages/core/src/editor/editor.css
@@ -62,7 +62,19 @@ Tippy popups that are appended to document.body directly
 
 .bn-drag-preview {
   position: absolute;
-  z-index: -1;
+  top: 0;
+  left: 0;
+  padding: 10px;
+  /* Sort of a hack but seems like the most reliable solution. */
+  /* Drag preview element needs to be within bounds of the document area or it
+   won't work in some cases. */
+  /* Negative z-index covers most cases, but the element can still be visible
+   if UI elements are translucent. */
+  /* Setting opacity has no effect on the drag preview but does affect the
+   element. Unless it's set to 0, in which case the drag preview also becomes
+   hidden. So setting it to an extremely low value instead makes the element
+   functionally invisible while not affecting the drag preview itself. */
+  opacity: 0.001;
 }
 
 /* Give a remote user a caret */


### PR DESCRIPTION
Even though we've tried different approaches, we still keep seeing people have issues with the drag preview. Here's a summary of the things we've tried before and why they weren't ideal:

### Displaying the drag preview element off-screen

This is [recommended by Mozilla](https://developer.mozilla.org/en-US/docs/Web/API/DataTransfer/setDragImage):

> Note: If the [Element](https://developer.mozilla.org/en-US/docs/Web/API/Element) is an existing [HTMLElement](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement) it needs to be visible in the viewport in order to be shown as a drag feedback image. Alternatively, you can create a new DOM element that might be off-screen specifically for this purpose.

It works for most cases but isn't 100% reliable, as it causes bugs with some apps (@YousefED this was specifically an issue with DeepOrigin). Typically the issue is that the drag preview cuts off whatever part of the element is not within bounds of the screen.

### Setting a negative drag preview z-index

This again works for most cases but not all, as the element will still be visible through any UI components that aren't fully opaque. See #966 for examples of this.

This PR makes the drag preview element get displayed at the top of the page with a very low opacity, which seems to be a more reliable fix than the previous approaches. Opacity has no effect of the drag preview itself unless the value is 0, in which case it becomes invisible. However, it works as expected for the drag preview element. This means that setting a very low opacity value makes the element functionally invisible without changing the drag preview at all. While this is a hack, it still seems to work better than the previous approaches, even though one of them is officially recommended.

Closes #966