### PR TITLE
feat: SuggestionMenuController.tsx support ignoreQueryLength

### DIFF
--- a/packages/react/src/components/SuggestionMenu/SuggestionMenuController.tsx
+++ b/packages/react/src/components/SuggestionMenu/SuggestionMenuController.tsx
@@ -130,7 +130,8 @@ export function SuggestionMenuController<
   if (
     !isMounted ||
     !state ||
-    (minQueryLength &&
+    (!state?.ignoreQueryLength &&
+      minQueryLength &&
       (state.query.startsWith(" ") || state.query.length < minQueryLength))
   ) {
     return null;


### PR DESCRIPTION
In #984, we added the ignoreQuery state, and I think it applies `SuggestionMenuController` as well