### PR TITLE
fix: add CSS to package.json sideEffects

### DIFF
--- a/packages/shadcn/package.json
+++ b/packages/shadcn/package.json
@@ -2,7 +2,7 @@
   "name": "@blocknote/shadcn",
   "homepage": "https://github.com/TypeCellOS/BlockNote",
   "private": false,
-  "sideEffects": false,
+  "sideEffects": ["./dist/style.css"],
   "license": "MPL-2.0",
   "version": "0.16.0",
   "files": [


### PR DESCRIPTION
Got this warning (bundling with esbuild and esbuild-sass-plugin) and the styles are missing in the output:
```
▲ [WARNING] Ignoring this import because "node_modules/@blocknote/shadcn/dist/style.css" was marked as having no side effects [ignored-bare-import]

    components/Hello.tsx:4:7:
      4 │ import "@blocknote/shadcn/style.css"
        ╵        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

  "sideEffects" is false in the enclosing "package.json" file:

    node_modules/@blocknote/shadcn/package.json:5:2:
      5 │   "sideEffects": false,
```
This patch fixes it for me, but I'm not sure that's the best approach.

See also https://github.com/TypeCellOS/BlockNote/commit/7593ba3450b6e839bd5ca460cd34cb1ebe266077