### PR TITLE
fix: Show formatting toolbar when editor isn't editable

### DIFF
--- a/packages/core/src/extensions/FormattingToolbar/FormattingToolbarPlugin.ts
+++ b/packages/core/src/extensions/FormattingToolbar/FormattingToolbarPlugin.ts
@@ -31,8 +31,18 @@ export class FormattingToolbarView implements PluginView {
     const isEmptyTextBlock =
       !doc.textBetween(from, to).length && isTextSelection(state.selection);
 
+    const domSelection = window.getSelection();
+    if (!domSelection) {
+      return false;
+    }
+
     // check view.hasFocus so that the toolbar doesn't show up when the editor is not focused or when for example a code block is focused
-    return !(!view.hasFocus() || empty || isEmptyTextBlock);
+    return !(
+      !view.dom.contains(domSelection.anchorNode) ||
+      !view.dom.contains(domSelection.focusNode) ||
+      empty ||
+      isEmptyTextBlock
+    );
   };
 
   constructor(
@@ -146,6 +156,7 @@ export class FormattingToolbarView implements PluginView {
       from,
       to,
     });
+    console.log(shouldShow);
 
     // Checks if menu should be shown/updated.
     if (!this.preventShow && (shouldShow || this.preventHide)) {


### PR DESCRIPTION
There seems to have been a regression as the formatting toolbar no longer shows when the editor is not editable. It should be the responsibility of toolbar buttons to determine whether to be shown instead, as the file download button should always be visible when a file block is selected.

This PR changes the behaviour to show the formatting toolbar when the DOM selection is within the editor, as opposed to when the editor is focused. This means that clicking off the editor still hides the toolbar, but it doesn't force it to stay hidden when the editor isn't editable.