### PR TITLE
feat: Added `resolveFileUrl` block ID field

### DIFF
--- a/packages/core/src/blocks/AudioBlockContent/AudioBlockContent.ts
+++ b/packages/core/src/blocks/AudioBlockContent/AudioBlockContent.ts
@@ -55,7 +55,7 @@ export const audioRender = (
 
   const audio = document.createElement("audio");
   audio.className = "bn-audio";
-  editor.resolveFileUrl(block.props.url).then((downloadUrl) => {
+  editor.resolveFileUrl(block.props.url, block.id).then((downloadUrl) => {
     audio.src = downloadUrl;
   });
   audio.controls = true;

--- a/packages/core/src/blocks/ImageBlockContent/ImageBlockContent.ts
+++ b/packages/core/src/blocks/ImageBlockContent/ImageBlockContent.ts
@@ -60,7 +60,7 @@ export const imageRender = (
 
   const image = document.createElement("img");
   image.className = "bn-visual-media";
-  editor.resolveFileUrl(block.props.url).then((downloadUrl) => {
+  editor.resolveFileUrl(block.props.url, block.id).then((downloadUrl) => {
     image.src = downloadUrl;
   });
   image.alt = block.props.name || block.props.caption || "BlockNote image";

--- a/packages/core/src/blocks/VideoBlockContent/VideoBlockContent.ts
+++ b/packages/core/src/blocks/VideoBlockContent/VideoBlockContent.ts
@@ -61,7 +61,9 @@ export const videoRender = (
 
   const video = document.createElement("video");
   video.className = "bn-visual-media";
-  video.src = block.props.url;
+  editor.resolveFileUrl(block.props.url, block.id).then((downloadUrl) => {
+    video.src = downloadUrl;
+  });
   video.controls = true;
   video.contentEditable = "false";
   video.draggable = false;

--- a/packages/core/src/editor/BlockNoteEditor.ts
+++ b/packages/core/src/editor/BlockNoteEditor.ts
@@ -137,7 +137,7 @@ export type BlockNoteEditorOptions<
    * implementing custom protocols / schemes
    * @returns The URL that's
    */
-  resolveFileUrl: (url: string) => Promise<string>;
+  resolveFileUrl: (url: string, blockId?: string) => Promise<string>;
 
   /**
    * When enabled, allows for collaboration between multiple users.
@@ -282,7 +282,10 @@ export class BlockNoteEditor<
   private onUploadStartCallbacks: ((blockId?: string) => void)[] = [];
   private onUploadEndCallbacks: ((blockId?: string) => void)[] = [];
 
-  public readonly resolveFileUrl: (url: string) => Promise<string>;
+  public readonly resolveFileUrl: (
+    url: string,
+    blockId?: string
+  ) => Promise<string>;
 
   public get pmSchema() {
     return this._pmSchema;

--- a/packages/react/src/blocks/AudioBlockContent/AudioBlockContent.tsx
+++ b/packages/react/src/blocks/AudioBlockContent/AudioBlockContent.tsx
@@ -18,7 +18,7 @@ export const AudioPreview = (
     "contentRef"
   >
 ) => {
-  const resolved = useResolveUrl(props.block.props.url!);
+  const resolved = useResolveUrl(props.block.props.url!, props.block.id);
 
   if (resolved.loadingState === "loading") {
     return null;

--- a/packages/react/src/blocks/FileBlockContent/useResolveUrl.tsx
+++ b/packages/react/src/blocks/FileBlockContent/useResolveUrl.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react";
 import { useBlockNoteEditor } from "../../hooks/useBlockNoteEditor";
 import { BlockSchema, InlineContentSchema, StyleSchema } from "@blocknote/core";
 
-export function useResolveUrl(fetchUrl: string) {
+export function useResolveUrl(fetchUrl: string, blockId?: string) {
   const editor = useBlockNoteEditor<
     BlockSchema,
     InlineContentSchema,
@@ -21,7 +21,7 @@ export function useResolveUrl(fetchUrl: string) {
       setLoadingState("loading");
 
       try {
-        url = await editor.resolveFileUrl(fetchUrl);
+        url = await editor.resolveFileUrl(fetchUrl, blockId);
       } catch (error) {
         setLoadingState("error");
         return;

--- a/packages/react/src/blocks/ImageBlockContent/ImageBlockContent.tsx
+++ b/packages/react/src/blocks/ImageBlockContent/ImageBlockContent.tsx
@@ -27,7 +27,7 @@ export const ImagePreview = (
     )
   );
 
-  const resolved = useResolveUrl(props.block.props.url!);
+  const resolved = useResolveUrl(props.block.props.url!, props.block.id);
 
   if (resolved.loadingState === "loading") {
     return null;

--- a/packages/react/src/blocks/VideoBlockContent/VideoBlockContent.tsx
+++ b/packages/react/src/blocks/VideoBlockContent/VideoBlockContent.tsx
@@ -27,7 +27,7 @@ export const VideoPreview = (
     )
   );
 
-  const resolved = useResolveUrl(props.block.props.url!);
+  const resolved = useResolveUrl(props.block.props.url!, props.block.id);
 
   if (resolved.loadingState === "loading") {
     return null;

--- a/packages/react/src/components/FilePanel/DefaultTabs/UploadTab.tsx
+++ b/packages/react/src/components/FilePanel/DefaultTabs/UploadTab.tsx
@@ -50,7 +50,7 @@ export const UploadTab = <
 
         if (editor.uploadFile !== undefined) {
           try {
-            let updateData = await editor.uploadFile(file);
+            let updateData = await editor.uploadFile(file, block.id);
             if (typeof updateData === "string") {
               // received a url
               updateData = {

--- a/packages/react/src/components/FormattingToolbar/DefaultButtons/FileDownloadButton.tsx
+++ b/packages/react/src/components/FormattingToolbar/DefaultButtons/FileDownloadButton.tsx
@@ -45,7 +45,7 @@ export const FileDownloadButton = () => {
     if (fileBlock && fileBlock.props.url) {
       editor.focus();
       editor
-        .resolveFileUrl(fileBlock.props.url)
+        .resolveFileUrl(fileBlock.props.url, fileBlock.id)
         .then((downloadUrl) =>
           window.open(sanitizeUrl(downloadUrl, window.location.href))
         );


### PR DESCRIPTION
This PR adds a block ID field to `resolveFileUrl` as there seems to be a use case for it as per [this Discord thread](https://discord.com/channels/928190961455087667/1286268979253481503/1286268979253481503).

Also fixes the upload file button not including the block ID when calling `editor.uploadFile`, and the video block not calling `editor.resolveUrl`.