### PR TITLE
fix: `getSelection` behaviour and build

### DIFF
--- a/packages/core/src/api/blockManipulation/selections/selection.ts
+++ b/packages/core/src/api/blockManipulation/selections/selection.ts
@@ -23,17 +23,17 @@ export function getSelection<
 ): Selection<BSchema, I, S> | undefined {
   const state = editor._tiptapEditor.state;
 
+  // Return undefined if the selection is collapsed or a node is selected.
+  if (state.selection.empty || "node" in state.selection) {
+    return undefined;
+  }
+
   const $startBlockBeforePos = state.doc.resolve(
     getNearestBlockPos(state.doc, state.selection.from).posBeforeNode
   );
   const $endBlockBeforePos = state.doc.resolve(
     getNearestBlockPos(state.doc, state.selection.to).posBeforeNode
   );
-
-  // Return undefined if anchor and head are in the same block.
-  if ($startBlockBeforePos.pos === $endBlockBeforePos.pos) {
-    return undefined;
-  }
 
   // Converts the node at the given index and depth around `$startBlockBeforePos`
   // to a block. Used to get blocks at given indices at the shared depth and

--- a/packages/react/src/components/FormattingToolbar/DefaultButtons/CreateLinkButton.tsx
+++ b/packages/react/src/components/FormattingToolbar/DefaultButtons/CreateLinkButton.tsx
@@ -66,12 +66,12 @@ export const CreateLinkButton = () => {
       }
     };
 
-    editor.prosemirrorView.dom.addEventListener("keydown", callback);
+    editor.prosemirrorView?.dom.addEventListener("keydown", callback);
 
     return () => {
-      editor.prosemirrorView.dom.removeEventListener("keydown", callback);
+      editor.prosemirrorView?.dom.removeEventListener("keydown", callback);
     };
-  }, [editor.prosemirrorView.dom]);
+  }, [editor.prosemirrorView?.dom]);
 
   const update = useCallback(
     (url: string, text: string) => {


### PR DESCRIPTION
This PR reverts when `getSelection` returns `undefined` to be the same as in 0.19.2, as we unintentionally changed this slightly in 0.20.0.

It also fixes a build issue currently on main that happened due to previous PRs passing CI individually but conflicting when merged.