### PR TITLE
feat: Table cell rowspan/colspan in API

### DIFF
--- a/docs/pages/docs/editor-basics/document-structure.mdx
+++ b/docs/pages/docs/editor-basics/document-structure.mdx
@@ -73,7 +73,7 @@ The `styles` property is explained below.
 
 While most blocks use an array of `InlineContent` objects to describe their content (e.g.: paragraphs, headings, list items). Some blocks, like [images](/docs/editor-basics/default-schema#image), don't contain any rich text content, so their `content` fields will be `undefined`.
 
-[Tables](/docs/editor-basics/default-schema#table) are also different, as they contain `TableContent`. Here, each table cell is represented as an array of `InlineContent` objects with a width:
+[Tables](/docs/editor-basics/default-schema#table) are also different, as they contain `TableContent`. Here, each table cell is represented as an array of `InlineContent` objects with a width, colspan and rowspan:
 
 ```typescript
 type TableContent = {
@@ -81,7 +81,9 @@ type TableContent = {
   rows: {
     cells: {
       content: InlineContent,
-      width?: number
+      width?: number,
+      colspan?: number,
+      rowspan?: number
     }[][];
   }[];
 };

--- a/packages/core/src/api/nodeConversions/nodeConversions.ts
+++ b/packages/core/src/api/nodeConversions/nodeConversions.ts
@@ -186,7 +186,11 @@ export function tableContentToNodes<
       }
 
       const cellNode = schema.nodes["tableCell"].create(
-        { colwidth: [cell.width] || null },
+        {
+          colwidth: [cell.width] || null,
+          colspan: cell.colspan || 1, 
+          rowspan: cell.rowspan || 1
+        },
         pNode
       );
       columnNodes.push(cellNode);
@@ -299,6 +303,8 @@ function contentNodeToTableContent<
           cellNode.attrs.colwidth !== null
             ? cellNode.attrs.colwidth[0]
             : undefined,
+          colspan: cellNode.attrs.colspan || 1,
+          rowspan: cellNode.attrs.rowspan || 1
       });
     });
 

--- a/packages/core/src/schema/blocks/types.ts
+++ b/packages/core/src/schema/blocks/types.ts
@@ -158,6 +158,8 @@ export type CellContent<
 > = {
   content: InlineContent<I, T>[];
   width?: number;
+  colspan?: number;
+  rowspan?: number;
 };
 
 // A BlockConfig has all the information to get the type of a Block (which is a specific instance of the BlockConfig.
@@ -241,6 +243,8 @@ export type PartialCellContent<
 > = {
   content: PartialInlineContent<I, T>;
   width?: number;
+  colspan?: number;
+  rowspan?: number;
 };
 
 type PartialBlockFromConfigNoChildren<


### PR DESCRIPTION
**Summary:**
This PR introduces support for `rowspan` and `colspan` properties in the API, laying the foundation for future cell merging functionality.

**Details:**
- Added `rowspan` and `colspan` parameters to the `CellContent` and `PartialCellContent` types.
- Integrated these parameters into `nodeConversion`, with default values set to 1.

**Why:**
Supporting `rowspan` and `colspan` is essential for enabling merged cells, which will enhance the user experience by allowing more complex and dynamic table structures.

**Additional Notes:**
- This PR targets the current branch since I think it makes sense to merge them together.
- The naming convention of the parameters (`rowspan` and `colspan`) can be adjusted based on feedback.
