### PR TITLE
fix: caption width match file container #1169

### DIFF
--- a/packages/core/src/blocks/FileBlockContent/fileBlockHelpers.ts
+++ b/packages/core/src/blocks/FileBlockContent/fileBlockHelpers.ts
@@ -339,9 +339,6 @@ export const createResizeHandlesWrapper = (
   const windowMouseUpHandler = (event: MouseEvent) => {
     // Hides the drag handles if the cursor is no longer over the element.
 
-    // console.log("mouse up-- now ---", wrapper, editor, block)
-    // console.log("next to wrapper-- now ---", wrapper.nextSibling, element)
-    const caption = wrapper.nextSibling as HTMLElement;
     if (
       (!event.target ||
         !wrapper.contains(event.target as Node) ||

--- a/packages/core/src/blocks/FileBlockContent/fileBlockHelpers.ts
+++ b/packages/core/src/blocks/FileBlockContent/fileBlockHelpers.ts
@@ -273,10 +273,10 @@ export const createResizeHandlesWrapper = (
   // calculate the new width of the element.
   let resizeParams:
     | {
-      handleUsed: "left" | "right";
-      initialWidth: number;
-      initialClientX: number;
-    }
+        handleUsed: "left" | "right";
+        initialWidth: number;
+        initialClientX: number;
+      }
     | undefined;
 
   // Updates the element width with an updated width depending on the cursor X
@@ -338,7 +338,6 @@ export const createResizeHandlesWrapper = (
   // `width` prop to the new value.
   const windowMouseUpHandler = (event: MouseEvent) => {
     // Hides the drag handles if the cursor is no longer over the element.
-
     if (
       (!event.target ||
         !wrapper.contains(event.target as Node) ||

--- a/packages/core/src/blocks/FileBlockContent/fileBlockHelpers.ts
+++ b/packages/core/src/blocks/FileBlockContent/fileBlockHelpers.ts
@@ -108,6 +108,13 @@ export const createFileAndCaptionWrapper = (
   caption.className = "bn-file-caption";
   caption.textContent = block.props.caption;
 
+  if (typeof block.props.previewWidth === "number" &&
+    block.props.previewWidth > 0 &&
+    block.props.caption !== undefined
+  ) {
+    caption.style.width = `${block.props.previewWidth}px`
+  }
+
   fileAndCaptionWrapper.appendChild(file);
   fileAndCaptionWrapper.appendChild(caption);
 
@@ -266,10 +273,10 @@ export const createResizeHandlesWrapper = (
   // calculate the new width of the element.
   let resizeParams:
     | {
-        handleUsed: "left" | "right";
-        initialWidth: number;
-        initialClientX: number;
-      }
+      handleUsed: "left" | "right";
+      initialWidth: number;
+      initialClientX: number;
+    }
     | undefined;
 
   // Updates the element width with an updated width depending on the cursor X
@@ -331,6 +338,10 @@ export const createResizeHandlesWrapper = (
   // `width` prop to the new value.
   const windowMouseUpHandler = (event: MouseEvent) => {
     // Hides the drag handles if the cursor is no longer over the element.
+
+    // console.log("mouse up-- now ---", wrapper, editor, block)
+    // console.log("next to wrapper-- now ---", wrapper.nextSibling, element)
+    const caption = wrapper.nextSibling as HTMLElement;
     if (
       (!event.target ||
         !wrapper.contains(event.target as Node) ||


### PR DESCRIPTION
## PR Summary
Fix caption width issue it now able to sync when reizing.

The way fix it just to set same width, but this might not perfect solution.

_Note: potential problem:_
- when caption trim by white space, it will go another line, but we cant decide when it change line.
- due to same pixel, it might not good when we have some element on left or right overlapped.(this can be fix if have proper padding for caption paragraph tag)
- I notice when it resize it will actualy re-render the whole block container, this can be improve.

### Video:
https://github.com/user-attachments/assets/6346a338-7291-488e-b430-dad674e3c8cd


### Screenshots:

![Snipaste_2024-10-25_00-05-28](https://github.com/user-attachments/assets/0971a7a3-ce9d-4416-8351-06a7a665e35e)
![Snipaste_2024-10-25_00-05-40](https://github.com/user-attachments/assets/839c75e4-ed96-4af3-b2d0-5cafe5c594d8)
