### PR TITLE
Typo fixing in examples

### DIFF
--- a/examples/03-ui-components/07-suggestion-menus-slash-menu-component/App.tsx
+++ b/examples/03-ui-components/07-suggestion-menus-slash-menu-component/App.tsx
@@ -18,7 +18,7 @@ function CustomSlashMenu(
     <div className={"slash-menu"}>
       {props.items.map((item, index) => (
         <div
-          className={`slash-menu-item${
+          className={`slash-menu-item ${
             props.selectedIndex === index ? " selected" : ""
           }`}
           onClick={() => {

--- a/examples/03-ui-components/09-suggestion-menus-emoji-picker-component/App.tsx
+++ b/examples/03-ui-components/09-suggestion-menus-emoji-picker-component/App.tsx
@@ -22,7 +22,7 @@ function CustomEmojiPicker(
       }>
       {props.items.map((item, index) => (
         <div
-          className={`emoji-picker-item${
+          className={`emoji-picker-item ${
             props.selectedIndex === index ? " selected" : ""
           }`}
           onClick={() => {


### PR DESCRIPTION
Examples for custom slash commands & emoji picker had the following:

 `slash-menu-item${...`

`emoji-picker-item${...`

Due to there being no space, the classNames were being called `slash-menu-itemselected` and `emoji-picker-itemselected` rather than `slash-menu-item selected` and `emoji-picker-item selected`.

