### PR TITLE
fix: xss in link toolbar and file download

### DIFF
--- a/packages/react/src/components/FormattingToolbar/DefaultButtons/FileDownloadButton.tsx
+++ b/packages/react/src/components/FormattingToolbar/DefaultButtons/FileDownloadButton.tsx
@@ -12,6 +12,7 @@ import { useComponentsContext } from "../../../editor/ComponentsContext";
 import { useBlockNoteEditor } from "../../../hooks/useBlockNoteEditor";
 import { useSelectedBlocks } from "../../../hooks/useSelectedBlocks";
 import { useDictionary } from "../../../i18n/dictionary";
+import { sanitizeUrl } from "../../../util/sanitizeUrl";
 
 export const FileDownloadButton = () => {
   const dict = useDictionary();
@@ -45,7 +46,9 @@ export const FileDownloadButton = () => {
       editor.focus();
       editor
         .resolveFileUrl(fileBlock.props.url)
-        .then((downloadUrl) => window.open(downloadUrl));
+        .then((downloadUrl) =>
+          window.open(sanitizeUrl(downloadUrl, window.location.href))
+        );
     }
   }, [editor, fileBlock]);
 

--- a/packages/react/src/components/LinkToolbar/DefaultButtons/OpenLinkButton.tsx
+++ b/packages/react/src/components/LinkToolbar/DefaultButtons/OpenLinkButton.tsx
@@ -2,6 +2,7 @@ import { RiExternalLinkFill } from "react-icons/ri";
 import { useComponentsContext } from "../../../editor/ComponentsContext";
 import { useDictionary } from "../../../i18n/dictionary";
 import { LinkToolbarProps } from "../LinkToolbarProps";
+import { sanitizeUrl } from "../../../util/sanitizeUrl";
 
 export const OpenLinkButton = (props: Pick<LinkToolbarProps, "url">) => {
   const Components = useComponentsContext()!;
@@ -14,7 +15,7 @@ export const OpenLinkButton = (props: Pick<LinkToolbarProps, "url">) => {
       label={dict.link_toolbar.open.tooltip}
       isSelected={false}
       onClick={() => {
-        window.open(props.url, "_blank");
+        window.open(sanitizeUrl(props.url, window.location.href), "_blank");
       }}
       icon={<RiExternalLinkFill />}
     />

--- a/packages/react/src/util/sanitizeUrl.ts
+++ b/packages/react/src/util/sanitizeUrl.ts
@@ -8,7 +8,7 @@ export function sanitizeUrl(inputUrl: string, baseUrl: string): string {
   try {
     const url = new URL(inputUrl, baseUrl);
 
-    // check if the protocol is safe to prevent XSS
+    // eslint-disable-next-line no-script-url -- false positive, we are explicitly checking if the protocol is safe to prevent XSS
     if (url.protocol !== "javascript:") {
       return url.href;
     }

--- a/packages/react/src/util/sanitizeUrl.ts
+++ b/packages/react/src/util/sanitizeUrl.ts
@@ -1,0 +1,21 @@
+/**
+ * Sanitizes a potentially unsafe URL.
+ * @param {string} inputUrl - The URL to sanitize.
+ * @param {string} baseUrl - The base URL to use for relative URLs.
+ * @returns {string} The normalized URL, or "#" if the URL is invalid or unsafe.
+ */
+export function sanitizeUrl(inputUrl: string, baseUrl: string): string {
+  try {
+    const url = new URL(inputUrl, baseUrl);
+
+    // check if the protocol is safe to prevent XSS
+    if (url.protocol !== "javascript:") {
+      return url.href;
+    }
+  } catch (error) {
+    // if URL creation fails, it's an invalid URL
+  }
+
+  // return a safe default for invalid or unsafe URLs
+  return "#";
+}


### PR DESCRIPTION
There is an XSS vulnerability in the file upload and link toolbar features.

To reproduce, create a file embed or a link with `javascript:alert(origin)`. Click on the download / open button, and `alert(origin)` will be run in the user's browser.

![image](https://github.com/user-attachments/assets/925d2ce5-adfa-4c4f-8362-2ff65aa857e7)

This fixes the XSS vulnerability by providing a sensible default when the protocol is `javascript:`.
