### PR TITLE
fix: export updateBlockCommand, to allow extending heading block

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -46,6 +46,7 @@ export * from "./util/string.js";
 export * from "./util/typescript.js";
 export { UnreachableCaseError, assertEmpty } from "./util/typescript.js";
 export { locales };
+export * from "./api/blockManipulation/commands/updateBlock/updateBlock.js";
 
 // for testing from react (TODO: move):
 export * from "./api/nodeConversions/blockToNode.js";


### PR DESCRIPTION
This pull request adds an export statement to `index.ts` to include the `updateBlockCommand` function from `./api/blockManipulation/commands/updateBlock/updateBlock.js`. This change is necessary to facilitate the extension of the heading block, which requires access to the updateBlockCommand function.