### PR TITLE
feat: make callback return value optional in forEachBlock function

### DIFF
--- a/docs/pages/docs/editor-api/manipulating-blocks.mdx
+++ b/docs/pages/docs/editor-api/manipulating-blocks.mdx
@@ -91,7 +91,7 @@ Use `forEachBlock` to traverse all blocks in the editor depth-first, and execute
 
 ```typescript
 forEachBlock(
-  callback: (block: Block) => boolean,
+  callback: (block: Block) => boolean | undefined,
   reverse: boolean = false
 ): void;
 

--- a/packages/core/src/editor/BlockNoteEditor.ts
+++ b/packages/core/src/editor/BlockNoteEditor.ts
@@ -550,7 +550,7 @@ export class BlockNoteEditor<
       blockArray: Block<BSchema, ISchema, SSchema>[]
     ): boolean {
       for (const block of blockArray) {
-        if (!callback(block)) {
+        if (callback(block) === false) {
           return false;
         }
 


### PR DESCRIPTION
This pull request introduces an enhancement to the `forEachBlock` function by making the callback return value optional. Previously, the `forEachBlock` function expected the callback to return a value that is explicitly checked against `false` to determine whether to break out of the loop. With this update, the callback return value becomes optional, and the loop will continue to the next block if the callback returns `undefined` or `true`.

**Changes:**

1. **Modified the `forEachBlock` function logic:**

    ```typescript
    if (callback(block) === false) {
      return false;
    }
    ```
    has been altered to handle optional return values more gracefully.
   
2. **Updated Usage:**
    - If the callback returns `false`, the function will still exit early.
    - If the callback returns `undefined` or `true`, the function will continue iterating through the blocks.

**Reasons for Change:**

- **Flexibility:** This change provides more flexibility in using the `forEachBlock` function by not forcing callbacks to always return a value.
- **Backward Compatibility:** Existing code that relies on the callback returning `false` to break the loop will continue to function as expected. Hence, this is a non-breaking change.
- **Cleaner Code:** Allows for cleaner callback implementations where returning a value is unnecessary.

**Example Usage:**

Before:

```typescript
forEachBlock(block, (block) => {
  // some logic
  return true; // or return false explicitly
});
```

After:

```typescript
forEachBlock(block, (block) => {
  // some logic
  // no need to return true explicitly
});
```