### PR TITLE
fix: `getNearestBlockContainerPos` unclear

### DIFF
--- a/packages/core/src/api/blockManipulation/commands/moveBlock/moveBlock.test.ts
+++ b/packages/core/src/api/blockManipulation/commands/moveBlock/moveBlock.test.ts
@@ -13,9 +13,13 @@ import {
 const getEditor = setupTestEnv();
 
 function makeSelectionSpanContent(selectionType: "text" | "node" | "cell") {
-  const { blockContent } = getBlockInfoFromSelection(
-    getEditor()._tiptapEditor.state
-  );
+  const blockInfo = getBlockInfoFromSelection(getEditor()._tiptapEditor.state);
+  if (!blockInfo.isBlockContainer) {
+    throw new Error(
+      `Selection points to a ${blockInfo.blockNoteType} node, not a blockContainer node`
+    );
+  }
+  const { blockContent } = blockInfo;
 
   if (selectionType === "cell") {
     getEditor()._tiptapEditor.view.dispatch(

--- a/packages/core/src/api/blockManipulation/commands/splitBlock/splitBlock.ts
+++ b/packages/core/src/api/blockManipulation/commands/splitBlock/splitBlock.ts
@@ -2,7 +2,7 @@ import { EditorState } from "prosemirror-state";
 
 import {
   getBlockInfo,
-  getNearestBlockContainerPos,
+  getNearestBlockPos,
 } from "../../../getBlockInfoFromPos.js";
 
 export const splitBlockCommand = (
@@ -17,10 +17,7 @@ export const splitBlockCommand = (
     state: EditorState;
     dispatch: ((args?: any) => any) | undefined;
   }) => {
-    const nearestBlockContainerPos = getNearestBlockContainerPos(
-      state.doc,
-      posInBlock
-    );
+    const nearestBlockContainerPos = getNearestBlockPos(state.doc, posInBlock);
 
     const info = getBlockInfo(nearestBlockContainerPos);
 

--- a/packages/core/src/api/clipboard/fromClipboard/handleFileInsertion.ts
+++ b/packages/core/src/api/clipboard/fromClipboard/handleFileInsertion.ts
@@ -6,10 +6,7 @@ import {
   InlineContentSchema,
   StyleSchema,
 } from "../../../schema/index.js";
-import {
-  getBlockInfo,
-  getNearestBlockContainerPos,
-} from "../../getBlockInfoFromPos.js";
+import { getBlockInfo, getNearestBlockPos } from "../../getBlockInfoFromPos.js";
 import { acceptedMIMETypes } from "./acceptedMIMETypes.js";
 
 function checkFileExtensionsMatch(
@@ -135,7 +132,7 @@ export async function handleFileInsertion<
           return;
         }
 
-        const posInfo = getNearestBlockContainerPos(
+        const posInfo = getNearestBlockPos(
           editor._tiptapEditor.state.doc,
           pos.pos
         );

--- a/packages/core/src/api/getBlockInfoFromPos.ts
+++ b/packages/core/src/api/getBlockInfoFromPos.ts
@@ -45,22 +45,21 @@ export type BlockInfo = {
 );
 
 /**
- * Retrieves the position just before the nearest blockContainer node in a
- * ProseMirror doc, relative to a position. If the position is within a
- * blockContainer node or its descendants, the position just before it is
- * returned. If the position is not within a blockContainer node or its
- * descendants, the position just before the next closest blockContainer node
- * is returned. If the position is beyond the last blockContainer, the position
- * just before the last blockContainer is returned.
+ * Retrieves the position just before the nearest block node in a ProseMirror
+ * doc, relative to a position. If the position is within a block node or its
+ * descendants, the position just before it is returned. If the position is not
+ * within a block node or its descendants, the position just before the next
+ * closest block node is returned. If the position is beyond the last block, the
+ * position just before the last block is returned.
  * @param doc The ProseMirror doc.
  * @param pos An integer position in the document.
  * @returns The position just before the nearest blockContainer node.
  */
-export function getNearestBlockContainerPos(doc: Node, pos: number) {
+export function getNearestBlockPos(doc: Node, pos: number) {
   const $pos = doc.resolve(pos);
 
-  // Checks if the position provided is already just before a blockContainer
-  // node, in which case we return the position.
+  // Checks if the position provided is already just before a block node, in
+  // which case we return the position.
   if ($pos.nodeAfter && $pos.nodeAfter.type.isInGroup("bnBlock")) {
     return {
       posBeforeNode: $pos.pos,
@@ -69,7 +68,7 @@ export function getNearestBlockContainerPos(doc: Node, pos: number) {
   }
 
   // Checks the node containing the position and its ancestors until a
-  // blockContainer node is found and returned.
+  // block node is found and returned.
   let depth = $pos.depth;
   let node = $pos.node(depth);
   while (depth > 0) {
@@ -84,13 +83,12 @@ export function getNearestBlockContainerPos(doc: Node, pos: number) {
     node = $pos.node(depth);
   }
 
-  // If the position doesn't lie within a blockContainer node, we instead find
-  // the position of the next closest one. If the position is beyond the last
-  // blockContainer, we return the position of the last blockContainer. While
-  // running `doc.descendants` is expensive, this case should be very rarely
-  // triggered. However, it's possible for the position to sometimes be beyond
-  // the last blockContainer node. This is a problem specifically when using the
-  // collaboration plugin.
+  // If the position doesn't lie within a block node, we instead find the
+  // position of the next closest one. If the position is beyond the last block,
+  // we return the position of the last block. While running `doc.descendants`
+  // is expensive, this case should be very rarely triggered. However, it's
+  // possible for the position to sometimes be beyond the last block node. This
+  // is a problem specifically when using the collaboration plugin.
   const allBlockContainerPositions: number[] = [];
   doc.descendants((node, pos) => {
     if (node.type.isInGroup("bnBlock")) {
@@ -119,7 +117,7 @@ export function getNearestBlockContainerPos(doc: Node, pos: number) {
  * the ProseMirror positions just before & after each node.
  * @param node The main `blockContainer` node that the block information should
  * be retrieved from,
- * @param blockContainerBeforePosOffset the position just before the
+ * @param bnBlockBeforePosOffset the position just before the
  * `blockContainer` node in the document.
  */
 export function getBlockInfoWithManualOffset(
@@ -237,15 +235,7 @@ export function getBlockInfoFromResolvedPos(resolvedPos: ResolvedPos) {
  * @param state The ProseMirror editor state.
  */
 export function getBlockInfoFromSelection(state: EditorState) {
-  const posInfo = getNearestBlockContainerPos(
-    state.doc,
-    state.selection.anchor
-  );
-  const ret = getBlockInfo(posInfo);
-  if (!ret.isBlockContainer) {
-    throw new Error(
-      `selection always expected to return blockContainer ${state.selection.anchor}`
-    );
-  }
-  return ret;
+  const posInfo = getNearestBlockPos(state.doc, state.selection.anchor);
+
+  return getBlockInfo(posInfo);
 }

--- a/packages/core/src/blocks/HeadingBlockContent/HeadingBlockContent.ts
+++ b/packages/core/src/blocks/HeadingBlockContent/HeadingBlockContent.ts
@@ -48,7 +48,10 @@ const HeadingBlockContent = createStronglyTypedTiptapNode({
           find: new RegExp(`^(#{${level}})\\s$`),
           handler: ({ state, chain, range }) => {
             const blockInfo = getBlockInfoFromSelection(state);
-            if (blockInfo.blockContent.node.type.spec.content !== "inline*") {
+            if (
+              !blockInfo.isBlockContainer ||
+              blockInfo.blockContent.node.type.spec.content !== "inline*"
+            ) {
               return;
             }
 
@@ -78,7 +81,10 @@ const HeadingBlockContent = createStronglyTypedTiptapNode({
     return {
       "Mod-Alt-1": () => {
         const blockInfo = getBlockInfoFromSelection(this.editor.state);
-        if (blockInfo.blockContent.node.type.spec.content !== "inline*") {
+        if (
+          !blockInfo.isBlockContainer ||
+          blockInfo.blockContent.node.type.spec.content !== "inline*"
+        ) {
           return true;
         }
 
@@ -94,7 +100,10 @@ const HeadingBlockContent = createStronglyTypedTiptapNode({
       },
       "Mod-Alt-2": () => {
         const blockInfo = getBlockInfoFromSelection(this.editor.state);
-        if (blockInfo.blockContent.node.type.spec.content !== "inline*") {
+        if (
+          !blockInfo.isBlockContainer ||
+          blockInfo.blockContent.node.type.spec.content !== "inline*"
+        ) {
           return true;
         }
 
@@ -109,7 +118,10 @@ const HeadingBlockContent = createStronglyTypedTiptapNode({
       },
       "Mod-Alt-3": () => {
         const blockInfo = getBlockInfoFromSelection(this.editor.state);
-        if (blockInfo.blockContent.node.type.spec.content !== "inline*") {
+        if (
+          !blockInfo.isBlockContainer ||
+          blockInfo.blockContent.node.type.spec.content !== "inline*"
+        ) {
           return true;
         }
 

--- a/packages/core/src/blocks/ListItemBlockContent/BulletListItemBlockContent/BulletListItemBlockContent.ts
+++ b/packages/core/src/blocks/ListItemBlockContent/BulletListItemBlockContent/BulletListItemBlockContent.ts
@@ -28,7 +28,10 @@ const BulletListItemBlockContent = createStronglyTypedTiptapNode({
         find: new RegExp(`^[-+*]\\s$`),
         handler: ({ state, chain, range }) => {
           const blockInfo = getBlockInfoFromSelection(state);
-          if (blockInfo.blockContent.node.type.spec.content !== "inline*") {
+          if (
+            !blockInfo.isBlockContainer ||
+            blockInfo.blockContent.node.type.spec.content !== "inline*"
+          ) {
             return;
           }
 
@@ -55,7 +58,10 @@ const BulletListItemBlockContent = createStronglyTypedTiptapNode({
       Enter: () => handleEnter(this.options.editor),
       "Mod-Shift-8": () => {
         const blockInfo = getBlockInfoFromSelection(this.editor.state);
-        if (blockInfo.blockContent.node.type.spec.content !== "inline*") {
+        if (
+          !blockInfo.isBlockContainer ||
+          blockInfo.blockContent.node.type.spec.content !== "inline*"
+        ) {
           return true;
         }
 

--- a/packages/core/src/blocks/ListItemBlockContent/CheckListItemBlockContent/CheckListItemBlockContent.ts
+++ b/packages/core/src/blocks/ListItemBlockContent/CheckListItemBlockContent/CheckListItemBlockContent.ts
@@ -2,7 +2,7 @@ import { InputRule } from "@tiptap/core";
 import { updateBlockCommand } from "../../../api/blockManipulation/commands/updateBlock/updateBlock.js";
 import {
   getBlockInfoFromSelection,
-  getNearestBlockContainerPos,
+  getNearestBlockPos,
 } from "../../../api/getBlockInfoFromPos.js";
 import {
   PropSchema,
@@ -49,7 +49,10 @@ const checkListItemBlockContent = createStronglyTypedTiptapNode({
         find: new RegExp(`\\[\\s*\\]\\s$`),
         handler: ({ state, chain, range }) => {
           const blockInfo = getBlockInfoFromSelection(state);
-          if (blockInfo.blockContent.node.type.spec.content !== "inline*") {
+          if (
+            !blockInfo.isBlockContainer ||
+            blockInfo.blockContent.node.type.spec.content !== "inline*"
+          ) {
             return;
           }
 
@@ -75,7 +78,10 @@ const checkListItemBlockContent = createStronglyTypedTiptapNode({
         handler: ({ state, chain, range }) => {
           const blockInfo = getBlockInfoFromSelection(state);
 
-          if (blockInfo.blockContent.node.type.spec.content !== "inline*") {
+          if (
+            !blockInfo.isBlockContainer ||
+            blockInfo.blockContent.node.type.spec.content !== "inline*"
+          ) {
             return;
           }
 
@@ -104,7 +110,10 @@ const checkListItemBlockContent = createStronglyTypedTiptapNode({
       Enter: () => handleEnter(this.options.editor),
       "Mod-Shift-9": () => {
         const blockInfo = getBlockInfoFromSelection(this.options.editor.state);
-        if (blockInfo.blockContent.node.type.spec.content !== "inline*") {
+        if (
+          !blockInfo.isBlockContainer ||
+          blockInfo.blockContent.node.type.spec.content !== "inline*"
+        ) {
           return true;
         }
 
@@ -232,7 +241,7 @@ const checkListItemBlockContent = createStronglyTypedTiptapNode({
 
         // TODO: test
         if (typeof getPos !== "boolean") {
-          const beforeBlockContainerPos = getNearestBlockContainerPos(
+          const beforeBlockContainerPos = getNearestBlockPos(
             editor.state.doc,
             getPos()
           );

--- a/packages/core/src/blocks/ListItemBlockContent/CheckListItemBlockContent/CheckListItemBlockContent.ts
+++ b/packages/core/src/blocks/ListItemBlockContent/CheckListItemBlockContent/CheckListItemBlockContent.ts
@@ -245,6 +245,13 @@ const checkListItemBlockContent = createStronglyTypedTiptapNode({
             editor.state.doc,
             getPos()
           );
+
+          if (beforeBlockContainerPos.node.type.name !== "blockContainer") {
+            throw new Error(
+              `Expected blockContainer node, got ${beforeBlockContainerPos.node.type.name}`
+            );
+          }
+
           this.editor.commands.command(
             updateBlockCommand(
               this.options.editor,

--- a/packages/core/src/blocks/ListItemBlockContent/ListItemKeyboardShortcuts.ts
+++ b/packages/core/src/blocks/ListItemBlockContent/ListItemKeyboardShortcuts.ts
@@ -5,9 +5,11 @@ import { BlockNoteEditor } from "../../editor/BlockNoteEditor.js";
 
 export const handleEnter = (editor: BlockNoteEditor<any, any, any>) => {
   const ttEditor = editor._tiptapEditor;
-  const { blockContent, bnBlock: blockContainer } = getBlockInfoFromSelection(
-    ttEditor.state
-  );
+  const blockInfo = getBlockInfoFromSelection(ttEditor.state);
+  if (!blockInfo.isBlockContainer) {
+    return false;
+  }
+  const { bnBlock: blockContainer, blockContent } = blockInfo;
 
   const selectionEmpty =
     ttEditor.state.selection.anchor === ttEditor.state.selection.head;

--- a/packages/core/src/blocks/ListItemBlockContent/NumberedListItemBlockContent/NumberedListItemBlockContent.ts
+++ b/packages/core/src/blocks/ListItemBlockContent/NumberedListItemBlockContent/NumberedListItemBlockContent.ts
@@ -41,7 +41,10 @@ const NumberedListItemBlockContent = createStronglyTypedTiptapNode({
         find: new RegExp(`^1\\.\\s$`),
         handler: ({ state, chain, range }) => {
           const blockInfo = getBlockInfoFromSelection(state);
-          if (blockInfo.blockContent.node.type.spec.content !== "inline*") {
+          if (
+            !blockInfo.isBlockContainer ||
+            blockInfo.blockContent.node.type.spec.content !== "inline*"
+          ) {
             return;
           }
 
@@ -68,7 +71,10 @@ const NumberedListItemBlockContent = createStronglyTypedTiptapNode({
       Enter: () => handleEnter(this.options.editor),
       "Mod-Shift-7": () => {
         const blockInfo = getBlockInfoFromSelection(this.editor.state);
-        if (blockInfo.blockContent.node.type.spec.content !== "inline*") {
+        if (
+          !blockInfo.isBlockContainer ||
+          blockInfo.blockContent.node.type.spec.content !== "inline*"
+        ) {
           return true;
         }
 

--- a/packages/core/src/blocks/ParagraphBlockContent/ParagraphBlockContent.ts
+++ b/packages/core/src/blocks/ParagraphBlockContent/ParagraphBlockContent.ts
@@ -20,7 +20,10 @@ export const ParagraphBlockContent = createStronglyTypedTiptapNode({
     return {
       "Mod-Alt-0": () => {
         const blockInfo = getBlockInfoFromSelection(this.editor.state);
-        if (blockInfo.blockContent.node.type.spec.content !== "inline*") {
+        if (
+          !blockInfo.isBlockContainer ||
+          blockInfo.blockContent.node.type.spec.content !== "inline*"
+        ) {
           return true;
         }
 

--- a/packages/core/src/editor/BlockNoteEditor.test.ts
+++ b/packages/core/src/editor/BlockNoteEditor.test.ts
@@ -1,7 +1,7 @@
 import { expect, it } from "vitest";
 import {
   getBlockInfo,
-  getNearestBlockContainerPos,
+  getNearestBlockPos,
 } from "../api/getBlockInfoFromPos.js";
 import { BlockNoteEditor } from "./BlockNoteEditor.js";
 
@@ -10,10 +10,7 @@ import { BlockNoteEditor } from "./BlockNoteEditor.js";
  */
 it("creates an editor", () => {
   const editor = BlockNoteEditor.create();
-  const posInfo = getNearestBlockContainerPos(
-    editor._tiptapEditor.state.doc,
-    2
-  );
+  const posInfo = getNearestBlockPos(editor._tiptapEditor.state.doc, 2);
   const info = getBlockInfo(posInfo);
   expect(info.blockNoteType).toEqual("paragraph");
 });

--- a/packages/core/src/extensions/KeyboardShortcuts/KeyboardShortcutsExtension.ts
+++ b/packages/core/src/extensions/KeyboardShortcuts/KeyboardShortcutsExtension.ts
@@ -33,6 +33,9 @@ export const KeyboardShortcutsExtension = Extension.create<{
         () =>
           commands.command(({ state }) => {
             const blockInfo = getBlockInfoFromSelection(state);
+            if (!blockInfo.isBlockContainer) {
+              return false;
+            }
 
             const selectionAtBlockStart =
               state.selection.from === blockInfo.blockContent.beforePos + 1;
@@ -57,7 +60,11 @@ export const KeyboardShortcutsExtension = Extension.create<{
         // Removes a level of nesting if the block is indented if the selection is at the start of the block.
         () =>
           commands.command(({ state }) => {
-            const { blockContent } = getBlockInfoFromSelection(state);
+            const blockInfo = getBlockInfoFromSelection(state);
+            if (!blockInfo.isBlockContainer) {
+              return false;
+            }
+            const { blockContent } = blockInfo;
 
             const selectionAtBlockStart =
               state.selection.from === blockContent.beforePos + 1;
@@ -72,8 +79,11 @@ export const KeyboardShortcutsExtension = Extension.create<{
         // block. The target block for merging must contain inline content.
         () =>
           commands.command(({ state }) => {
-            const { bnBlock: blockContainer, blockContent } =
-              getBlockInfoFromSelection(state);
+            const blockInfo = getBlockInfoFromSelection(state);
+            if (!blockInfo.isBlockContainer) {
+              return false;
+            }
+            const { bnBlock: blockContainer, blockContent } = blockInfo;
 
             const selectionAtBlockStart =
               state.selection.from === blockContent.beforePos + 1;
@@ -94,6 +104,9 @@ export const KeyboardShortcutsExtension = Extension.create<{
           commands.command(({ state, dispatch }) => {
             // when at the start of a first block in a column
             const blockInfo = getBlockInfoFromSelection(state);
+            if (!blockInfo.isBlockContainer) {
+              return false;
+            }
 
             const selectionAtBlockStart =
               state.selection.from === blockInfo.blockContent.beforePos + 1;
@@ -315,11 +328,15 @@ export const KeyboardShortcutsExtension = Extension.create<{
         () =>
           commands.command(({ state }) => {
             // TODO: Change this to not rely on offsets & schema assumptions
+            const blockInfo = getBlockInfoFromSelection(state);
+            if (!blockInfo.isBlockContainer) {
+              return false;
+            }
             const {
               bnBlock: blockContainer,
               blockContent,
               childContainer,
-            } = getBlockInfoFromSelection(state);
+            } = blockInfo;
 
             const { depth } = state.doc.resolve(blockContainer.beforePos);
             const blockAtDocEnd =
@@ -358,8 +375,11 @@ export const KeyboardShortcutsExtension = Extension.create<{
         // of the block.
         () =>
           commands.command(({ state }) => {
-            const { blockContent, bnBlock: blockContainer } =
-              getBlockInfoFromSelection(state);
+            const blockInfo = getBlockInfoFromSelection(state);
+            if (!blockInfo.isBlockContainer) {
+              return false;
+            }
+            const { bnBlock: blockContainer, blockContent } = blockInfo;
 
             const { depth } = state.doc.resolve(blockContainer.beforePos);
 
@@ -385,8 +405,11 @@ export const KeyboardShortcutsExtension = Extension.create<{
         // empty & at the start of the block.
         () =>
           commands.command(({ state, dispatch }) => {
-            const { bnBlock: blockContainer, blockContent } =
-              getBlockInfoFromSelection(state);
+            const blockInfo = getBlockInfoFromSelection(state);
+            if (!blockInfo.isBlockContainer) {
+              return false;
+            }
+            const { bnBlock: blockContainer, blockContent } = blockInfo;
 
             const selectionAtBlockStart =
               state.selection.$anchor.parentOffset === 0;
@@ -419,7 +442,11 @@ export const KeyboardShortcutsExtension = Extension.create<{
         // deletes the selection beforehand, if it's not empty.
         () =>
           commands.command(({ state, chain }) => {
-            const { blockContent } = getBlockInfoFromSelection(state);
+            const blockInfo = getBlockInfoFromSelection(state);
+            if (!blockInfo.isBlockContainer) {
+              return false;
+            }
+            const { blockContent } = blockInfo;
 
             const selectionAtBlockStart =
               state.selection.$anchor.parentOffset === 0;

--- a/packages/xl-multi-column/src/extensions/DropCursor/MultiColumnDropCursorPlugin.ts
+++ b/packages/xl-multi-column/src/extensions/DropCursor/MultiColumnDropCursorPlugin.ts
@@ -2,7 +2,7 @@ import type { BlockNoteEditor } from "@blocknote/core";
 import {
   UniqueID,
   getBlockInfo,
-  getNearestBlockContainerPos,
+  getNearestBlockPos,
   nodeToBlock,
 } from "@blocknote/core";
 import { EditorState, Plugin } from "prosemirror-state";
@@ -465,7 +465,7 @@ function getTargetPosInfo(
   state: EditorState,
   eventPos: { pos: number; inside: number }
 ) {
-  const blockPos = getNearestBlockContainerPos(state.doc, eventPos.pos);
+  const blockPos = getNearestBlockPos(state.doc, eventPos.pos);
 
   // if we're at a block that's in a column, we want to compare the mouse position to the column, not the block inside it
   // why? because we want to insert a new column in the columnList, instead of a new columnList inside of the column


### PR DESCRIPTION
Closes #1237 

Currently, `getNearestBlockContainerPos` gets the nearest block, which may be a `columnList`, `column`, or `blockContainer`. I think the functionality is fine, but this PR renames it to `getNearestBlockPos` for better clarity and removes the error in `getBlockInfoFromSelection` for when something other than a `blockContainer` is returned. This fixes a bug that caused said error to be thrown by selecting a `column` node using triple click (I think) or Cmd+click.