### PR TITLE
fix: BlockNoteView typescript issue for some users

### DIFF
--- a/packages/ariakit/src/index.tsx
+++ b/packages/ariakit/src/index.tsx
@@ -5,11 +5,11 @@ import {
   StyleSchema,
 } from "@blocknote/core";
 import {
+  BlockNoteViewProps,
   BlockNoteViewRaw,
   Components,
   ComponentsContext,
 } from "@blocknote/react";
-import { ComponentProps } from "react";
 
 import { Form } from "./input/Form.js";
 import { TextInput } from "./input/TextInput.js";
@@ -38,8 +38,8 @@ import { SuggestionMenuEmptyItem } from "./suggestionMenu/SuggestionMenuEmptyIte
 import { SuggestionMenuItem } from "./suggestionMenu/SuggestionMenuItem.js";
 import { SuggestionMenuLabel } from "./suggestionMenu/SuggestionMenuLabel.js";
 import { SuggestionMenuLoader } from "./suggestionMenu/SuggestionMenuLoader.js";
-import { TableHandle } from "./tableHandle/TableHandle.js";
 import { ExtendButton } from "./tableHandle/ExtendButton.js";
+import { TableHandle } from "./tableHandle/TableHandle.js";
 import { Toolbar } from "./toolbar/Toolbar.js";
 import { ToolbarButton } from "./toolbar/ToolbarButton.js";
 import { ToolbarSelect } from "./toolbar/ToolbarSelect.js";
@@ -110,7 +110,7 @@ export const BlockNoteView = <
   ISchema extends InlineContentSchema,
   SSchema extends StyleSchema
 >(
-  props: ComponentProps<typeof BlockNoteViewRaw<BSchema, ISchema, SSchema>>
+  props: BlockNoteViewProps<BSchema, ISchema, SSchema>
 ) => {
   const { className, ...rest } = props;
 

--- a/packages/mantine/src/index.tsx
+++ b/packages/mantine/src/index.tsx
@@ -5,6 +5,7 @@ import {
   StyleSchema,
 } from "@blocknote/core";
 import {
+  BlockNoteViewProps,
   BlockNoteViewRaw,
   Components,
   ComponentsContext,
@@ -12,7 +13,7 @@ import {
   usePrefersColorScheme,
 } from "@blocknote/react";
 import { MantineProvider } from "@mantine/core";
-import { ComponentProps, useCallback } from "react";
+import { useCallback } from "react";
 
 import {
   applyBlockNoteCSSVariablesFromTheme,
@@ -46,8 +47,8 @@ import { SuggestionMenuEmptyItem } from "./suggestionMenu/SuggestionMenuEmptyIte
 import { SuggestionMenuItem } from "./suggestionMenu/SuggestionMenuItem.js";
 import { SuggestionMenuLabel } from "./suggestionMenu/SuggestionMenuLabel.js";
 import { SuggestionMenuLoader } from "./suggestionMenu/SuggestionMenuLoader.js";
-import { TableHandle } from "./tableHandle/TableHandle.js";
 import { ExtendButton } from "./tableHandle/ExtendButton.js";
+import { TableHandle } from "./tableHandle/TableHandle.js";
 import { Toolbar } from "./toolbar/Toolbar.js";
 import { ToolbarButton } from "./toolbar/ToolbarButton.js";
 import { ToolbarSelect } from "./toolbar/ToolbarSelect.js";
@@ -124,10 +125,7 @@ export const BlockNoteView = <
   ISchema extends InlineContentSchema,
   SSchema extends StyleSchema
 >(
-  props: Omit<
-    ComponentProps<typeof BlockNoteViewRaw<BSchema, ISchema, SSchema>>,
-    "theme"
-  > & {
+  props: Omit<BlockNoteViewProps<BSchema, ISchema, SSchema>, "theme"> & {
     theme?:
       | "light"
       | "dark"

--- a/packages/react/src/editor/BlockNoteView.tsx
+++ b/packages/react/src/editor/BlockNoteView.tsx
@@ -7,7 +7,6 @@ import {
 } from "@blocknote/core";
 
 import React, {
-  ComponentProps,
   HTMLAttributes,
   ReactNode,
   Ref,
@@ -185,9 +184,7 @@ export const BlockNoteViewRaw = React.forwardRef(BlockNoteViewComponent) as <
   ISchema extends InlineContentSchema,
   SSchema extends StyleSchema
 >(
-  props: ComponentProps<
-    typeof BlockNoteViewComponent<BSchema, ISchema, SSchema>
-  > & {
+  props: BlockNoteViewProps<BSchema, ISchema, SSchema> & {
     ref?: React.ForwardedRef<HTMLDivElement>;
   }
 ) => ReturnType<typeof BlockNoteViewComponent<BSchema, ISchema, SSchema>>;

--- a/packages/shadcn/src/index.tsx
+++ b/packages/shadcn/src/index.tsx
@@ -5,11 +5,12 @@ import {
   StyleSchema,
 } from "@blocknote/core";
 import {
+  BlockNoteViewProps,
   BlockNoteViewRaw,
   Components,
   ComponentsContext,
 } from "@blocknote/react";
-import { ComponentProps, useMemo } from "react";
+import { useMemo } from "react";
 
 import { Form } from "./form/Form.js";
 import { TextInput } from "./form/TextInput.js";
@@ -39,8 +40,8 @@ import { SuggestionMenuEmptyItem } from "./suggestionMenu/SuggestionMenuEmptyIte
 import { SuggestionMenuItem } from "./suggestionMenu/SuggestionMenuItem.js";
 import { SuggestionMenuLabel } from "./suggestionMenu/SuggestionMenuLabel.js";
 import { SuggestionMenuLoader } from "./suggestionMenu/SuggestionMenuLoader.js";
-import { TableHandle } from "./tableHandle/TableHandle.js";
 import { ExtendButton } from "./tableHandle/ExtendButton.js";
+import { TableHandle } from "./tableHandle/TableHandle.js";
 import { Toolbar, ToolbarButton, ToolbarSelect } from "./toolbar/Toolbar.js";
 
 import { PanelButton } from "./panel/PanelButton.js";
@@ -113,7 +114,7 @@ export const BlockNoteView = <
   ISchema extends InlineContentSchema,
   SSchema extends StyleSchema
 >(
-  props: ComponentProps<typeof BlockNoteViewRaw<BSchema, ISchema, SSchema>> & {
+  props: BlockNoteViewProps<BSchema, ISchema, SSchema> & {
     /**
      * (optional)Provide your own shadcn component overrides
      */


### PR DESCRIPTION
I think this should resolve the issues here: https://github.com/TypeCellOS/BlockNote/issues/1211#issuecomment-2534944376

(haven't been able to reproduce, but at least this is simpler / shouldn't confuse the typescript compiler if that's the case)