### PR TITLE
docs: remove free tier on pricing page

### DIFF
--- a/docs/components/pages/pricing/faq.tsx
+++ b/docs/components/pages/pricing/faq.tsx
@@ -16,7 +16,7 @@ const faqs = [
   {
     question:
       "What License is BlockNote using? Can I use it for commercial projects?",
-    answer: `BlockNote is licensed under the MPL 2.0 license, which allows you to use BlockNote in commercial (and closed-source) applications. 
+    answer: `BlockNote is open source software licensed under the MPL 2.0 license, which allows you to use BlockNote in commercial (and closed-source) applications - even without a subscription. 
     If you make changes to the BlockNote source files, you're expected to publish these changes so the wider community can benefit as well.`,
   },
   // More questions...

--- a/docs/components/pages/pricing/tiers.tsx
+++ b/docs/components/pages/pricing/tiers.tsx
@@ -107,7 +107,7 @@ export function Tiers({
   frequency: Frequency;
 }) {
   return (
-    <div className="isolate mx-auto mt-10 grid max-w-md grid-cols-1 gap-4 lg:mx-0 lg:max-w-none lg:grid-cols-4">
+    <div className="isolate mx-auto mt-10 grid max-w-md grid-cols-1 gap-4 lg:mx-0 lg:max-w-none lg:grid-cols-3">
       {tiers.map((tier) => (
         <div
           key={tier.id}

--- a/docs/pages/pricing.mdx
+++ b/docs/pages/pricing.mdx
@@ -4,20 +4,20 @@ import { Tiers } from "../components/pages/pricing/tiers";
 
 export default function Pricing() {
   const tiers = [
-    {
-      id: "tier-free",
-      title: "Community",
-      description: "Everything necessary to get started for individuals and non-commercial projects.",
-      price: "Free",
-      features: [
-        "Use BlockNote for free (open source license)",
-        "Community Discord for help & feedback",
-      ],
-      href: "/docs/",
-    },
+    // {
+    //   id: "tier-free",
+    //   title: "Community",
+    //   description: "Everything necessary to get started for individuals and non-commercial projects.",
+    //   price: "Free",
+    //   features: [
+    //     "Use BlockNote for free (open source license)",
+    //     "Community Discord for help & feedback",
+    //   ],
+    //   href: "/docs/",
+    // },
     {
       id: "tier-starter",
-      mostPopular: true,
+      mostPopular: false,
       title: "Starter",
       description:
         "Best for companies and organizations building products with BlockNote.",
@@ -32,6 +32,7 @@ export default function Pricing() {
     {
       id: "tier-business",
       title: "Business",
+      mostPopular: true,
       description:
         "Best for companies that want a direct line to the team.",
       price: { month: 189, year: 48 },


### PR DESCRIPTION
blocknote always remains free and open source, but let's focus the pricing page on paid subscriptions