### PR TITLE
Fix: Prevent file deletion when merging with a blank line block

### DIFF
--- a/packages/core/src/api/blockManipulation/commands/mergeBlocks/mergeBlocks.ts
+++ b/packages/core/src/api/blockManipulation/commands/mergeBlocks/mergeBlocks.ts
@@ -125,14 +125,18 @@ const mergeBlocks = (
     // TODO: test merging between a columnList and paragraph, between two columnLists, and v.v.
     let startPos = prevBlockInfo.blockContent.afterPos - 1;
     let endPos = nextBlockInfo.blockContent.beforePos + 1;
+    const isPrevFileBlock =
+      prevBlockInfo.blockNoteType === "image" ||
+      prevBlockInfo.blockNoteType === "file" ||
+      prevBlockInfo.blockNoteType === "audio";
 
-    // Check if the previous block is an image
-    if (prevBlockInfo.blockNoteType === "image") {
-      // If the next block contains text, merging will remove the image (previous block) and retain the text
+    // Check if the previous is a file block
+    if (isPrevFileBlock) {
+      // If the next block contains text, merging will remove the file (previous block) and retain the text
       if (nextBlockInfo.blockContent.node.textContent) {
         endPos = nextBlockInfo.blockContent.beforePos;
       } else {
-        // If the next block has no text, merging will remove the text block and retain the image
+        // If the next block has no text, merging will remove the text block and retain the file
         startPos = prevBlockInfo.blockContent.afterPos;
       }
     }
@@ -169,9 +173,12 @@ export const mergeBlocksCommand =
       prevBlockInfo
     );
 
-    const prevBlockIsImage = prevBlockInfo.blockNoteType === "image";
+    const isPrevFileBlock =
+      prevBlockInfo.blockNoteType === "image" ||
+      prevBlockInfo.blockNoteType === "file" ||
+      prevBlockInfo.blockNoteType === "audio";
 
-    if (!canMerge(bottomNestedBlockInfo, nextBlockInfo) && !prevBlockIsImage) {
+    if (!canMerge(bottomNestedBlockInfo, nextBlockInfo) && !isPrevFileBlock) {
       return false;
     }
 

--- a/packages/core/src/extensions/KeyboardShortcuts/KeyboardShortcutsExtension.ts
+++ b/packages/core/src/extensions/KeyboardShortcuts/KeyboardShortcutsExtension.ts
@@ -297,9 +297,12 @@ export const KeyboardShortcutsExtension = Extension.create<{
                   "inline*" &&
                   bottomBlock.blockContent.node.childCount === 0);
 
-              const isImageBlock = bottomBlock.blockNoteType === "image";
+              const isFileBlock =
+                bottomBlock.blockNoteType === "image" ||
+                bottomBlock.blockNoteType === "file" ||
+                bottomBlock.blockNoteType === "audio";
 
-              if (prevBlockNotTableAndNoContent && !isImageBlock) {
+              if (prevBlockNotTableAndNoContent && !isFileBlock) {
                 return chain()
                   .cut(
                     {

--- a/packages/core/src/extensions/KeyboardShortcuts/KeyboardShortcutsExtension.ts
+++ b/packages/core/src/extensions/KeyboardShortcuts/KeyboardShortcutsExtension.ts
@@ -297,7 +297,9 @@ export const KeyboardShortcutsExtension = Extension.create<{
                   "inline*" &&
                   bottomBlock.blockContent.node.childCount === 0);
 
-              if (prevBlockNotTableAndNoContent) {
+              const isImageBlock = bottomBlock.blockNoteType === "image";
+
+              if (prevBlockNotTableAndNoContent && !isImageBlock) {
                 return chain()
                   .cut(
                     {


### PR DESCRIPTION
fixed #605

**Description:**

- Fixed an issue where an file block was unintentionally deleted when merging with a blank line block.
- Adjusted logic to retain the file block if the next block is blank and only delete the blank block.
- Ensured proper merging behavior when the next block contains text (delete the file block and retain the text).
- 

https://github.com/user-attachments/assets/ce534fd7-6e54-4886-b270-1afa5babb7e1



