### PR TITLE
feat: add option to set html id

### DIFF
--- a/examples/01-basic/01-minimal/App.tsx
+++ b/examples/01-basic/01-minimal/App.tsx
@@ -5,9 +5,7 @@ import { useCreateBlockNote } from "@blocknote/react";
 
 export default function App() {
   // Creates a new editor instance.
-  const editor = useCreateBlockNote({
-    setIdAttribute: true,
-  });
+  const editor = useCreateBlockNote();
 
   // Renders the editor instance using a React component.
   return <BlockNoteView editor={editor} />;

--- a/examples/01-basic/01-minimal/App.tsx
+++ b/examples/01-basic/01-minimal/App.tsx
@@ -1,11 +1,13 @@
 import "@blocknote/core/fonts/inter.css";
-import { useCreateBlockNote } from "@blocknote/react";
 import { BlockNoteView } from "@blocknote/mantine";
 import "@blocknote/mantine/style.css";
+import { useCreateBlockNote } from "@blocknote/react";
 
 export default function App() {
   // Creates a new editor instance.
-  const editor = useCreateBlockNote();
+  const editor = useCreateBlockNote({
+    setIdAttribute: true,
+  });
 
   // Renders the editor instance using a React component.
   return <BlockNoteView editor={editor} />;

--- a/packages/core/src/editor/BlockNoteEditor.test.ts
+++ b/packages/core/src/editor/BlockNoteEditor.test.ts
@@ -57,3 +57,16 @@ it("immediately replaces doc", async () => {
     ]
   `);
 });
+
+it("adds id attribute when requested", async () => {
+  const editor = BlockNoteEditor.create({
+    setIdAttribute: true,
+  });
+  const blocks = await editor.tryParseMarkdownToBlocks(
+    "This is a normal text\n\n# And this is a large heading"
+  );
+  editor.replaceBlocks(editor.document, blocks);
+  expect(
+    await editor.blocksToFullHTML(editor.document)
+  ).toMatchInlineSnapshot(`"<div class="bn-block-group" data-node-type="blockGroup"><div class="bn-block-outer" data-node-type="blockOuter" data-id="1" id="1"><div class="bn-block" data-node-type="blockContainer" data-id="1" id="1"><div class="bn-block-content" data-content-type="paragraph"><p class="bn-inline-content">This is a normal text</p></div></div></div><div class="bn-block-outer" data-node-type="blockOuter" data-id="2" id="2"><div class="bn-block" data-node-type="blockContainer" data-id="2" id="2"><div class="bn-block-content" data-content-type="heading" data-level="1"><h1 class="bn-inline-content">And this is a large heading</h1></div></div></div></div>"`);
+});

--- a/packages/core/src/editor/BlockNoteEditor.ts
+++ b/packages/core/src/editor/BlockNoteEditor.ts
@@ -172,8 +172,10 @@ export type BlockNoteEditorOptions<
    *
    * When set to `true`, on each block an id attribute will be set with the block id
    * Otherwise, the HTML ID attribute will not be set.
+   *
+   * (note that the id is always set on the `data-id` attribute)
    */
-  setHtmlId?: boolean;
+  setIdAttribute?: boolean;
 };
 
 const blockNoteTipTapOptions = {
@@ -347,7 +349,7 @@ export class BlockNoteEditor<
       collaboration: newOptions.collaboration,
       trailingBlock: newOptions.trailingBlock,
       disableExtensions: newOptions.disableExtensions,
-      setHtmlId: newOptions.setHtmlId,
+      setIdAttribute: newOptions.setIdAttribute,
     });
 
     const blockNoteUIExtension = Extension.create({

--- a/packages/core/src/editor/BlockNoteEditor.ts
+++ b/packages/core/src/editor/BlockNoteEditor.ts
@@ -166,6 +166,14 @@ export type BlockNoteEditorOptions<
    * You probably don't need to set this manually, but use the `server-util` package instead that uses this option internally
    */
   _headless: boolean;
+
+  /**
+   * A flag indicating whether to set an HTML ID for every block
+   *
+   * When set to `true`, on each block an id attribute will be set with the block id
+   * Otherwise, the HTML ID attribute will not be set.
+   */
+  setHtmlId?: boolean;
 };
 
 const blockNoteTipTapOptions = {
@@ -339,6 +347,7 @@ export class BlockNoteEditor<
       collaboration: newOptions.collaboration,
       trailingBlock: newOptions.trailingBlock,
       disableExtensions: newOptions.disableExtensions,
+      setHtmlId: newOptions.setHtmlId,
     });
 
     const blockNoteUIExtension = Extension.create({

--- a/packages/core/src/editor/BlockNoteExtensions.ts
+++ b/packages/core/src/editor/BlockNoteExtensions.ts
@@ -55,6 +55,7 @@ export const getBlockNoteExtensions = <
     renderCursor?: (user: any) => HTMLElement;
   };
   disableExtensions: string[] | undefined;
+  setHtmlId?: boolean;
 }) => {
   const ret: Extensions = [
     extensions.ClipboardTextSerializer,
@@ -69,6 +70,7 @@ export const getBlockNoteExtensions = <
     // DropCursor,
     UniqueID.configure({
       types: ["blockContainer"],
+      setHtmlId: opts.setHtmlId
     }),
     HardBreak.extend({ priority: 10 }),
     // Comments,

--- a/packages/core/src/editor/BlockNoteExtensions.ts
+++ b/packages/core/src/editor/BlockNoteExtensions.ts
@@ -12,8 +12,8 @@ import { Link } from "@tiptap/extension-link";
 import { Text } from "@tiptap/extension-text";
 import * as Y from "yjs";
 import { createCopyToClipboardExtension } from "../api/exporters/copyExtension";
-import { createPasteFromClipboardExtension } from "../api/parsers/pasteExtension";
 import { createDropFileExtension } from "../api/parsers/fileDropExtension";
+import { createPasteFromClipboardExtension } from "../api/parsers/pasteExtension";
 import { BackgroundColorExtension } from "../extensions/BackgroundColor/BackgroundColorExtension";
 import { TextAlignmentExtension } from "../extensions/TextAlignment/TextAlignmentExtension";
 import { TextColorExtension } from "../extensions/TextColor/TextColorExtension";
@@ -55,7 +55,7 @@ export const getBlockNoteExtensions = <
     renderCursor?: (user: any) => HTMLElement;
   };
   disableExtensions: string[] | undefined;
-  setHtmlId?: boolean;
+  setIdAttribute?: boolean;
 }) => {
   const ret: Extensions = [
     extensions.ClipboardTextSerializer,
@@ -70,7 +70,7 @@ export const getBlockNoteExtensions = <
     // DropCursor,
     UniqueID.configure({
       types: ["blockContainer"],
-      setHtmlId: opts.setHtmlId
+      setIdAttribute: opts.setIdAttribute,
     }),
     HardBreak.extend({ priority: 10 }),
     // Comments,
@@ -199,5 +199,5 @@ export const getBlockNoteExtensions = <
   }
 
   const disableExtensions: string[] = opts.disableExtensions || [];
-  return ret.filter(ex => !disableExtensions.includes(ex.name));
+  return ret.filter((ex) => !disableExtensions.includes(ex.name));
 };

--- a/packages/core/src/extensions/UniqueID/UniqueID.ts
+++ b/packages/core/src/extensions/UniqueID/UniqueID.ts
@@ -1,12 +1,7 @@
-import {
-  combineTransactionSteps,
-  Extension,
-  findChildrenInRange,
-  getChangedRanges,
-} from "@tiptap/core";
-import { Fragment, Slice } from "prosemirror-model";
-import { Plugin, PluginKey } from "prosemirror-state";
-import { v4 } from "uuid";
+import {combineTransactionSteps, Extension, findChildrenInRange, getChangedRanges,} from "@tiptap/core";
+import {Fragment, Slice} from "prosemirror-model";
+import {Plugin, PluginKey} from "prosemirror-state";
+import {v4} from "uuid";
 
 /**
  * Code from Tiptap UniqueID extension (https://tiptap.dev/api/extensions/unique-id)
@@ -50,6 +45,7 @@ const UniqueID = Extension.create({
     return {
       attributeName: "id",
       types: [],
+      setHtmlId: false,
       generateID: () => {
         // Use mock ID if tests are running.
         if (typeof window !== "undefined" && (window as any).__TEST_OPTIONS) {
@@ -69,6 +65,7 @@ const UniqueID = Extension.create({
     };
   },
   addGlobalAttributes() {
+
     return [
       {
         types: this.options.types,
@@ -77,10 +74,17 @@ const UniqueID = Extension.create({
             default: null,
             parseHTML: (element) =>
               element.getAttribute(`data-${this.options.attributeName}`),
-            renderHTML: (attributes) => ({
-              [`data-${this.options.attributeName}`]:
-                attributes[this.options.attributeName],
-            }),
+            renderHTML: (attributes) => {
+              const defaultIdAttributes = {
+                [`data-${this.options.attributeName}`]:
+                    attributes[this.options.attributeName]
+              };
+              if (this.options.setHtmlId) {
+                return {...defaultIdAttributes, 'id': attributes[this.options.attributeName]}
+              } else {
+                return defaultIdAttributes
+              }
+            },
           },
         },
       },

--- a/packages/core/src/extensions/UniqueID/UniqueID.ts
+++ b/packages/core/src/extensions/UniqueID/UniqueID.ts
@@ -1,7 +1,12 @@
-import {combineTransactionSteps, Extension, findChildrenInRange, getChangedRanges,} from "@tiptap/core";
-import {Fragment, Slice} from "prosemirror-model";
-import {Plugin, PluginKey} from "prosemirror-state";
-import {v4} from "uuid";
+import {
+  combineTransactionSteps,
+  Extension,
+  findChildrenInRange,
+  getChangedRanges,
+} from "@tiptap/core";
+import { Fragment, Slice } from "prosemirror-model";
+import { Plugin, PluginKey } from "prosemirror-state";
+import { v4 } from "uuid";
 
 /**
  * Code from Tiptap UniqueID extension (https://tiptap.dev/api/extensions/unique-id)
@@ -45,7 +50,7 @@ const UniqueID = Extension.create({
     return {
       attributeName: "id",
       types: [],
-      setHtmlId: false,
+      setIdAttribute: false,
       generateID: () => {
         // Use mock ID if tests are running.
         if (typeof window !== "undefined" && (window as any).__TEST_OPTIONS) {
@@ -65,7 +70,6 @@ const UniqueID = Extension.create({
     };
   },
   addGlobalAttributes() {
-
     return [
       {
         types: this.options.types,
@@ -77,12 +81,15 @@ const UniqueID = Extension.create({
             renderHTML: (attributes) => {
               const defaultIdAttributes = {
                 [`data-${this.options.attributeName}`]:
-                    attributes[this.options.attributeName]
+                  attributes[this.options.attributeName],
               };
-              if (this.options.setHtmlId) {
-                return {...defaultIdAttributes, 'id': attributes[this.options.attributeName]}
+              if (this.options.setIdAttribute) {
+                return {
+                  ...defaultIdAttributes,
+                  id: attributes[this.options.attributeName],
+                };
               } else {
-                return defaultIdAttributes
+                return defaultIdAttributes;
               }
             },
           },


### PR DESCRIPTION
This PR adds a the option to set the html id on each block. This can then be used for anchors in a table of contents. 