### PR TITLE
fix: External file drag/drop and copy/paste

### DIFF
--- a/packages/core/src/api/parsers/handleFileInsertion.ts
+++ b/packages/core/src/api/parsers/handleFileInsertion.ts
@@ -82,7 +82,7 @@ export async function handleFileInsertion<
     // Gets file block corresponding to MIME type.
     let fileBlockType = "file";
     for (const fileBlockConfig of fileBlockConfigs) {
-      for (const mimeType of fileBlockConfig.fileBlockAcceptMimeTypes || []) {
+      for (const mimeType of fileBlockConfig.fileBlockAccept || []) {
         const isFileExtension = mimeType.startsWith(".");
         const file = items[i].getAsFile();
 
@@ -93,7 +93,7 @@ export async function handleFileInsertion<
               checkMIMETypesMatch(items[i].type, mimeType)) ||
             (isFileExtension &&
               checkFileExtensionsMatch(
-                "." + items[i].getAsFile()!.name.split(".").pop(),
+                "." + file.name.split(".").pop(),
                 mimeType
               ))
           ) {

--- a/packages/core/src/api/parsers/handleFileInsertion.ts
+++ b/packages/core/src/api/parsers/handleFileInsertion.ts
@@ -1,13 +1,24 @@
 import type { BlockNoteEditor } from "../../editor/BlockNoteEditor";
 import { PartialBlock } from "../../blocks/defaultBlocks";
-import { insertOrUpdateBlock } from "../../extensions/SuggestionMenu/getDefaultSlashMenuItems";
 import {
   BlockSchema,
   FileBlockConfig,
   InlineContentSchema,
   StyleSchema,
 } from "../../schema";
+import { getBlockInfoFromPos } from "../getBlockInfoFromPos";
 import { acceptedMIMETypes } from "./acceptedMIMETypes";
+
+function checkFileExtensionsMatch(
+  fileExtension1: string,
+  fileExtension2: string
+) {
+  if (!fileExtension1.startsWith(".") || !fileExtension2.startsWith(".")) {
+    throw new Error(`The strings provided are not valid file extensions.`);
+  }
+
+  return fileExtension1 === fileExtension2;
+}
 
 function checkMIMETypesMatch(mimeType1: string, mimeType2: string) {
   const types1 = mimeType1.split("/");
@@ -72,9 +83,23 @@ export async function handleFileInsertion<
     let fileBlockType = "file";
     for (const fileBlockConfig of fileBlockConfigs) {
       for (const mimeType of fileBlockConfig.fileBlockAcceptMimeTypes || []) {
-        if (checkMIMETypesMatch(items[i].type, mimeType)) {
-          fileBlockType = fileBlockConfig.type;
-          break;
+        const isFileExtension = mimeType.startsWith(".");
+        const file = items[i].getAsFile();
+
+        if (file) {
+          if (
+            (!isFileExtension &&
+              file.type &&
+              checkMIMETypesMatch(items[i].type, mimeType)) ||
+            (isFileExtension &&
+              checkFileExtensionsMatch(
+                "." + items[i].getAsFile()!.name.split(".").pop(),
+                mimeType
+              ))
+          ) {
+            fileBlockType = fileBlockConfig.type;
+            break;
+          }
         }
       }
     }
@@ -83,16 +108,42 @@ export async function handleFileInsertion<
     if (file) {
       const updateData = await editor.uploadFile(file);
 
-      if (typeof updateData === "string") {
-        const fileBlock = {
-          type: fileBlockType,
-          props: {
-            name: file.name,
-            url: updateData,
-          },
-        } as PartialBlock<BSchema, I, S>;
+      const fileBlock =
+        typeof updateData === "string"
+          ? ({
+              type: fileBlockType,
+              props: {
+                name: file.name,
+                url: updateData,
+              },
+            } as PartialBlock<BSchema, I, S>)
+          : { type: fileBlockType, ...updateData };
 
-        insertOrUpdateBlock(editor, fileBlock);
+      if (event.type === "paste") {
+        editor.insertBlocks(
+          [fileBlock],
+          editor.getTextCursorPosition().block,
+          "after"
+        );
+      }
+
+      if (event.type === "drop") {
+        const coords = {
+          left: (event as DragEvent).clientX,
+          top: (event as DragEvent).clientY,
+        };
+
+        const pos = editor._tiptapEditor.view.posAtCoords(coords);
+        if (!pos) {
+          return;
+        }
+
+        const blockInfo = getBlockInfoFromPos(
+          editor._tiptapEditor.state.doc,
+          pos.pos
+        );
+
+        editor.insertBlocks([fileBlock], blockInfo.id, "after");
       }
     }
   }

--- a/packages/core/src/blocks/AudioBlockContent/AudioBlockContent.ts
+++ b/packages/core/src/blocks/AudioBlockContent/AudioBlockContent.ts
@@ -43,7 +43,7 @@ export const audioBlockConfig = {
   propSchema: audioPropSchema,
   content: "none",
   isFileBlock: true,
-  fileBlockAcceptMimeTypes: ["audio/*"],
+  fileBlockAccept: ["audio/*"],
 } satisfies FileBlockConfig;
 
 export const audioRender = (

--- a/packages/core/src/blocks/ImageBlockContent/ImageBlockContent.ts
+++ b/packages/core/src/blocks/ImageBlockContent/ImageBlockContent.ts
@@ -49,7 +49,7 @@ export const imageBlockConfig = {
   propSchema: imagePropSchema,
   content: "none",
   isFileBlock: true,
-  fileBlockAcceptMimeTypes: ["image/*"],
+  fileBlockAccept: ["image/*"],
 } satisfies FileBlockConfig;
 
 export const imageRender = (

--- a/packages/core/src/blocks/VideoBlockContent/VideoBlockContent.ts
+++ b/packages/core/src/blocks/VideoBlockContent/VideoBlockContent.ts
@@ -49,7 +49,7 @@ export const videoBlockConfig = {
   propSchema: videoPropSchema,
   content: "none",
   isFileBlock: true,
-  fileBlockAcceptMimeTypes: ["video/*"],
+  fileBlockAccept: ["video/*"],
 } satisfies FileBlockConfig;
 
 export const videoRender = (

--- a/packages/core/src/schema/blocks/types.ts
+++ b/packages/core/src/schema/blocks/types.ts
@@ -50,7 +50,7 @@ export type FileBlockConfig = {
   };
   content: "none";
   isFileBlock: true;
-  fileBlockAcceptMimeTypes?: string[];
+  fileBlockAccept?: string[];
 };
 
 // BlockConfig contains the "schema" info about a Block type

--- a/packages/react/src/components/FilePanel/DefaultTabs/UploadTab.tsx
+++ b/packages/react/src/components/FilePanel/DefaultTabs/UploadTab.tsx
@@ -76,8 +76,8 @@ export const UploadTab = <
 
   const config = editor.schema.blockSchema[block.type];
   const accept =
-    config.isFileBlock && config.fileBlockAcceptMimeTypes?.length
-      ? config.fileBlockAcceptMimeTypes.join(",")
+    config.isFileBlock && config.fileBlockAccept?.length
+      ? config.fileBlockAccept.join(",")
       : "*/*";
 
   return (


### PR DESCRIPTION
This PR fixes 2 issues with dropping and pasting external files into the editor.

First, the files are now always inserted as new blocks instead of updating existing ones, and also dropping has been fixed to use the block under the mouse cursor instead of the currently selected one.

Second, using file extensions in a file block's `fileBlockAcceptMimeTypes` was throwing errors before, and is now fixed. File extensions and MIME types are now checked independently, whereas before, file extensions were just treated as MIME types causing some logic to fail.