### PR TITLE
Feature: Add missing line in index.ts for locales

### DIFF
--- a/packages/core/src/i18n/locales/index.ts
+++ b/packages/core/src/i18n/locales/index.ts
@@ -11,3 +11,4 @@ export * from "./vi";
 export * from "./zh";
 export * from "./ru";
 export * from "./de";
+export * from "./es";


### PR DESCRIPTION
In the previous PR #985 the index.ts is missing the line to export the new language format.