### PR TITLE
fix: List item shortcuts throwing errors

### DIFF
--- a/packages/core/src/blocks/ListItemBlockContent/BulletListItemBlockContent/BulletListItemBlockContent.ts
+++ b/packages/core/src/blocks/ListItemBlockContent/BulletListItemBlockContent/BulletListItemBlockContent.ts
@@ -59,7 +59,7 @@ const BulletListItemBlockContent = createStronglyTypedTiptapNode({
           return true;
         }
 
-        return this.options.editor.commands.command(
+        return this.editor.commands.command(
           updateBlockCommand(this.options.editor, blockInfo.bnBlock.beforePos, {
             type: "bulletListItem",
             props: {},

--- a/packages/core/src/blocks/ListItemBlockContent/CheckListItemBlockContent/CheckListItemBlockContent.ts
+++ b/packages/core/src/blocks/ListItemBlockContent/CheckListItemBlockContent/CheckListItemBlockContent.ts
@@ -103,7 +103,7 @@ const checkListItemBlockContent = createStronglyTypedTiptapNode({
     return {
       Enter: () => handleEnter(this.options.editor),
       "Mod-Shift-9": () => {
-        const blockInfo = getBlockInfoFromSelection(this.options.editor.state);
+        const blockInfo = getBlockInfoFromSelection(this.editor.state);
         if (blockInfo.blockContent.node.type.spec.content !== "inline*") {
           return true;
         }

--- a/tests/src/component/copypaste-internal.spec.tsx
+++ b/tests/src/component/copypaste-internal.spec.tsx
@@ -32,7 +32,7 @@ test("Alert Copy/Paste Internal", async ({ browserName, mount, page }) => {
   );
   await button.first().click();
 
-  await copyPasteAll(page, "mac");
+  await copyPasteAll(page);
   await page.waitForTimeout(50);
 
   await compareDocToSnapshot(page, "alert-internal");
@@ -52,7 +52,7 @@ test("Button Copy/Paste Internal", async ({ browserName, mount, page }) => {
   await page.keyboard.press("ArrowDown");
   await page.keyboard.type("Paragraph 2");
 
-  await copyPasteAll(page, "mac");
+  await copyPasteAll(page);
   await page.waitForTimeout(50);
 
   const button = await page.locator("button");
@@ -76,7 +76,7 @@ test("Embed Copy/Paste Internal", async ({ browserName, mount, page }) => {
   await page.keyboard.press("ArrowDown");
   await page.keyboard.type("Paragraph 2");
 
-  await copyPasteAll(page, "mac");
+  await copyPasteAll(page);
   await page.waitForTimeout(50);
 
   await compareDocToSnapshot(page, "embed-internal");
@@ -98,7 +98,7 @@ test("Image Copy/Paste Internal", async ({ browserName, mount, page }) => {
   await page.keyboard.press("ArrowDown");
   await page.keyboard.type("Paragraph 2");
 
-  await copyPasteAll(page, "mac");
+  await copyPasteAll(page);
   await page.waitForTimeout(50);
 
   await compareDocToSnapshot(page, "image-internal");
@@ -118,7 +118,7 @@ test("Separator Copy/Paste Internal", async ({ browserName, mount, page }) => {
   await page.keyboard.press("ArrowDown");
   await page.keyboard.type("Paragraph 2");
 
-  await copyPasteAll(page, "mac");
+  await copyPasteAll(page);
   await page.waitForTimeout(50);
 
   await compareDocToSnapshot(page, "separator-internal");
@@ -144,7 +144,7 @@ test("Table of Contents Copy/Paste Internal", async ({
   await executeSlashCommand(page, "h2");
   await page.keyboard.type("Heading 2");
 
-  await copyPasteAll(page, "mac");
+  await copyPasteAll(page);
   await page.waitForTimeout(50);
 
   const expectedToC =

--- a/tests/src/end-to-end/keyboardhandlers/keyboardhandlers.test.ts
+++ b/tests/src/end-to-end/keyboardhandlers/keyboardhandlers.test.ts
@@ -131,4 +131,46 @@ test.describe("Check Keyboard Handlers' Behaviour", () => {
 
     await compareDocToSnapshot(page, "backspacePreservesNestedBlocks.json");
   });
+  test("Check heading 1 shortcut", async ({ page }) => {
+    await focusOnEditor(page);
+    await page.keyboard.type("Paragraph");
+    await page.keyboard.press("ControlOrMeta+Alt+1");
+
+    await compareDocToSnapshot(page, "heading1Shortcut.json");
+  });
+  test("Check heading 2 shortcut", async ({ page }) => {
+    await focusOnEditor(page);
+    await page.keyboard.type("Paragraph");
+    await page.keyboard.press("ControlOrMeta+Alt+2");
+
+    await compareDocToSnapshot(page, "heading2Shortcut.json");
+  });
+  test("Check heading 3 shortcut", async ({ page }) => {
+    await focusOnEditor(page);
+    await page.keyboard.type("Paragraph");
+    await page.keyboard.press("ControlOrMeta+Alt+3");
+
+    await compareDocToSnapshot(page, "heading3Shortcut.json");
+  });
+  test("Check numbered list item shortcut", async ({ page }) => {
+    await focusOnEditor(page);
+    await page.keyboard.type("Paragraph");
+    await page.keyboard.press("ControlOrMeta+Shift+7");
+
+    await compareDocToSnapshot(page, "numberedListItemShortcut.json");
+  });
+  test("Check bullet list item shortcut", async ({ page }) => {
+    await focusOnEditor(page);
+    await page.keyboard.type("Paragraph");
+    await page.keyboard.press("ControlOrMeta+Shift+8");
+
+    await compareDocToSnapshot(page, "bulletListItemShortcut.json");
+  });
+  test("Check checked list item shortcut", async ({ page }) => {
+    await focusOnEditor(page);
+    await page.keyboard.type("Paragraph");
+    await page.keyboard.press("ControlOrMeta+Shift+9");
+
+    await compareDocToSnapshot(page, "checkedListItemShortcut.json");
+  });
 });

--- a/tests/src/end-to-end/keyboardhandlers/keyboardhandlers.test.ts-snapshots/bulletListItemShortcut-json-chromium-linux.json
+++ b/tests/src/end-to-end/keyboardhandlers/keyboardhandlers.test.ts-snapshots/bulletListItemShortcut-json-chromium-linux.json
@@ -1,0 +1,48 @@
+{
+  "type": "doc",
+  "content": [
+    {
+      "type": "blockGroup",
+      "content": [
+        {
+          "type": "blockContainer",
+          "attrs": {
+            "id": "0",
+            "textColor": "default",
+            "backgroundColor": "default"
+          },
+          "content": [
+            {
+              "type": "bulletListItem",
+              "attrs": {
+                "textAlignment": "left"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "Paragraph"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "blockContainer",
+          "attrs": {
+            "id": "1",
+            "textColor": "default",
+            "backgroundColor": "default"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "textAlignment": "left"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/src/end-to-end/keyboardhandlers/keyboardhandlers.test.ts-snapshots/bulletListItemShortcut-json-firefox-linux.json
+++ b/tests/src/end-to-end/keyboardhandlers/keyboardhandlers.test.ts-snapshots/bulletListItemShortcut-json-firefox-linux.json
@@ -1,0 +1,48 @@
+{
+  "type": "doc",
+  "content": [
+    {
+      "type": "blockGroup",
+      "content": [
+        {
+          "type": "blockContainer",
+          "attrs": {
+            "id": "0",
+            "textColor": "default",
+            "backgroundColor": "default"
+          },
+          "content": [
+            {
+              "type": "bulletListItem",
+              "attrs": {
+                "textAlignment": "left"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "Paragraph"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "blockContainer",
+          "attrs": {
+            "id": "1",
+            "textColor": "default",
+            "backgroundColor": "default"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "textAlignment": "left"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/src/end-to-end/keyboardhandlers/keyboardhandlers.test.ts-snapshots/bulletListItemShortcut-json-webkit-linux.json
+++ b/tests/src/end-to-end/keyboardhandlers/keyboardhandlers.test.ts-snapshots/bulletListItemShortcut-json-webkit-linux.json
@@ -1,0 +1,48 @@
+{
+  "type": "doc",
+  "content": [
+    {
+      "type": "blockGroup",
+      "content": [
+        {
+          "type": "blockContainer",
+          "attrs": {
+            "id": "0",
+            "textColor": "default",
+            "backgroundColor": "default"
+          },
+          "content": [
+            {
+              "type": "bulletListItem",
+              "attrs": {
+                "textAlignment": "left"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "Paragraph"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "blockContainer",
+          "attrs": {
+            "id": "1",
+            "textColor": "default",
+            "backgroundColor": "default"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "textAlignment": "left"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/src/end-to-end/keyboardhandlers/keyboardhandlers.test.ts-snapshots/checkedListItemShortcut-json-chromium-linux.json
+++ b/tests/src/end-to-end/keyboardhandlers/keyboardhandlers.test.ts-snapshots/checkedListItemShortcut-json-chromium-linux.json
@@ -1,0 +1,49 @@
+{
+  "type": "doc",
+  "content": [
+    {
+      "type": "blockGroup",
+      "content": [
+        {
+          "type": "blockContainer",
+          "attrs": {
+            "id": "0",
+            "textColor": "default",
+            "backgroundColor": "default"
+          },
+          "content": [
+            {
+              "type": "checkListItem",
+              "attrs": {
+                "textAlignment": "left",
+                "checked": false
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "Paragraph"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "blockContainer",
+          "attrs": {
+            "id": "1",
+            "textColor": "default",
+            "backgroundColor": "default"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "textAlignment": "left"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/src/end-to-end/keyboardhandlers/keyboardhandlers.test.ts-snapshots/checkedListItemShortcut-json-firefox-linux.json
+++ b/tests/src/end-to-end/keyboardhandlers/keyboardhandlers.test.ts-snapshots/checkedListItemShortcut-json-firefox-linux.json
@@ -1,0 +1,49 @@
+{
+  "type": "doc",
+  "content": [
+    {
+      "type": "blockGroup",
+      "content": [
+        {
+          "type": "blockContainer",
+          "attrs": {
+            "id": "0",
+            "textColor": "default",
+            "backgroundColor": "default"
+          },
+          "content": [
+            {
+              "type": "checkListItem",
+              "attrs": {
+                "textAlignment": "left",
+                "checked": false
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "Paragraph"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "blockContainer",
+          "attrs": {
+            "id": "1",
+            "textColor": "default",
+            "backgroundColor": "default"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "textAlignment": "left"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/src/end-to-end/keyboardhandlers/keyboardhandlers.test.ts-snapshots/checkedListItemShortcut-json-webkit-linux.json
+++ b/tests/src/end-to-end/keyboardhandlers/keyboardhandlers.test.ts-snapshots/checkedListItemShortcut-json-webkit-linux.json
@@ -1,0 +1,49 @@
+{
+  "type": "doc",
+  "content": [
+    {
+      "type": "blockGroup",
+      "content": [
+        {
+          "type": "blockContainer",
+          "attrs": {
+            "id": "0",
+            "textColor": "default",
+            "backgroundColor": "default"
+          },
+          "content": [
+            {
+              "type": "checkListItem",
+              "attrs": {
+                "textAlignment": "left",
+                "checked": false
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "Paragraph"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "blockContainer",
+          "attrs": {
+            "id": "1",
+            "textColor": "default",
+            "backgroundColor": "default"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "textAlignment": "left"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/src/end-to-end/keyboardhandlers/keyboardhandlers.test.ts-snapshots/heading1Shortcut-json-chromium-linux.json
+++ b/tests/src/end-to-end/keyboardhandlers/keyboardhandlers.test.ts-snapshots/heading1Shortcut-json-chromium-linux.json
@@ -1,0 +1,49 @@
+{
+  "type": "doc",
+  "content": [
+    {
+      "type": "blockGroup",
+      "content": [
+        {
+          "type": "blockContainer",
+          "attrs": {
+            "id": "0",
+            "textColor": "default",
+            "backgroundColor": "default"
+          },
+          "content": [
+            {
+              "type": "heading",
+              "attrs": {
+                "textAlignment": "left",
+                "level": 1
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "Paragraph"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "blockContainer",
+          "attrs": {
+            "id": "1",
+            "textColor": "default",
+            "backgroundColor": "default"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "textAlignment": "left"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/src/end-to-end/keyboardhandlers/keyboardhandlers.test.ts-snapshots/heading1Shortcut-json-firefox-linux.json
+++ b/tests/src/end-to-end/keyboardhandlers/keyboardhandlers.test.ts-snapshots/heading1Shortcut-json-firefox-linux.json
@@ -1,0 +1,49 @@
+{
+  "type": "doc",
+  "content": [
+    {
+      "type": "blockGroup",
+      "content": [
+        {
+          "type": "blockContainer",
+          "attrs": {
+            "id": "0",
+            "textColor": "default",
+            "backgroundColor": "default"
+          },
+          "content": [
+            {
+              "type": "heading",
+              "attrs": {
+                "textAlignment": "left",
+                "level": 1
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "Paragraph"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "blockContainer",
+          "attrs": {
+            "id": "1",
+            "textColor": "default",
+            "backgroundColor": "default"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "textAlignment": "left"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/src/end-to-end/keyboardhandlers/keyboardhandlers.test.ts-snapshots/heading1Shortcut-json-webkit-linux.json
+++ b/tests/src/end-to-end/keyboardhandlers/keyboardhandlers.test.ts-snapshots/heading1Shortcut-json-webkit-linux.json
@@ -1,0 +1,49 @@
+{
+  "type": "doc",
+  "content": [
+    {
+      "type": "blockGroup",
+      "content": [
+        {
+          "type": "blockContainer",
+          "attrs": {
+            "id": "0",
+            "textColor": "default",
+            "backgroundColor": "default"
+          },
+          "content": [
+            {
+              "type": "heading",
+              "attrs": {
+                "textAlignment": "left",
+                "level": 1
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "Paragraph"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "blockContainer",
+          "attrs": {
+            "id": "1",
+            "textColor": "default",
+            "backgroundColor": "default"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "textAlignment": "left"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/src/end-to-end/keyboardhandlers/keyboardhandlers.test.ts-snapshots/heading2Shortcut-json-chromium-linux.json
+++ b/tests/src/end-to-end/keyboardhandlers/keyboardhandlers.test.ts-snapshots/heading2Shortcut-json-chromium-linux.json
@@ -1,0 +1,49 @@
+{
+  "type": "doc",
+  "content": [
+    {
+      "type": "blockGroup",
+      "content": [
+        {
+          "type": "blockContainer",
+          "attrs": {
+            "id": "0",
+            "textColor": "default",
+            "backgroundColor": "default"
+          },
+          "content": [
+            {
+              "type": "heading",
+              "attrs": {
+                "textAlignment": "left",
+                "level": 2
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "Paragraph"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "blockContainer",
+          "attrs": {
+            "id": "1",
+            "textColor": "default",
+            "backgroundColor": "default"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "textAlignment": "left"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/src/end-to-end/keyboardhandlers/keyboardhandlers.test.ts-snapshots/heading2Shortcut-json-firefox-linux.json
+++ b/tests/src/end-to-end/keyboardhandlers/keyboardhandlers.test.ts-snapshots/heading2Shortcut-json-firefox-linux.json
@@ -1,0 +1,49 @@
+{
+  "type": "doc",
+  "content": [
+    {
+      "type": "blockGroup",
+      "content": [
+        {
+          "type": "blockContainer",
+          "attrs": {
+            "id": "0",
+            "textColor": "default",
+            "backgroundColor": "default"
+          },
+          "content": [
+            {
+              "type": "heading",
+              "attrs": {
+                "textAlignment": "left",
+                "level": 2
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "Paragraph"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "blockContainer",
+          "attrs": {
+            "id": "1",
+            "textColor": "default",
+            "backgroundColor": "default"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "textAlignment": "left"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/src/end-to-end/keyboardhandlers/keyboardhandlers.test.ts-snapshots/heading2Shortcut-json-webkit-linux.json
+++ b/tests/src/end-to-end/keyboardhandlers/keyboardhandlers.test.ts-snapshots/heading2Shortcut-json-webkit-linux.json
@@ -1,0 +1,49 @@
+{
+  "type": "doc",
+  "content": [
+    {
+      "type": "blockGroup",
+      "content": [
+        {
+          "type": "blockContainer",
+          "attrs": {
+            "id": "0",
+            "textColor": "default",
+            "backgroundColor": "default"
+          },
+          "content": [
+            {
+              "type": "heading",
+              "attrs": {
+                "textAlignment": "left",
+                "level": 2
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "Paragraph"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "blockContainer",
+          "attrs": {
+            "id": "1",
+            "textColor": "default",
+            "backgroundColor": "default"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "textAlignment": "left"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/src/end-to-end/keyboardhandlers/keyboardhandlers.test.ts-snapshots/heading3Shortcut-json-chromium-linux.json
+++ b/tests/src/end-to-end/keyboardhandlers/keyboardhandlers.test.ts-snapshots/heading3Shortcut-json-chromium-linux.json
@@ -1,0 +1,49 @@
+{
+  "type": "doc",
+  "content": [
+    {
+      "type": "blockGroup",
+      "content": [
+        {
+          "type": "blockContainer",
+          "attrs": {
+            "id": "0",
+            "textColor": "default",
+            "backgroundColor": "default"
+          },
+          "content": [
+            {
+              "type": "heading",
+              "attrs": {
+                "textAlignment": "left",
+                "level": 3
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "Paragraph"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "blockContainer",
+          "attrs": {
+            "id": "1",
+            "textColor": "default",
+            "backgroundColor": "default"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "textAlignment": "left"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/src/end-to-end/keyboardhandlers/keyboardhandlers.test.ts-snapshots/heading3Shortcut-json-firefox-linux.json
+++ b/tests/src/end-to-end/keyboardhandlers/keyboardhandlers.test.ts-snapshots/heading3Shortcut-json-firefox-linux.json
@@ -1,0 +1,49 @@
+{
+  "type": "doc",
+  "content": [
+    {
+      "type": "blockGroup",
+      "content": [
+        {
+          "type": "blockContainer",
+          "attrs": {
+            "id": "0",
+            "textColor": "default",
+            "backgroundColor": "default"
+          },
+          "content": [
+            {
+              "type": "heading",
+              "attrs": {
+                "textAlignment": "left",
+                "level": 3
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "Paragraph"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "blockContainer",
+          "attrs": {
+            "id": "1",
+            "textColor": "default",
+            "backgroundColor": "default"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "textAlignment": "left"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/src/end-to-end/keyboardhandlers/keyboardhandlers.test.ts-snapshots/heading3Shortcut-json-webkit-linux.json
+++ b/tests/src/end-to-end/keyboardhandlers/keyboardhandlers.test.ts-snapshots/heading3Shortcut-json-webkit-linux.json
@@ -1,0 +1,49 @@
+{
+  "type": "doc",
+  "content": [
+    {
+      "type": "blockGroup",
+      "content": [
+        {
+          "type": "blockContainer",
+          "attrs": {
+            "id": "0",
+            "textColor": "default",
+            "backgroundColor": "default"
+          },
+          "content": [
+            {
+              "type": "heading",
+              "attrs": {
+                "textAlignment": "left",
+                "level": 3
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "Paragraph"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "blockContainer",
+          "attrs": {
+            "id": "1",
+            "textColor": "default",
+            "backgroundColor": "default"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "textAlignment": "left"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/src/end-to-end/keyboardhandlers/keyboardhandlers.test.ts-snapshots/numberedListItemShortcut-json-chromium-linux.json
+++ b/tests/src/end-to-end/keyboardhandlers/keyboardhandlers.test.ts-snapshots/numberedListItemShortcut-json-chromium-linux.json
@@ -1,0 +1,49 @@
+{
+  "type": "doc",
+  "content": [
+    {
+      "type": "blockGroup",
+      "content": [
+        {
+          "type": "blockContainer",
+          "attrs": {
+            "id": "0",
+            "textColor": "default",
+            "backgroundColor": "default"
+          },
+          "content": [
+            {
+              "type": "numberedListItem",
+              "attrs": {
+                "textAlignment": "left",
+                "index": "1"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "Paragraph"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "blockContainer",
+          "attrs": {
+            "id": "1",
+            "textColor": "default",
+            "backgroundColor": "default"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "textAlignment": "left"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/src/end-to-end/keyboardhandlers/keyboardhandlers.test.ts-snapshots/numberedListItemShortcut-json-firefox-linux.json
+++ b/tests/src/end-to-end/keyboardhandlers/keyboardhandlers.test.ts-snapshots/numberedListItemShortcut-json-firefox-linux.json
@@ -1,0 +1,49 @@
+{
+  "type": "doc",
+  "content": [
+    {
+      "type": "blockGroup",
+      "content": [
+        {
+          "type": "blockContainer",
+          "attrs": {
+            "id": "0",
+            "textColor": "default",
+            "backgroundColor": "default"
+          },
+          "content": [
+            {
+              "type": "numberedListItem",
+              "attrs": {
+                "textAlignment": "left",
+                "index": "1"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "Paragraph"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "blockContainer",
+          "attrs": {
+            "id": "1",
+            "textColor": "default",
+            "backgroundColor": "default"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "textAlignment": "left"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/src/end-to-end/keyboardhandlers/keyboardhandlers.test.ts-snapshots/numberedListItemShortcut-json-webkit-linux.json
+++ b/tests/src/end-to-end/keyboardhandlers/keyboardhandlers.test.ts-snapshots/numberedListItemShortcut-json-webkit-linux.json
@@ -1,0 +1,49 @@
+{
+  "type": "doc",
+  "content": [
+    {
+      "type": "blockGroup",
+      "content": [
+        {
+          "type": "blockContainer",
+          "attrs": {
+            "id": "0",
+            "textColor": "default",
+            "backgroundColor": "default"
+          },
+          "content": [
+            {
+              "type": "numberedListItem",
+              "attrs": {
+                "textAlignment": "left",
+                "index": "1"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "Paragraph"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "blockContainer",
+          "attrs": {
+            "id": "1",
+            "textColor": "default",
+            "backgroundColor": "default"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "textAlignment": "left"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/src/utils/copypaste.ts
+++ b/tests/src/utils/copypaste.ts
@@ -2,20 +2,16 @@ import { Page } from "@playwright/test";
 import { PASTE_ZONE_SELECTOR, TYPE_DELAY } from "./const.js";
 import { focusOnEditor } from "./editor.js";
 
-export async function copyPaste(page: Page, os: "mac" | "linux" = "linux") {
-  const modifierKey = os === "mac" ? "Meta" : "Control";
-
-  await page.keyboard.press(`${modifierKey}+C`);
+export async function copyPaste(page: Page) {
+  await page.keyboard.press(`ControlOrMeta+C`);
   await page.keyboard.press("ArrowDown", { delay: TYPE_DELAY });
   await page.keyboard.press("Enter");
-  await page.keyboard.press(`${modifierKey}+V`);
+  await page.keyboard.press(`ControlOrMeta+V`);
 }
 
-export async function copyPasteAll(page: Page, os: "mac" | "linux" = "linux") {
-  const modifierKey = os === "mac" ? "Meta" : "Control";
-
-  await page.keyboard.press(`${modifierKey}+A`);
-  await copyPaste(page, os);
+export async function copyPasteAll(page: Page) {
+  await page.keyboard.press(`ControlOrMeta+A`);
+  await copyPaste(page);
 }
 
 export async function copyPasteAllExternal(


### PR DESCRIPTION
There was a regression in #1137 which broke keyboard shortcuts for bullet and check list items, which this PR addresses