### PR TITLE
docs: Fix Emoji Picker link

### DIFF
--- a/docs/pages/docs/editor-basics/setup.mdx
+++ b/docs/pages/docs/editor-basics/setup.mdx
@@ -121,7 +121,7 @@ export type BlockNoteViewProps = {
 
 `slashMenu`: Whether the [Slash Menu](/docs/ui-components/suggestion-menus#slash-menu) should be enabled.
 
-`emojiPicker`: Whether the [Emoji Picker](/docs/ui-components/suggestion-menus#emoji-picker) should be enabled.
+`emojiPicker`: Whether the [Emoji Picker](/docs/advanced/grid-suggestion-menus#emoji-picker) should be enabled.
 
 `filePanel`: Whether the File Toolbar should be enabled.
 


### PR DESCRIPTION
Fixed incorrect link for emojiPicker documentation.

Updated the emojiPicker link in the docs from (/docs/ui-components/suggestion-menus#emoji-picker) to (/docs/advanced/grid-suggestion-menus#emoji-picker), which is the correct URL.