### PR TITLE
Fix error in suggestion-menus.mdx

### DIFF
--- a/docs/pages/docs/ui-components/suggestion-menus.mdx
+++ b/docs/pages/docs/ui-components/suggestion-menus.mdx
@@ -58,10 +58,10 @@ BlockNote offers a few other features for working with Suggestion Menus which ma
 While suggestion menus are generally meant to be opened when the user presses a trigger character, you may also want to open them from code. To do this, you can use the following editor method:
 
 ```typescript
-openSuggestionMenu(triggerCharacter: string): void;
+openSelectionMenu(triggerCharacter: string): void;
 
 // Usage
-editor.openSuggestionMenu("/");
+editor.openSelectionMenu("/");
 ```
 
 ### Waiting for a Query


### PR DESCRIPTION
Fixed an error that refers to an `openSuggestionMenu` method on editor which can be used for opening a suggestion menu programmatically. However the method is actually called `openSelectionMenu`.