### PR TITLE
chore: mark all css files as sideEffects

### DIFF
--- a/packages/ariakit/package.json
+++ b/packages/ariakit/package.json
@@ -2,6 +2,9 @@
   "name": "@blocknote/ariakit",
   "homepage": "https://github.com/TypeCellOS/BlockNote",
   "private": false,
+  "sideEffects": [
+    "*.css"
+  ],
   "license": "MPL-2.0",
   "version": "0.16.0",
   "files": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -2,6 +2,9 @@
   "name": "@blocknote/core",
   "homepage": "https://github.com/TypeCellOS/BlockNote",
   "private": false,
+  "sideEffects": [
+    "*.css"
+  ],
   "license": "MPL-2.0",
   "version": "0.16.0",
   "files": [

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -2,7 +2,9 @@
   "name": "@blocknote/react",
   "homepage": "https://github.com/TypeCellOS/BlockNote",
   "private": false,
-  "sideEffects": false,
+  "sideEffects": [
+    "*.css"
+  ],
   "license": "MPL-2.0",
   "version": "0.16.0",
   "files": [

--- a/packages/server-util/package.json
+++ b/packages/server-util/package.json
@@ -2,6 +2,9 @@
   "name": "@blocknote/server-util",
   "homepage": "https://github.com/TypeCellOS/BlockNote",
   "private": false,
+  "sideEffects": [
+    "*.css"
+  ],
   "license": "MPL-2.0",
   "version": "0.16.0",
   "files": [

--- a/packages/shadcn/package.json
+++ b/packages/shadcn/package.json
@@ -2,7 +2,9 @@
   "name": "@blocknote/shadcn",
   "homepage": "https://github.com/TypeCellOS/BlockNote",
   "private": false,
-  "sideEffects": false,
+  "sideEffects": [
+    "*.css"
+  ],
   "license": "MPL-2.0",
   "version": "0.16.0",
   "files": [


### PR DESCRIPTION
correctly set sideeffects for all packages.

closes https://github.com/TypeCellOS/BlockNote/pull/1144

earlier context: https://github.com/TypeCellOS/BlockNote/pull/801