### PR TITLE
wip: remove some formattingtoolbar listeners

### DIFF
--- a/packages/core/src/extensions/FormattingToolbar/FormattingToolbarPlugin.ts
+++ b/packages/core/src/extensions/FormattingToolbar/FormattingToolbarPlugin.ts
@@ -68,46 +68,7 @@ export class FormattingToolbarView implements PluginView {
 
     pmView.dom.addEventListener("mousedown", this.viewMousedownHandler);
     pmView.dom.addEventListener("mouseup", this.viewMouseupHandler);
-    pmView.dom.addEventListener("dragstart", this.dragHandler);
-    pmView.dom.addEventListener("dragover", this.dragHandler);
-    pmView.dom.addEventListener("blur", this.blurHandler);
-
-    // Setting capture=true ensures that any parent container of the editor that
-    // gets scrolled will trigger the scroll event. Scroll events do not bubble
-    // and so won't propagate to the document by default.
-    pmView.root.addEventListener("scroll", this.scrollHandler, true);
   }
-
-  blurHandler = (event: FocusEvent) => {
-    if (this.preventHide) {
-      this.preventHide = false;
-
-      return;
-    }
-
-    const editorWrapper = this.pmView.dom.parentElement!;
-
-    // Checks if the focus is moving to an element outside the editor. If it is,
-    // the toolbar is hidden.
-    if (
-      // An element is clicked.
-      event &&
-      event.relatedTarget &&
-      // Element is inside the editor.
-      (editorWrapper === (event.relatedTarget as Node) ||
-        editorWrapper.contains(event.relatedTarget as Node) ||
-        (event.relatedTarget as HTMLElement).matches(
-          ".bn-ui-container, .bn-ui-container *"
-        ))
-    ) {
-      return;
-    }
-
-    if (this.state?.show) {
-      this.state.show = false;
-      this.emitUpdate();
-    }
-  };
 
   viewMousedownHandler = () => {
     this.preventShow = true;
@@ -116,21 +77,6 @@ export class FormattingToolbarView implements PluginView {
   viewMouseupHandler = () => {
     this.preventShow = false;
     setTimeout(() => this.update(this.pmView));
-  };
-
-  // For dragging the whole editor.
-  dragHandler = () => {
-    if (this.state?.show) {
-      this.state.show = false;
-      this.emitUpdate();
-    }
-  };
-
-  scrollHandler = () => {
-    if (this.state?.show) {
-      this.state.referencePos = this.getSelectionBoundingBox();
-      this.emitUpdate();
-    }
   };
 
   update(view: EditorView, oldState?: EditorState) {
@@ -192,11 +138,6 @@ export class FormattingToolbarView implements PluginView {
   destroy() {
     this.pmView.dom.removeEventListener("mousedown", this.viewMousedownHandler);
     this.pmView.dom.removeEventListener("mouseup", this.viewMouseupHandler);
-    this.pmView.dom.removeEventListener("dragstart", this.dragHandler);
-    this.pmView.dom.removeEventListener("dragover", this.dragHandler);
-    this.pmView.dom.removeEventListener("blur", this.blurHandler);
-
-    this.pmView.root.removeEventListener("scroll", this.scrollHandler, true);
   }
 
   closeMenu = () => {


### PR DESCRIPTION
I'm investigating if we can remove these listeners or fix them somewhere else. 

It seems like floating-ui is covering a lot of the things these methods have been designed for. I think it would be nice to simplify this (and see "background" below for more motivation).

_Bugs / issues_
Can you help look into what bugs could arise from this? So far, I've encountered two changes:

- Formatting toolbar doesn't "flip" position any more when scrolling
- when dragging / dropping a block, the formatting toolbar appears. I think we need to solve this differently (i.e.: maybe we should just clear the selection when dragging blocks? Why is the dragged block selected at all?)
- ...

_Background_
The reason I'm investigating it is so that we can potentially render UI elements (shadcn / floating ui etc) within a Portal. Currently, the BlurHandler in FormattingToolbar is not compatible with this as it expects events to come from within a specific dom root.

This would fix two issues:
- https://github.com/TypeCellOS/BlockNote/issues/1255 by enabling portalling
- compatibility with ShadCN components that use a Portal (currently, we require users to comment out Portals in their components, see note at [bottom of docs](https://www.blocknotejs.org/docs/advanced/shadcn))