### PR TITLE
fix: Block insert twice when using korean at suggestion

### DIFF
--- a/packages/react/src/components/SuggestionMenu/GridSuggestionMenu/hooks/useGridSuggestionMenuKeyboardNavigation.ts
+++ b/packages/react/src/components/SuggestionMenu/GridSuggestionMenu/hooks/useGridSuggestionMenuKeyboardNavigation.ts
@@ -55,7 +55,7 @@ export function useGridSuggestionMenuKeyboardNavigation<Item>(
       if (event.key === "Enter") {
         event.preventDefault();
 
-        if (items.length) {
+        if (items.length && !event.isComposing) {
           onItemClick?.(items[selectedIndex]);
         }
 

--- a/packages/react/src/components/SuggestionMenu/GridSuggestionMenu/hooks/useGridSuggestionMenuKeyboardNavigation.ts
+++ b/packages/react/src/components/SuggestionMenu/GridSuggestionMenu/hooks/useGridSuggestionMenuKeyboardNavigation.ts
@@ -52,10 +52,10 @@ export function useGridSuggestionMenuKeyboardNavigation<Item>(
         return true;
       }
 
-      if (event.key === "Enter") {
+      if (event.key === "Enter" && !event.isComposing) {
         event.preventDefault();
 
-        if (items.length && !event.isComposing) {
+        if (items.length) {
           onItemClick?.(items[selectedIndex]);
         }
 

--- a/packages/react/src/components/SuggestionMenu/hooks/useSuggestionMenuKeyboardNavigation.ts
+++ b/packages/react/src/components/SuggestionMenu/hooks/useSuggestionMenuKeyboardNavigation.ts
@@ -33,7 +33,7 @@ export function useSuggestionMenuKeyboardNavigation<Item>(
         return true;
       }
 
-      if (event.key === "Enter") {
+      if (event.key === "Enter" && !event.isComposing) {
         event.preventDefault();
 
         if (items.length) {


### PR DESCRIPTION
Any languages with composition sessions (Korean, Japanese, etc..) have `isComposing` at keydown events.

Because of this, using the Korean suggestion make two same blocks(ex. /이미지, /구분선).
(If you press Enter after typing Korean, the keyDown event is fired both when the isComposing state is true and when it is false, resulting in two blocks with duplicate events.)


to prevent this situation, checking `event.isComposing` is necessary.

by simply adding checking `event.isCompoising == false`, We can prevent making blocks twice when using Korean.


here is the MDN page that explains `isComposing`


https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/isComposing