### PR TITLE
fix: Slight improvement to suggestion menu positioning

### DIFF
--- a/packages/react/src/components/SuggestionMenu/SuggestionMenuController.tsx
+++ b/packages/react/src/components/SuggestionMenu/SuggestionMenuController.tsx
@@ -5,7 +5,7 @@ import {
   SuggestionMenuState,
   filterSuggestionItems,
 } from "@blocknote/core";
-import { flip, offset, size } from "@floating-ui/react";
+import { flip, offset, shift, size } from "@floating-ui/react";
 import { FC, useCallback, useMemo } from "react";
 
 import { useBlockNoteEditor } from "../../hooks/useBlockNoteEditor";
@@ -106,7 +106,11 @@ export function SuggestionMenuController<
         offset(10),
         // Flips the menu placement to maximize the space available, and prevents
         // the menu from being cut off by the confines of the screen.
-        flip(),
+        flip({
+          mainAxis: true,
+          crossAxis: false,
+        }),
+        shift(),
         size({
           apply({ availableHeight, elements }) {
             Object.assign(elements.floating.style, {


### PR DESCRIPTION
This PR slightly changes how the suggestion menu is positioned to better handle horizontal overflows on small screens. It now moves only enough to prevent the overflow, instead of getting flipped to the other side of the text caret and potentially causing an overflow on the other side.