### PR TITLE
feat: stop suggestion menu event propagation

### DIFF
--- a/packages/react/src/components/SuggestionMenu/hooks/useSuggestionMenuKeyboardNavigation.ts
+++ b/packages/react/src/components/SuggestionMenu/hooks/useSuggestionMenuKeyboardNavigation.ts
@@ -35,6 +35,7 @@ export function useSuggestionMenuKeyboardNavigation<Item>(
 
       if (event.key === "Enter" && !event.isComposing) {
         event.preventDefault();
+        event.stopPropagation();
 
         if (items.length) {
           onItemClick?.(items[selectedIndex]);


### PR DESCRIPTION
I am adding a feature to my Blocknote instance where a modal with a form opens when a suggestion menu item is clicked. The modal behaves as expected when opened via a mouse click on the suggestion menu item. However, when the modal is opened using keyboard navigation, the form auto-submits unexpectedly. I resolved this issue by adding event.stopPropagation.