### PR TITLE
fix: Add exports for vanilla block helpers

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -2,11 +2,12 @@ import * as locales from "./i18n/locales";
 export * from "./api/exporters/html/externalHTMLExporter";
 export * from "./api/exporters/html/internalHTMLSerializer";
 export * from "./api/testUtil";
+export * from "./api/getCurrentBlockContentType";
+export * from "./blocks/defaultBlockHelpers";
 export * from "./blocks/AudioBlockContent/AudioBlockContent";
 export * from "./blocks/FileBlockContent/FileBlockContent";
 export * from "./blocks/ImageBlockContent/ImageBlockContent";
 export * from "./blocks/VideoBlockContent/VideoBlockContent";
-
 export * from "./blocks/FileBlockContent/fileBlockHelpers";
 export * from "./blocks/FileBlockContent/uploadToTmpFilesDotOrg_DEV_ONLY";
 export { parseImageElement } from "./blocks/ImageBlockContent/imageBlockHelpers";


### PR DESCRIPTION
Right now, the only way to extend default blocks is to redefine them entirely, using most of the existing code. While we should figure out a proper API for extending blocks at some point, right now it's not possible to even redefine the default vanilla blocks as some exports are missing. This PR adds them.