### PR TITLE
fix: Cut deleting selection when editor is non-editable

### DIFF
--- a/packages/core/src/api/clipboard/toClipboard/copyExtension.ts
+++ b/packages/core/src/api/clipboard/toClipboard/copyExtension.ts
@@ -189,7 +189,9 @@ export const createCopyToClipboardExtension = <
               },
               cut(view, event) {
                 copyToClipboard(editor, view, event);
-                view.dispatch(view.state.tr.deleteSelection());
+                if (view.editable) {
+                  view.dispatch(view.state.tr.deleteSelection());
+                }
                 // Prevent default PM handler to be called
                 return true;
               },


### PR DESCRIPTION
Closes #1303 