### PR TITLE
add support for blocknote transactions

### DIFF
--- a/packages/react/src/components/FormattingToolbar/DefaultSelects/BlockTypeSelect.tsx
+++ b/packages/react/src/components/FormattingToolbar/DefaultSelects/BlockTypeSelect.tsx
@@ -125,12 +125,14 @@ export const BlockTypeSelect = (props: { items?: BlockTypeSelectItem[] }) => {
       const onClick = (item: BlockTypeSelectItem) => {
         editor.focus();
 
-        for (const block of selectedBlocks) {
-          editor.updateBlock(block, {
-            type: item.type as any,
-            props: item.props as any,
-          });
-        }
+        editor.transact(() => {
+          for (const block of selectedBlocks) {
+            editor.updateBlock(block, {
+              type: item.type as any,
+              props: item.props as any,
+            });
+          }
+        });
       };
 
       return filteredItems.map((item) => {


### PR DESCRIPTION
This is a POC for blocknote-level transactions. It should make it possible to clean our existing commands (those in `blockManipulation` further down by migrating away from tiptap-style commands). It also unlocks the possibility for userland-transactions. 

For example, the following bug is fixed:
- select a number of paragraphs
- change type to "heading"
- "undo" will undo them one by one (after the fix, "undo" will reset all headings back to paragraphs in one step as expected)

closes https://github.com/TypeCellOS/BlockNote/issues?q=is%3Aissue+is%3Aopen+undo

TODO:
- add tests
- See if there are bugs with this approach. For example, what if you call other functions in a transact block that depend on `editor.state`? It's likely they should read the state from the `activeTransaction` instead (diagnose, create tests, and fix)
- if there are other BlockNote APIs called in a loop (similar to blocktype select), migrate them to use `transact`
