### PR TITLE
fix: Table copy paste into spreadsheets (#1298)

### DIFF
--- a/packages/core/src/api/clipboard/__snapshots__/tableAllCells.html
+++ b/packages/core/src/api/clipboard/__snapshots__/tableAllCells.html
@@ -1,1 +1,1 @@
-<tr><td colspan="1" rowspan="1"><p>Table Cell</p></td><td colspan="1" rowspan="1"><p>Table Cell</p></td></tr><tr><td colspan="1" rowspan="1"><p>Table Cell</p></td><td colspan="1" rowspan="1"><p>Table Cell</p></td></tr>
+<table><tr><td colspan="1" rowspan="1"><p>Table Cell</p></td><td colspan="1" rowspan="1"><p>Table Cell</p></td></tr><tr><td colspan="1" rowspan="1"><p>Table Cell</p></td><td colspan="1" rowspan="1"><p>Table Cell</p></td></tr></table>

--- a/packages/core/src/api/clipboard/__snapshots__/tableCell.html
+++ b/packages/core/src/api/clipboard/__snapshots__/tableCell.html
@@ -1,1 +1,1 @@
-<tr><td colspan="1" rowspan="1"><p>Table Cell</p></td></tr>
+<table><tr><td colspan="1" rowspan="1"><p>Table Cell</p></td></tr></table>

--- a/packages/core/src/api/clipboard/__snapshots__/tableRow.html
+++ b/packages/core/src/api/clipboard/__snapshots__/tableRow.html
@@ -1,1 +1,1 @@
-<tr><td colspan="1" rowspan="1"><p>Table Cell</p></td><td colspan="1" rowspan="1"><p>Table Cell</p></td></tr>
+<table><tr><td colspan="1" rowspan="1"><p>Table Cell</p></td><td colspan="1" rowspan="1"><p>Table Cell</p></td></tr></table>

--- a/packages/core/src/api/clipboard/toClipboard/copyExtension.ts
+++ b/packages/core/src/api/clipboard/toClipboard/copyExtension.ts
@@ -80,7 +80,10 @@ function fragmentToExternalHTML<
       editor.schema.styleSchema
     );
 
-    externalHTML = externalHTMLExporter.exportInlineContent(ic as any, {});
+    externalHTML = `<table>${externalHTMLExporter.exportInlineContent(
+      ic as any,
+      {}
+    )}</table>`;
   } else if (isWithinBlockContent) {
     // first convert selection to blocknote-style inline content, and then
     // pass this to the exporter


### PR DESCRIPTION
This PR fixes copy/pasting of tables into spreadsheet applications (like Excel/Google Sheets); #1298 