### PR TITLE
Update Doc: table's content type is TableContent

### DIFF
--- a/docs/pages/docs/editor-basics/default-schema.mdx
+++ b/docs/pages/docs/editor-basics/default-schema.mdx
@@ -117,7 +117,7 @@ type TableBlock = {
   id: string;
   type: "table";
   props: DefaultProps;
-  content: TableContent[];
+  content: TableContent;
   children: Block[];
 };
 ```


### PR DESCRIPTION
`TableContent[]` is wrong

`TableContent` is correct