### PR TITLE
fix: update max-height to inherit for suggestion menus

### DIFF
--- a/examples/03-ui-components/07-suggestion-menus-slash-menu-component/styles.css
+++ b/examples/03-ui-components/07-suggestion-menus-slash-menu-component/styles.css
@@ -8,7 +8,7 @@
   flex-direction: column;
   gap: 8px;
   height: fit-content;
-  max-height: 100%;
+  max-height: inherit;
 
   overflow: auto;
 

--- a/examples/03-ui-components/09-suggestion-menus-emoji-picker-component/styles.css
+++ b/examples/03-ui-components/09-suggestion-menus-emoji-picker-component/styles.css
@@ -8,7 +8,7 @@
   flex-direction: column;
   gap: 8px;
   height: fit-content;
-  max-height: 100%;
+  max-height: inherit;
 
   overflow: auto;
 

--- a/packages/ariakit/src/style.css
+++ b/packages/ariakit/src/style.css
@@ -59,7 +59,7 @@
 
 .bn-ariakit .bn-suggestion-menu {
   height: fit-content;
-  max-height: 100%;
+  max-height: inherit;
 }
 
 .bn-ariakit .bn-color-picker-dropdown {
@@ -97,7 +97,7 @@
   gap: 7px;
   height: fit-content;
   justify-items: center;
-  max-height: min(500px, 100%);
+  max-height: inherit;
   overflow-y: auto;
   padding: 20px;
 }

--- a/packages/shadcn/src/style.css
+++ b/packages/shadcn/src/style.css
@@ -108,7 +108,7 @@
 
 .bn-shadcn .bn-suggestion-menu {
   height: fit-content;
-  max-height: 100%;
+  max-height: inherit;
 }
 
 .bn-shadcn .bn-suggestion-menu-item[aria-selected="true"],
@@ -124,7 +124,7 @@
   gap: 7px;
   height: fit-content;
   justify-items: center;
-  max-height: min(500px, 100%);
+  max-height: inherit;
   overflow-y: auto;
   padding: 20px;
 }


### PR DESCRIPTION
Prevents the page from stretching when suggestion menus are opened