### PR TITLE
feat: Non-selectable custom blocks

### DIFF
--- a/packages/core/src/schema/blocks/createSpec.ts
+++ b/packages/core/src/schema/blocks/createSpec.ts
@@ -63,12 +63,17 @@ export type CustomBlockImplementation<
   ) => PartialBlockFromConfig<T, I, S>["props"] | undefined;
 };
 
+// Function that enables copying of selected content within non-selectable
+// blocks.
 export function applyNonSelectableBlockFix(nodeView: NodeView, editor: Editor) {
   nodeView.stopEvent = (event) => {
-    // console.log("event", event);
+    // Ensures copy events are handled by the browser and not by ProseMirror.
     if (event.type === "copy") {
       return true;
     }
+    // Blurs the editor on mouse down as the block is non-selectable. This is
+    // mainly done to prevent UI elements like the formatting toolbar from being
+    // visible while content within a non-selectable block is selected.
     if (event.type === "mousedown") {
       setTimeout(() => {
         editor.view.dom.blur();

--- a/packages/core/src/schema/blocks/createSpec.ts
+++ b/packages/core/src/schema/blocks/createSpec.ts
@@ -1,4 +1,6 @@
+import { Editor } from "@tiptap/core";
 import { TagParseRule } from "@tiptap/pm/model";
+import { NodeView } from "@tiptap/pm/view";
 import type { BlockNoteEditor } from "../../editor/BlockNoteEditor";
 import { InlineContentSchema } from "../inlineContent/types";
 import { StyleSchema } from "../styles/types";
@@ -60,6 +62,22 @@ export type CustomBlockImplementation<
     el: HTMLElement
   ) => PartialBlockFromConfig<T, I, S>["props"] | undefined;
 };
+
+export function applyNonSelectableBlockFix(nodeView: NodeView, editor: Editor) {
+  nodeView.stopEvent = (event) => {
+    // console.log("event", event);
+    if (event.type === "copy") {
+      return true;
+    }
+    if (event.type === "mousedown") {
+      setTimeout(() => {
+        editor.view.dom.blur();
+      }, 10);
+      return true;
+    }
+    return false;
+  };
+}
 
 // Function that uses the 'parse' function of a blockConfig to create a
 // TipTap node's `parseHTML` property. This is only used for parsing content
@@ -125,7 +143,7 @@ export function createBlockSpec<
       ? "inline*"
       : "") as T["content"] extends "inline" ? "inline*" : "",
     group: "blockContent",
-    selectable: true,
+    selectable: blockConfig.isSelectable ?? true,
 
     addAttributes() {
       return propsToAttributes(blockConfig.propSchema);
@@ -163,13 +181,19 @@ export function createBlockSpec<
 
         const output = blockImplementation.render(block as any, editor);
 
-        return wrapInBlockStructure(
+        const nodeView: NodeView = wrapInBlockStructure(
           output,
           block.type,
           block.props,
           blockConfig.propSchema,
           blockContentDOMAttributes
         );
+
+        if (blockConfig.isSelectable === false) {
+          applyNonSelectableBlockFix(nodeView, this.editor);
+        }
+
+        return nodeView;
       };
     },
   });

--- a/packages/core/src/schema/blocks/createSpec.ts
+++ b/packages/core/src/schema/blocks/createSpec.ts
@@ -68,7 +68,7 @@ export type CustomBlockImplementation<
 export function applyNonSelectableBlockFix(nodeView: NodeView, editor: Editor) {
   nodeView.stopEvent = (event) => {
     // Ensures copy events are handled by the browser and not by ProseMirror.
-    if (event.type === "copy") {
+    if (event.type === "copy" || event.type === "cut") {
       return true;
     }
     // Blurs the editor on mouse down as the block is non-selectable. This is

--- a/packages/core/src/schema/blocks/types.ts
+++ b/packages/core/src/schema/blocks/types.ts
@@ -49,6 +49,7 @@ export type FileBlockConfig = {
     };
   };
   content: "none";
+  isSelectable?: boolean;
   isFileBlock: true;
   fileBlockAccept?: string[];
 };
@@ -60,6 +61,7 @@ export type BlockConfig =
       type: string;
       readonly propSchema: PropSchema;
       content: "inline" | "none" | "table";
+      isSelectable?: boolean;
       isFileBlock?: false;
     }
   | FileBlockConfig;

--- a/packages/react/src/schema/ReactBlockSpec.tsx
+++ b/packages/react/src/schema/ReactBlockSpec.tsx
@@ -1,4 +1,5 @@
 import {
+  applyNonSelectableBlockFix,
   BlockFromConfig,
   BlockNoteEditor,
   BlockSchemaWithBlock,
@@ -18,6 +19,7 @@ import {
   StyleSchema,
 } from "@blocknote/core";
 import {
+  NodeView,
   NodeViewContent,
   NodeViewProps,
   NodeViewWrapper,
@@ -118,7 +120,7 @@ export function createReactBlockSpec<
       ? "inline*"
       : "") as T["content"] extends "inline" ? "inline*" : "",
     group: "blockContent",
-    selectable: true,
+    selectable: blockConfig.isSelectable ?? true,
 
     addAttributes() {
       return propsToAttributes(blockConfig.propSchema);
@@ -141,7 +143,7 @@ export function createReactBlockSpec<
 
     addNodeView() {
       return (props) => {
-        const nv = ReactNodeViewRenderer(
+        const nodeView = ReactNodeViewRenderer(
           (props: NodeViewProps) => {
             // Gets the BlockNote editor instance
             const editor = this.options.editor! as BlockNoteEditor<any>;
@@ -178,22 +180,13 @@ export function createReactBlockSpec<
           {
             className: "bn-react-node-view-renderer",
           }
-        )(props);
+        )(props) as NodeView<any>;
 
-        nv.stopEvent = (event) => {
-          console.log("event", event);
-          if (event.type === "copy") {
-            return true;
-          }
-          if (event.type === "mousedown") {
-            setTimeout(() => {
-              this.editor.view.dom.blur();
-            }, 10);
-            return true;
-          }
-          return false;
-        };
-        return nv;
+        if (blockConfig.isSelectable === false) {
+          applyNonSelectableBlockFix(nodeView, this.editor);
+        }
+
+        return nodeView;
       };
     },
   });

--- a/packages/react/src/schema/ReactBlockSpec.tsx
+++ b/packages/react/src/schema/ReactBlockSpec.tsx
@@ -140,8 +140,8 @@ export function createReactBlockSpec<
     },
 
     addNodeView() {
-      return (props) =>
-        ReactNodeViewRenderer(
+      return (props) => {
+        const nv = ReactNodeViewRenderer(
           (props: NodeViewProps) => {
             // Gets the BlockNote editor instance
             const editor = this.options.editor! as BlockNoteEditor<any>;
@@ -179,6 +179,22 @@ export function createReactBlockSpec<
             className: "bn-react-node-view-renderer",
           }
         )(props);
+
+        nv.stopEvent = (event) => {
+          console.log("event", event);
+          if (event.type === "copy") {
+            return true;
+          }
+          if (event.type === "mousedown") {
+            setTimeout(() => {
+              this.editor.view.dom.blur();
+            }, 10);
+            return true;
+          }
+          return false;
+        };
+        return nv;
+      };
     },
   });
 


### PR DESCRIPTION
This PR adds the `isSelectable` field to block configs which allows the block to not be selectable. This is an optional field which is true by default.