### PR TITLE
fix: CodeBlock fixes (select menu, bundled languages, paste from VS Code)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "@blocknote/mantine": "^0.18.1",
         "@blocknote/react": "^0.18.1",
         "@blocknote/shadcn": "^0.18.1",
+        "@blocknote/xl-multi-column": "^0.18.1",
         "@headlessui/react": "^1.7.18",
         "@heroicons/react": "^2.1.4",
         "@mantine/core": "^7.10.1",

--- a/packages/core/src/blocks/CodeBlockContent/defaultSupportedLanguages.ts
+++ b/packages/core/src/blocks/CodeBlockContent/defaultSupportedLanguages.ts
@@ -43,7 +43,6 @@ export const defaultSupportedLanguages: SupportedLanguageConfig[] = [
         "shellscript",
         "sql",
         "svelte",
-        "tsx",
         "typescript",
         "vue",
         "vue-html",
@@ -58,6 +57,7 @@ export const defaultSupportedLanguages: SupportedLanguageConfig[] = [
       id: lang.id,
       name: lang.name,
     })),
+  { id: "tsx", name: "TSX", match: ["tsx", "typescriptreact"] },
   {
     id: "haskell",
     name: "Haskell",

--- a/packages/core/src/blocks/CodeBlockContent/defaultSupportedLanguages.ts
+++ b/packages/core/src/blocks/CodeBlockContent/defaultSupportedLanguages.ts
@@ -1,4 +1,4 @@
-import { bundledLanguagesInfo } from "shiki/bundle/web";
+import { bundledLanguagesInfo } from "shiki";
 
 export type SupportedLanguageConfig = {
   id: string;
@@ -14,23 +14,43 @@ export const defaultSupportedLanguages: SupportedLanguageConfig[] = [
   },
   ...bundledLanguagesInfo
     .filter((lang) => {
-      return ![
-        "angular-html",
-        "angular-ts",
-        "astro",
-        "blade",
-        "coffee",
-        "handlebars",
-        "html-derivative",
-        "http",
-        "imba",
-        "jinja",
-        "jison",
-        "json5",
-        "marko",
-        "mdc",
-        "stylus",
-        "ts-tags",
+      return [
+        "c",
+        "cpp",
+        "css",
+        "glsl",
+        "graphql",
+        "haml",
+        "html",
+        "java",
+        "javascript",
+        "json",
+        "jsonc",
+        "jsonl",
+        "jsx",
+        "julia",
+        "less",
+        "markdown",
+        "mdx",
+        "php",
+        "postcss",
+        "pug",
+        "python",
+        "r",
+        "regexp",
+        "sass",
+        "scss",
+        "shellscript",
+        "sql",
+        "svelte",
+        "tsx",
+        "typescript",
+        "vue",
+        "vue-html",
+        "wasm",
+        "wgsl",
+        "xml",
+        "yaml",
       ].includes(lang.id);
     })
     .map((lang) => ({

--- a/packages/core/src/editor/Block.css
+++ b/packages/core/src/editor/Block.css
@@ -299,6 +299,9 @@ NESTED BLOCKS
   transition: opacity 0.3s;
   transition-delay: 1s;
 }
+.bn-block-content[data-content-type="codeBlock"] > div > select > option {
+  color: black;
+}
 .bn-block-content[data-content-type="codeBlock"]:hover > div > select,
 .bn-block-content[data-content-type="codeBlock"] > div > select:focus {
   opacity: 0.5;


### PR DESCRIPTION
Fixes CodeBlock issues:
- #1212 (by setting text color for select options);
- #1210 (by improving language parsing from pasted HTML & matching `typescriptreact` alias for TSX);

Improves on the #1213, fixing duplicate languages in the bundle output (by importing from only a single Shiki bundle);