### PR TITLE
fix: Clipboard insertion with multiple data types

### DIFF
--- a/packages/core/src/api/clipboard/fromClipboard/acceptedMIMETypes.ts
+++ b/packages/core/src/api/clipboard/fromClipboard/acceptedMIMETypes.ts
@@ -1,7 +1,7 @@
 export const acceptedMIMETypes = [
   "vscode-editor-data",
   "blocknote/html",
-  "Files",
   "text/html",
   "text/plain",
+  "Files",
 ] as const;


### PR DESCRIPTION
Currently, when inserting content from the clipboard, we prioritize files over text. However, this is problematic in some cases, such as when copy/pasting Excel tables. In this scenario, the table is written to `text/html` and an image of the table is written to `Files` on the clipboard. So previously, an image block was created and in this PR, the table block is created instead.

There may be other cases in which we actually do want to prioritize files over text, but I'm not sure atm. This is not relevant for pasting/dropping files from the user's OS file system as in that case, data is only written to `Files` on the clipboard so the priority doesn't matter.