### PR TITLE
chore: remove unnecessary files from dist

### DIFF
--- a/packages/ariakit/tsconfig.json
+++ b/packages/ariakit/tsconfig.json
@@ -19,6 +19,7 @@
     "declarationDir": "types",
     "composite": true,
     "skipLibCheck": true,
+    "emitDeclarationOnly": true
   },
   "include": ["src"],
   "references": [

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -17,6 +17,7 @@
     "outDir": "dist",
     "declaration": true,
     "declarationDir": "types",
+    "emitDeclarationOnly": true,
     "composite": true,
     "skipLibCheck": true
   },

--- a/packages/mantine/tsconfig.json
+++ b/packages/mantine/tsconfig.json
@@ -19,6 +19,7 @@
     "declarationDir": "types",
     "composite": true,
     "skipLibCheck": true,
+    "emitDeclarationOnly": true
   },
   "include": ["src"],
   "references": [

--- a/packages/react/tsconfig.json
+++ b/packages/react/tsconfig.json
@@ -18,7 +18,8 @@
     "declaration": true,
     "declarationDir": "types",
     "composite": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "emitDeclarationOnly": true
   },
   "include": ["src"],
   "references": [

--- a/packages/server-util/tsconfig.json
+++ b/packages/server-util/tsconfig.json
@@ -18,7 +18,8 @@
     "declaration": true,
     "declarationDir": "types",
     "composite": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "emitDeclarationOnly": true
   },
   "include": ["src"],
   "references": [

--- a/packages/shadcn/tsconfig.json
+++ b/packages/shadcn/tsconfig.json
@@ -20,10 +20,9 @@
     "composite": true,
     "skipLibCheck": true,
     "baseUrl": ".",
+    "emitDeclarationOnly": true,
     "paths": {
-      "@/*": [
-        "./src/*"
-      ]
+      "@/*": ["./src/*"]
     }
   },
   "include": ["src"],

--- a/packages/xl-docx-exporter/tsconfig.json
+++ b/packages/xl-docx-exporter/tsconfig.json
@@ -19,6 +19,7 @@
     "declarationDir": "types",
     "composite": true,
     "skipLibCheck": true,
+    "emitDeclarationOnly": true,
     "paths": {
       "@shared/*": ["../../shared/*"]
     }

--- a/packages/xl-multi-column/tsconfig.json
+++ b/packages/xl-multi-column/tsconfig.json
@@ -18,7 +18,8 @@
     "declaration": true,
     "declarationDir": "types",
     "composite": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "emitDeclarationOnly": true
   },
   "include": ["src"]
 }

--- a/packages/xl-pdf-exporter/tsconfig.json
+++ b/packages/xl-pdf-exporter/tsconfig.json
@@ -19,6 +19,7 @@
     "declarationDir": "types",
     "composite": true,
     "skipLibCheck": true,
+    "emitDeclarationOnly": true,
     "paths": {
       "@shared/*": ["../../shared/*"]
     }

--- a/shared/tsconfig.json
+++ b/shared/tsconfig.json
@@ -15,7 +15,8 @@
     "isolatedModules": true,
     "jsx": "react-jsx",
     "composite": true,
-    "outDir": "dist"
+    "outDir": "dist",
+    "emitDeclarationOnly": true
   },
   "include": ["."],
   "references": [


### PR DESCRIPTION
Removes an unnecessary `dist/src` directory that was accidentally added on build when enabling tsc project references