### PR TITLE
fix: Made all events in non-selectable blocks get handled by browser

### DIFF
--- a/packages/core/src/schema/blocks/createSpec.ts
+++ b/packages/core/src/schema/blocks/createSpec.ts
@@ -63,18 +63,10 @@ export type CustomBlockImplementation<
   ) => PartialBlockFromConfig<T, I, S>["props"] | undefined;
 };
 
-// Function that enables copying of selected content within non-selectable
-// blocks.
+// Function that causes events within non-selectable blocks to be handled by the
+// browser instead of the editor.
 export function applyNonSelectableBlockFix(nodeView: NodeView, editor: Editor) {
   nodeView.stopEvent = (event) => {
-    // Ensures copy events are handled by the browser and not by ProseMirror.
-    if (
-      event.type === "copy" ||
-      event.type === "cut" ||
-      event.type === "paste"
-    ) {
-      return true;
-    }
     // Blurs the editor on mouse down as the block is non-selectable. This is
     // mainly done to prevent UI elements like the formatting toolbar from being
     // visible while content within a non-selectable block is selected.
@@ -82,9 +74,9 @@ export function applyNonSelectableBlockFix(nodeView: NodeView, editor: Editor) {
       setTimeout(() => {
         editor.view.dom.blur();
       }, 10);
-      return true;
     }
-    return false;
+
+    return true;
   };
 }
 


### PR DESCRIPTION
It seems pointless to let the editor handle any events within a non-selectable block, as these are basically islands of content that aren't handled by ProseMirror.

This fix is mainly done as keyboard events may still be handled by PM before reaching the DOM - I noticed this was causing some issues in the DO database block.