### PR TITLE
fix: Selecting start of table cell

### DIFF
--- a/packages/core/src/editor/editor.css
+++ b/packages/core/src/editor/editor.css
@@ -134,7 +134,7 @@ Tippy popups that are appended to document.body directly
 .bn-editor [data-content-type="table"] th,
 .bn-editor [data-content-type="table"] td {
   border: 1px solid #ddd;
-  padding: 3px 5px;
+  padding: 5px 10px;
 }
 
 .bn-editor [data-content-type="table"] th {


### PR DESCRIPTION
Because the table handles show up when hovering a table, they slightly cover the content for cells in the leftmost column. This means that the user can't click to select the starts of these cells as they end up clicking the table handle instead.

This PR slightly increases table cell padding so the table handles no longer overlap their content.