### PR TITLE
docs: Add Y-Sweet

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,36 +1,21 @@
-This is a [Next.js](https://nextjs.org/) project bootstrapped with [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packages/create-next-app).
+# BlockNote Docs
+
+This is the code for the [BlockNote documentation website](https://www.blocknotejs.org).
+
+If you're looking to work on BlockNote itself, check the [`packages`](/packages/) folder.
 
 ## Getting Started
 
-First, run the development server:
+First, run `npm run build` in the repository root.
+
+Next, run the development server:
 
 ```bash
 npm run dev
-# or
-yarn dev
-# or
-pnpm dev
-# or
-bun dev
 ```
 
 Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
 
-You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
+## Merging
 
-This project uses [`next/font`](https://nextjs.org/docs/basic-features/font-optimization) to automatically optimize and load Inter, a custom Google Font.
-
-## Learn More
-
-To learn more about Next.js, take a look at the following resources:
-
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
-
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js/) - your feedback and contributions are welcome!
-
-## Deploy on Vercel
-
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
-
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/deployment) for more details.
+Open a pull request to the [BlockNote GitHub repo](https://github.com/TypeCellOS/BlockNote). Pull requests will automatically be deployed to a preview environment.

--- a/docs/pages/docs/advanced/real-time-collaboration.mdx
+++ b/docs/pages/docs/advanced/real-time-collaboration.mdx
@@ -49,6 +49,7 @@ When a user edits the document, an incremental change (or "update") is captured 
 
 - [Liveblocks](https://liveblocks.io/yjs) A fully hosted WebSocket infrastructure and persisted data store for Yjs documents. Includes webhooks, REST API, and browser DevTools, all for Yjs
 - [PartyKit](https://www.partykit.io/) A serverless provider that runs on Cloudflare
+- [Y-Sweet](https://jamsocket.com/y-sweet) An open-source provider that runs fully managed on [Jamsocket](https://jamsocket.com) or self-hosted in your own cloud
 - [Hocuspocus](https://www.hocuspocus.dev/) open source and extensible Node.js server with pluggable storage (scales with Redis)
 - [y-websocket](https://github.com/yjs/y-websocket) provider that you can connect to your own websocket server
 - [y-indexeddb](https://github.com/yjs/y-indexeddb) for offline storage

--- a/examples/07-collaboration/01-partykit/README.md
+++ b/examples/07-collaboration/01-partykit/README.md
@@ -2,7 +2,7 @@
 
 In this example, we use PartyKit to let multiple users collaborate on a single BlockNote document in real-time.
 
-**Try it out:** Open this page ion a new browser tab or window to see it in action!
+**Try it out:** Open this page in a new browser tab or window to see it in action!
 
 **Relevant Docs:**
 

--- a/examples/07-collaboration/02-liveblocks/README.md
+++ b/examples/07-collaboration/02-liveblocks/README.md
@@ -2,7 +2,7 @@
 
 In this example, we use Liveblocks to let multiple users collaborate on a single BlockNote document in real-time.
 
-**Try it out:** Open this page ion a new browser tab or window to see it in action!
+**Try it out:** Open this page in a new browser tab or window to see it in action!
 
 **Relevant Docs:**
 

--- a/examples/07-collaboration/03-y-sweet/.bnexample.json
+++ b/examples/07-collaboration/03-y-sweet/.bnexample.json
@@ -1,0 +1,9 @@
+{
+  "playground": true,
+  "docs": true,
+  "author": "jakelazaroff",
+  "tags": ["Advanced", "Saving/Loading", "Collaboration"],
+  "dependencies": {
+    "@y-sweet/react": "^0.6.3"
+  }
+}

--- a/examples/07-collaboration/03-y-sweet/App.tsx
+++ b/examples/07-collaboration/03-y-sweet/App.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import { useYDoc, useYjsProvider, YDocProvider } from "@y-sweet/react";
+import { useCreateBlockNote } from "@blocknote/react";
+import { BlockNoteView } from "@blocknote/mantine";
+
+import "@blocknote/mantine/style.css";
+
+export default function App() {
+  const docId = "my-blocknote-document";
+
+  return (
+    <YDocProvider
+      docId={docId}
+      authEndpoint="https://demos.y-sweet.dev/api/auth">
+      <Document />
+    </YDocProvider>
+  );
+}
+
+function Document() {
+  const provider = useYjsProvider();
+  const doc = useYDoc();
+
+  const editor = useCreateBlockNote({
+    collaboration: {
+      provider,
+      fragment: doc.getXmlFragment("blocknote"),
+      user: { color: "#ff0000", name: "My Username" },
+    },
+  });
+
+  return <BlockNoteView editor={editor} />;
+}

--- a/examples/07-collaboration/03-y-sweet/README.md
+++ b/examples/07-collaboration/03-y-sweet/README.md
@@ -6,5 +6,5 @@ In this example, we use Y-Sweet to let multiple users collaborate on a single Bl
 
 **Relevant Docs:**
 
-- [Y-Sweet on Jamsocket](https://docs.jamsocket.com/y-sweet/quickstart)
+- [Y-Sweet on Jamsocket](https://docs.jamsocket.com/y-sweet/tutorials/blocknote)
 - [Editor Setup](/docs/editor-basics/setup)

--- a/examples/07-collaboration/03-y-sweet/README.md
+++ b/examples/07-collaboration/03-y-sweet/README.md
@@ -1,0 +1,10 @@
+# Collaborative Editing with Y-Sweet
+
+In this example, we use Y-Sweet to let multiple users collaborate on a single BlockNote document in real-time.
+
+**Try it out:** Open the [Y-Sweet BlockNote demo](https://demos.y-sweet.dev/blocknote) in multiple browser tabs to see it in action!
+
+**Relevant Docs:**
+
+- [Y-Sweet on Jamsocket](https://docs.jamsocket.com/y-sweet/quickstart)
+- [Editor Setup](/docs/editor-basics/setup)

--- a/examples/07-collaboration/03-y-sweet/index.html
+++ b/examples/07-collaboration/03-y-sweet/index.html
@@ -1,0 +1,14 @@
+<html lang="en">
+  <head>
+    <script>
+      <!-- AUTO-GENERATED FILE, DO NOT EDIT DIRECTLY -->
+    </script>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Collaborative Editing with Y-Sweet</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="./main.tsx"></script>
+  </body>
+</html>

--- a/examples/07-collaboration/03-y-sweet/main.tsx
+++ b/examples/07-collaboration/03-y-sweet/main.tsx
@@ -1,0 +1,11 @@
+// AUTO-GENERATED FILE, DO NOT EDIT DIRECTLY
+import React from "react";
+import { createRoot } from "react-dom/client";
+import App from "./App";
+
+const root = createRoot(document.getElementById("root")!);
+root.render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/examples/07-collaboration/03-y-sweet/package.json
+++ b/examples/07-collaboration/03-y-sweet/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "@blocknote/example-y-sweet",
+  "description": "AUTO-GENERATED FILE, DO NOT EDIT DIRECTLY",
+  "private": true,
+  "version": "0.12.4",
+  "scripts": {
+    "start": "vite",
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "preview": "vite preview",
+    "lint": "eslint . --max-warnings 0"
+  },
+  "dependencies": {
+    "@blocknote/core": "latest",
+    "@blocknote/react": "latest",
+    "@blocknote/ariakit": "latest",
+    "@blocknote/mantine": "latest",
+    "@blocknote/shadcn": "latest",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "@y-sweet/react": "^0.6.3"
+  },
+  "devDependencies": {
+    "@types/react": "^18.0.25",
+    "@types/react-dom": "^18.0.9",
+    "@vitejs/plugin-react": "^4.3.1",
+    "eslint": "^8.10.0",
+    "vite": "^5.3.4"
+  },
+  "eslintConfig": {
+    "extends": [
+      "../../../.eslintrc.js"
+    ]
+  },
+  "eslintIgnore": [
+    "dist"
+  ]
+}

--- a/examples/07-collaboration/03-y-sweet/tsconfig.json
+++ b/examples/07-collaboration/03-y-sweet/tsconfig.json
@@ -1,0 +1,36 @@
+{
+  "__comment": "AUTO-GENERATED FILE, DO NOT EDIT DIRECTLY",
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": [
+      "DOM",
+      "DOM.Iterable",
+      "ESNext"
+    ],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "composite": true
+  },
+  "include": [
+    "."
+  ],
+  "__ADD_FOR_LOCAL_DEV_references": [
+    {
+      "path": "../../../packages/core/"
+    },
+    {
+      "path": "../../../packages/react/"
+    }
+  ]
+}

--- a/examples/07-collaboration/03-y-sweet/vite.config.ts
+++ b/examples/07-collaboration/03-y-sweet/vite.config.ts
@@ -1,0 +1,32 @@
+// AUTO-GENERATED FILE, DO NOT EDIT DIRECTLY
+import react from "@vitejs/plugin-react";
+import * as fs from "fs";
+import * as path from "path";
+import { defineConfig } from "vite";
+// import eslintPlugin from "vite-plugin-eslint";
+// https://vitejs.dev/config/
+export default defineConfig((conf) => ({
+  plugins: [react()],
+  optimizeDeps: {},
+  build: {
+    sourcemap: true,
+  },
+  resolve: {
+    alias:
+      conf.command === "build" ||
+      !fs.existsSync(path.resolve(__dirname, "../../packages/core/src"))
+        ? {}
+        : ({
+            // Comment out the lines below to load a built version of blocknote
+            // or, keep as is to load live from sources with live reload working
+            "@blocknote/core": path.resolve(
+              __dirname,
+              "../../packages/core/src/"
+            ),
+            "@blocknote/react": path.resolve(
+              __dirname,
+              "../../packages/react/src/"
+            ),
+          } as any),
+  },
+}));

--- a/package-lock.json
+++ b/package-lock.json
@@ -11242,6 +11242,43 @@
       "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
       "peer": true
     },
+    "node_modules/@y-sweet/client": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/@y-sweet/client/-/client-0.6.3.tgz",
+      "integrity": "sha512-NQ2vRPJBtc6e6MZkbcKGDflMTkFLosACak3JhPTK9Jhzt/ihg6DwDIMNqj6tdT9nhCCvwOT36XwcS2QIjhOG4g==",
+      "license": "MIT",
+      "dependencies": {
+        "@y-sweet/sdk": "0.6.3",
+        "y-protocols": "^1.0.5"
+      },
+      "peerDependencies": {
+        "yjs": "^13.0.0"
+      }
+    },
+    "node_modules/@y-sweet/react": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/@y-sweet/react/-/react-0.6.3.tgz",
+      "integrity": "sha512-dsiVfeMpNl5WS+MdMmdWmdG+vuUDGNRODAAjeC9CMXMWKPRKRXBAc2mRbO0BA/zbGEZsYTrV5Ycc7yWMSys5Ww==",
+      "license": "MIT",
+      "dependencies": {
+        "@y-sweet/client": "0.6.3",
+        "@y-sweet/sdk": "0.6.3",
+        "y-protocols": "^1.0.5"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc",
+        "yjs": "^13"
+      }
+    },
+    "node_modules/@y-sweet/sdk": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/@y-sweet/sdk/-/sdk-0.6.3.tgz",
+      "integrity": "sha512-Gtd4oujr8hf9YceB9rcTd5iRshFzdh46Urk59IS+O0ICOFDH7FY6SSIUz7i+XYRLThywvdzw7P64ykJJH30Ufg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^20.5.9"
+      }
+    },
     "node_modules/@yarnpkg/lockfile": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz",
@@ -30885,6 +30922,7 @@
         "@uppy/status-bar": "^3.1.1",
         "@uppy/webcam": "^3.4.2",
         "@uppy/xhr-upload": "^3.4.0",
+        "@y-sweet/react": "^0.6.3",
         "docx": "^9.0.2",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",

--- a/playground/package.json
+++ b/playground/package.json
@@ -37,6 +37,7 @@
     "@uppy/status-bar": "^3.1.1",
     "@uppy/webcam": "^3.4.2",
     "@uppy/xhr-upload": "^3.4.0",
+    "@y-sweet/react": "^0.6.3",
     "docx": "^9.0.2",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/playground/src/examples.gen.tsx
+++ b/playground/src/examples.gen.tsx
@@ -1078,6 +1078,29 @@
           "pathFromRoot": "examples/07-collaboration",
           "slug": "collaboration"
         }
+      },
+      {
+        "projectSlug": "y-sweet",
+        "fullSlug": "collaboration/y-sweet",
+        "pathFromRoot": "examples/07-collaboration/03-y-sweet",
+        "config": {
+          "playground": true,
+          "docs": true,
+          "author": "jakelazaroff",
+          "tags": [
+            "Advanced",
+            "Saving/Loading",
+            "Collaboration"
+          ],
+          "dependencies": {
+            "@y-sweet/react": "^0.6.3"
+          } as any
+        },
+        "title": "Collaborative Editing with Y-Sweet",
+        "group": {
+          "pathFromRoot": "examples/07-collaboration",
+          "slug": "collaboration"
+        }
       }
     ]
   },


### PR DESCRIPTION
This PR adds [Y-Sweet](https://jamsocket.com/y-sweet) to…

- …the [Real-time Collaborative rich text editor](https://www.blocknotejs.org/docs/advanced/real-time-collaboration) page in the docs.
- …the Collaboration section of the examples. Note that because Y-Sweet requires a server-side endpoint, we omitted the example embedded within the docs and linked to our example hosted on [demos.y-sweet.dev](https://demos.y-sweet.dev/blocknote?doc=ihvp6vi0u0j).

Also fixes a typo on the Liveblocks and PartyKit examples 🙂 

Also also heads up that I'm getting a bunch of `docs: Module not found: Can't resolve '@blocknote/core'` errors whenever I try to run `npm run build:site`!