### PR TITLE
fix: Attribute check in `getDraggableBlockFromElement`

### DIFF
--- a/packages/core/src/extensions/SideMenu/SideMenuPlugin.ts
+++ b/packages/core/src/extensions/SideMenu/SideMenuPlugin.ts
@@ -33,11 +33,11 @@ export function getDraggableBlockFromElement(
     element &&
     element.parentElement &&
     element.parentElement !== view.dom &&
-    !element.hasAttribute?.("data-id")
+    element.getAttribute?.("data-node-type") !== "blockContainer"
   ) {
     element = element.parentElement;
   }
-  if (!element.hasAttribute("data-id")) {
+  if (element.getAttribute?.("data-node-type") !== "blockContainer") {
     return undefined;
   }
   return { node: element as HTMLElement, id: element.getAttribute("data-id")! };
@@ -383,6 +383,7 @@ export class SideMenuView<
 
     // Gets the block's content node, which lets to ignore child blocks when determining the block menu's position.
     const blockContent = block.node.firstChild as HTMLElement;
+    console.log(blockContent.textContent);
 
     if (!blockContent) {
       return;
@@ -577,6 +578,11 @@ export class SideMenuView<
   // would otherwise not update the side menu, and so clicking the button again
   // would attempt to remove the same block again, causing an error.
   update() {
+    // if (!this.needUpdate) {
+    //   return;
+    // }
+
+    console.log(this.state?.block);
     const prevBlockId = this.state?.block.id;
 
     this.updateState();

--- a/packages/core/src/extensions/SideMenu/SideMenuPlugin.ts
+++ b/packages/core/src/extensions/SideMenu/SideMenuPlugin.ts
@@ -383,7 +383,6 @@ export class SideMenuView<
 
     // Gets the block's content node, which lets to ignore child blocks when determining the block menu's position.
     const blockContent = block.node.firstChild as HTMLElement;
-    console.log(blockContent.textContent);
 
     if (!blockContent) {
       return;
@@ -578,11 +577,6 @@ export class SideMenuView<
   // would otherwise not update the side menu, and so clicking the button again
   // would attempt to remove the same block again, causing an error.
   update() {
-    // if (!this.needUpdate) {
-    //   return;
-    // }
-
-    console.log(this.state?.block);
     const prevBlockId = this.state?.block.id;
 
     this.updateState();


### PR DESCRIPTION
`getDraggableBlockFromElement` currently goes up the DOM tree until it finds an element with the `data-id` attribute, which it assumes to be a block. This is incorrect, as the `data-id` attribute can also come up in custom inline content and styles, so this PR changes it to ensure the attribute checked always belongs to a block.

Closes #863 