### PR TITLE
fix: NextJS 15 `Objects are not valid as a React child`

### DIFF
--- a/examples/01-basic/04-all-blocks/App.tsx
+++ b/examples/01-basic/04-all-blocks/App.tsx
@@ -195,9 +195,16 @@ export default function App() {
     );
   }, [editor]);
 
+  console.log(slashMenuItems);
+
   // Renders the editor instance using a React component.
   return (
-    <BlockNoteView editor={editor} slashMenu={false}>
+    <BlockNoteView
+      editor={editor}
+      slashMenu={false}
+      onSelectionChange={() => console.log("change")}
+      onFocus={() => console.log("focus")}
+      onBlur={() => console.log("blur")}>
       <SuggestionMenuController
         triggerCharacter={"/"}
         getItems={async (query) => filterSuggestionItems(slashMenuItems, query)}

--- a/examples/03-ui-components/06-suggestion-menus-slash-menu-items/App.tsx
+++ b/examples/03-ui-components/06-suggestion-menus-slash-menu-items/App.tsx
@@ -32,7 +32,7 @@ const insertHelloWorldItem = (editor: BlockNoteEditor) => ({
   },
   aliases: ["helloworld", "hw"],
   group: "Other",
-  icon: <HiOutlineGlobeAlt size={18} />,
+  icon: () => <HiOutlineGlobeAlt size={18} />,
   subtext: "Used to insert a block with 'Hello World' below.",
 });
 

--- a/examples/03-ui-components/09-suggestion-menus-emoji-picker-component/App.tsx
+++ b/examples/03-ui-components/09-suggestion-menus-emoji-picker-component/App.tsx
@@ -20,17 +20,21 @@ function CustomEmojiPicker(
       style={
         { gridTemplateColumns: `repeat(${props.columns || 1}, 1fr)` } as any
       }>
-      {props.items.map((item, index) => (
-        <div
-          className={`emoji-picker-item ${
-            props.selectedIndex === index ? " selected" : ""
-          }`}
-          onClick={() => {
-            props.onItemClick?.(item);
-          }}>
-          {item.icon}
-        </div>
-      ))}
+      {props.items.map((item, index) => {
+        const Icon = item.icon;
+
+        return (
+          <div
+            className={`emoji-picker-item ${
+              props.selectedIndex === index ? " selected" : ""
+            }`}
+            onClick={() => {
+              props.onItemClick?.(item);
+            }}>
+            {Icon && <Icon />}
+          </div>
+        );
+      })}
     </div>
   );
 }

--- a/examples/03-ui-components/10-suggestion-menus-grid-mentions/App.tsx
+++ b/examples/03-ui-components/10-suggestion-menus-grid-mentions/App.tsx
@@ -44,7 +44,7 @@ const getMentionMenuItems = (
         " ", // add a space after the mention
       ]);
     },
-    icon: <p>{user.substring(0, 1)}</p>,
+    icon: () => <p>{user.substring(0, 1)}</p>,
   }));
 };
 

--- a/examples/03-ui-components/11-uppy-file-panel/App.tsx
+++ b/examples/03-ui-components/11-uppy-file-panel/App.tsx
@@ -42,12 +42,22 @@ export default function App() {
           // Replaces default file replace button with one that opens Uppy.
           const items = getFormattingToolbarItems();
           items.splice(
-            items.findIndex((c) => c.key === "replaceFileButton"),
+            items.findIndex((c) => c.itemName === "replaceFileButton"),
             1,
-            <FileReplaceButton key={"fileReplaceButton"} />
+            {
+              itemName: "replaceFileButton",
+              Component: () => <FileReplaceButton key={"fileReplaceButton"} />,
+            }
           );
 
-          return <FormattingToolbar {...props}>{items}</FormattingToolbar>;
+          return (
+            <FormattingToolbar {...props}>
+              {items.map((item) => {
+                const Item = item.Component;
+                return <Item key={item.itemName} />;
+              })}
+            </FormattingToolbar>
+          );
         }}
       />
       {/* Replaces default file panel with Uppy one. */}

--- a/examples/03-ui-components/13-custom-ui/MUISuggestionMenu.tsx
+++ b/examples/03-ui-components/13-custom-ui/MUISuggestionMenu.tsx
@@ -70,7 +70,11 @@ function MUISuggestionMenuItem(
           props.onItemClick?.(props.item);
           editor.focus();
         }}>
-        <ListItemIcon>{Icon}</ListItemIcon>
+        {Icon && (
+          <ListItemIcon>
+            <Icon />
+          </ListItemIcon>
+        )}
         <ListItemText
           primary={props.item.title}
           secondary={props.item.subtext}

--- a/examples/06-custom-schema/01-alert-block/App.tsx
+++ b/examples/06-custom-schema/01-alert-block/App.tsx
@@ -45,7 +45,7 @@ const insertAlert = (editor: typeof schema.BlockNoteEditor) => ({
     "success",
   ],
   group: "Other",
-  icon: <RiAlertFill />,
+  icon: () => <RiAlertFill />,
 });
 
 export default function App() {

--- a/examples/06-custom-schema/04-pdf-file-block/App.tsx
+++ b/examples/06-custom-schema/04-pdf-file-block/App.tsx
@@ -38,7 +38,7 @@ const insertPDF = (editor: typeof schema.BlockNoteEditor) => ({
   },
   aliases: ["pdf", "document", "embed", "file"],
   group: "Other",
-  icon: <RiFilePdfFill />,
+  icon: () => <RiFilePdfFill />,
 });
 
 export default function App() {

--- a/packages/ariakit/src/suggestionMenu/SuggestionMenuItem.tsx
+++ b/packages/ariakit/src/suggestionMenu/SuggestionMenuItem.tsx
@@ -29,6 +29,8 @@ export const SuggestionMenuItem = forwardRef<
     }
   }, [isSelected]);
 
+  const Icon = item.icon;
+
   return (
     <div
       className={mergeCSSClasses("bn-ak-menu-item", className || "")}
@@ -37,11 +39,11 @@ export const SuggestionMenuItem = forwardRef<
       onClick={onClick}
       role="option"
       aria-selected={isSelected || undefined}>
-      {item.icon && (
+      {Icon && (
         <div
           className="bn-ak-suggestion-menu-item-section"
           data-position="left">
-          {item.icon}
+          <Icon />
         </div>
       )}
       <div className="bn-ak-suggestion-menu-item-body">

--- a/packages/ariakit/src/suggestionMenu/gridSuggestionMenu/GridSuggestionMenuItem.tsx
+++ b/packages/ariakit/src/suggestionMenu/gridSuggestionMenu/GridSuggestionMenuItem.tsx
@@ -29,6 +29,8 @@ export const GridSuggestionMenuItem = forwardRef<
     }
   }, [isSelected]);
 
+  const Icon = item.icon;
+
   return (
     <div
       className={className}
@@ -37,7 +39,7 @@ export const GridSuggestionMenuItem = forwardRef<
       role="option"
       onClick={onClick}
       aria-selected={isSelected || undefined}>
-      {item.icon}
+      {Icon && <Icon />}
     </div>
   );
 });

--- a/packages/mantine/src/suggestionMenu/SuggestionMenuItem.tsx
+++ b/packages/mantine/src/suggestionMenu/SuggestionMenuItem.tsx
@@ -37,6 +37,8 @@ export const SuggestionMenuItem = forwardRef<
     }
   }, [isSelected]);
 
+  const Icon = item.icon;
+
   return (
     <MantineGroup
       gap={0}
@@ -46,11 +48,11 @@ export const SuggestionMenuItem = forwardRef<
       role="option"
       onClick={onClick}
       aria-selected={isSelected || undefined}>
-      {item.icon && (
+      {Icon && (
         <MantineGroup
           className="bn-mt-suggestion-menu-item-section"
           data-position="left">
-          {item.icon}
+          <Icon />
         </MantineGroup>
       )}
       <MantineStack gap={0} className="bn-mt-suggestion-menu-item-body">

--- a/packages/mantine/src/suggestionMenu/gridSuggestionMenu/GridSuggestionMenuItem.tsx
+++ b/packages/mantine/src/suggestionMenu/gridSuggestionMenu/GridSuggestionMenuItem.tsx
@@ -31,6 +31,8 @@ export const GridSuggestionMenuItem = forwardRef<
     }
   }, [isSelected]);
 
+  const Icon = item.icon;
+
   return (
     <div
       className={className}
@@ -39,7 +41,7 @@ export const GridSuggestionMenuItem = forwardRef<
       role="option"
       onClick={onClick}
       aria-selected={isSelected || undefined}>
-      {item.icon}
+      {Icon && <Icon />}
     </div>
   );
 });

--- a/packages/react/src/components/FormattingToolbar/FormattingToolbar.tsx
+++ b/packages/react/src/components/FormattingToolbar/FormattingToolbar.tsx
@@ -1,4 +1,4 @@
-import { ReactNode } from "react";
+import { FC, ReactNode } from "react";
 
 import { useComponentsContext } from "../../editor/ComponentsContext.js";
 import { BasicTextStyleButton } from "./DefaultButtons/BasicTextStyleButton.js";
@@ -24,28 +24,104 @@ import { FormattingToolbarProps } from "./FormattingToolbarProps.js";
 
 export const getFormattingToolbarItems = (
   blockTypeSelectItems?: BlockTypeSelectItem[]
-): JSX.Element[] => [
-  <BlockTypeSelect key={"blockTypeSelect"} items={blockTypeSelectItems} />,
-  <FileCaptionButton key={"fileCaptionButton"} />,
-  <FileReplaceButton key={"replaceFileButton"} />,
-  <FileRenameButton key={"fileRenameButton"} />,
-  <FileDeleteButton key={"fileDeleteButton"} />,
-  <FileDownloadButton key={"fileDownloadButton"} />,
-  <FilePreviewButton key={"filePreviewButton"} />,
-  <BasicTextStyleButton basicTextStyle={"bold"} key={"boldStyleButton"} />,
-  <BasicTextStyleButton basicTextStyle={"italic"} key={"italicStyleButton"} />,
-  <BasicTextStyleButton
-    basicTextStyle={"underline"}
-    key={"underlineStyleButton"}
-  />,
-  <BasicTextStyleButton basicTextStyle={"strike"} key={"strikeStyleButton"} />,
-  <TextAlignButton textAlignment={"left"} key={"textAlignLeftButton"} />,
-  <TextAlignButton textAlignment={"center"} key={"textAlignCenterButton"} />,
-  <TextAlignButton textAlignment={"right"} key={"textAlignRightButton"} />,
-  <ColorStyleButton key={"colorStyleButton"} />,
-  <NestBlockButton key={"nestBlockButton"} />,
-  <UnnestBlockButton key={"unnestBlockButton"} />,
-  <CreateLinkButton key={"createLinkButton"} />,
+): { itemName: string; Component: FC }[] => [
+  {
+    itemName: "blockTypeSelect",
+    Component: () => (
+      <BlockTypeSelect key={"blockTypeSelect"} items={blockTypeSelectItems} />
+    ),
+  },
+  {
+    itemName: "fileCaptionButton",
+    Component: () => <FileCaptionButton key={"fileCaptionButton"} />,
+  },
+  {
+    itemName: "replaceFileButton",
+    Component: () => <FileReplaceButton key={"replaceFileButton"} />,
+  },
+  {
+    itemName: "fileRenameButton",
+    Component: () => <FileRenameButton key={"fileRenameButton"} />,
+  },
+  {
+    itemName: "fileDeleteButton",
+    Component: () => <FileDeleteButton key={"fileDeleteButton"} />,
+  },
+  {
+    itemName: "fileDownloadButton",
+    Component: () => <FileDownloadButton key={"fileDownloadButton"} />,
+  },
+  {
+    itemName: "filePreviewButton",
+    Component: () => <FilePreviewButton key={"filePreviewButton"} />,
+  },
+  {
+    itemName: "boldStyleButton",
+    Component: () => (
+      <BasicTextStyleButton basicTextStyle={"bold"} key={"boldStyleButton"} />
+    ),
+  },
+  {
+    itemName: "italicStyleButton",
+    Component: () => (
+      <BasicTextStyleButton
+        basicTextStyle={"italic"}
+        key={"italicStyleButton"}
+      />
+    ),
+  },
+  {
+    itemName: "underlineStyleButton",
+    Component: () => (
+      <BasicTextStyleButton
+        basicTextStyle={"underline"}
+        key={"underlineStyleButton"}
+      />
+    ),
+  },
+  {
+    itemName: "strikeStyleButton",
+    Component: () => (
+      <BasicTextStyleButton
+        basicTextStyle={"strike"}
+        key={"strikeStyleButton"}
+      />
+    ),
+  },
+  {
+    itemName: "textAlignLeftButton",
+    Component: () => (
+      <TextAlignButton textAlignment={"left"} key={"textAlignLeftButton"} />
+    ),
+  },
+  {
+    itemName: "textAlignCenterButton",
+    Component: () => (
+      <TextAlignButton textAlignment={"center"} key={"textAlignCenterButton"} />
+    ),
+  },
+  {
+    itemName: "textAlignRightButton",
+    Component: () => (
+      <TextAlignButton textAlignment={"right"} key={"textAlignRightButton"} />
+    ),
+  },
+  {
+    itemName: "colorStyleButton",
+    Component: () => <ColorStyleButton key={"colorStyleButton"} />,
+  },
+  {
+    itemName: "nestBlockButton",
+    Component: () => <NestBlockButton key={"nestBlockButton"} />,
+  },
+  {
+    itemName: "unnestBlockButton",
+    Component: () => <UnnestBlockButton key={"unnestBlockButton"} />,
+  },
+  {
+    itemName: "createLinkButton",
+    Component: () => <CreateLinkButton key={"createLinkButton"} />,
+  },
 ];
 
 // TODO: props.blockTypeSelectItems should only be available if no children
@@ -70,7 +146,11 @@ export const FormattingToolbar = (
   return (
     <Components.FormattingToolbar.Root
       className={"bn-toolbar bn-formatting-toolbar"}>
-      {props.children || getFormattingToolbarItems(props.blockTypeSelectItems)}
+      {props.children ||
+        getFormattingToolbarItems(props.blockTypeSelectItems).map((item) => {
+          const Item = item.Component;
+          return <Item />;
+        })}
     </Components.FormattingToolbar.Root>
   );
 };

--- a/packages/react/src/components/SuggestionMenu/GridSuggestionMenu/getDefaultReactEmojiPickerItems.tsx
+++ b/packages/react/src/components/SuggestionMenu/GridSuggestionMenu/getDefaultReactEmojiPickerItems.tsx
@@ -19,7 +19,7 @@ export async function getDefaultReactEmojiPickerItems<
     ({ id, onItemClick }) => ({
       id,
       onItemClick,
-      icon: id as any,
+      icon: () => <>{id}</>,
     })
   );
 }

--- a/packages/react/src/components/SuggestionMenu/GridSuggestionMenu/types.tsx
+++ b/packages/react/src/components/SuggestionMenu/GridSuggestionMenu/types.tsx
@@ -1,9 +1,10 @@
 import { DefaultGridSuggestionItem } from "@blocknote/core";
+import { FC } from "react";
 
 import { SuggestionMenuProps } from "../types.js";
 
 export type DefaultReactGridSuggestionItem = DefaultGridSuggestionItem & {
-  icon?: JSX.Element;
+  icon?: FC;
 };
 
 export type GridSuggestionMenuProps<T> = SuggestionMenuProps<T> & {

--- a/packages/react/src/components/SuggestionMenu/getDefaultReactSlashMenuItems.tsx
+++ b/packages/react/src/components/SuggestionMenu/getDefaultReactSlashMenuItems.tsx
@@ -49,7 +49,7 @@ export function getDefaultReactSlashMenuItems<
     const Icon = icons[item.key];
     return {
       ...item,
-      icon: <Icon size={18} />,
+      icon: () => <Icon size={18} />,
     };
   });
 }

--- a/packages/react/src/components/SuggestionMenu/types.tsx
+++ b/packages/react/src/components/SuggestionMenu/types.tsx
@@ -1,11 +1,12 @@
 import { DefaultSuggestionItem } from "@blocknote/core";
+import { FC } from "react";
 
 /**
  * Although any arbitrary data can be passed as suggestion items, the built-in
  * UI components such as `MantineSuggestionMenu` expect a shape that conforms to DefaultSuggestionItem
  */
 export type DefaultReactSuggestionItem = Omit<DefaultSuggestionItem, "key"> & {
-  icon?: JSX.Element;
+  icon?: FC;
 };
 
 /**

--- a/packages/shadcn/src/suggestionMenu/SuggestionMenuItem.tsx
+++ b/packages/shadcn/src/suggestionMenu/SuggestionMenuItem.tsx
@@ -33,6 +33,8 @@ export const SuggestionMenuItem = forwardRef<
     }
   }, [isSelected]);
 
+  const Icon = item.icon;
+
   return (
     <div
       // Styles from ShadCN DropdownMenuItem component
@@ -45,9 +47,9 @@ export const SuggestionMenuItem = forwardRef<
       onClick={onClick}
       role="option"
       aria-selected={isSelected || undefined}>
-      {item.icon && (
+      {Icon && (
         <div className="bn-p-3" data-position="left">
-          {item.icon}
+          <Icon />
         </div>
       )}
       <div className="bn-flex-1">

--- a/packages/shadcn/src/suggestionMenu/gridSuggestionMenu/GridSuggestionMenuItem.tsx
+++ b/packages/shadcn/src/suggestionMenu/gridSuggestionMenu/GridSuggestionMenuItem.tsx
@@ -29,6 +29,8 @@ export const GridSuggestionMenuItem = forwardRef<
     }
   }, [isSelected]);
 
+  const Icon = item.icon;
+
   return (
     <div
       className={className}
@@ -37,7 +39,7 @@ export const GridSuggestionMenuItem = forwardRef<
       role="option"
       onClick={onClick}
       aria-selected={isSelected || undefined}>
-      {item.icon}
+      {Icon && <Icon />}
     </div>
   );
 });

--- a/packages/xl-multi-column/src/extensions/SuggestionMenu/getMultiColumnSlashMenuItems.tsx
+++ b/packages/xl-multi-column/src/extensions/SuggestionMenu/getMultiColumnSlashMenuItems.tsx
@@ -38,7 +38,7 @@ export function getMultiColumnSlashMenuItems<
     items.push(
       {
         ...getMultiColumnDictionary(editor).slash_menu.two_columns,
-        icon: <TbColumns2 size={18} />,
+        icon: () => <TbColumns2 size={18} />,
         onItemClick: () => {
           insertOrUpdateBlock(editor, {
             type: "columnList",
@@ -65,7 +65,7 @@ export function getMultiColumnSlashMenuItems<
       },
       {
         ...getMultiColumnDictionary(editor).slash_menu.three_columns,
-        icon: <TbColumns3 size={18} />,
+        icon: () => <TbColumns3 size={18} />,
         onItemClick: () => {
           insertOrUpdateBlock(editor, {
             type: "columnList",

--- a/tests/src/utils/customblocks/Alert.tsx
+++ b/tests/src/utils/customblocks/Alert.tsx
@@ -141,7 +141,7 @@ export const insertAlert = (editor: BlockNoteEditor<any, any, any>) => ({
     editor.insertBlocks([block], editor.getTextCursorPosition().block, "after");
   },
   subtext: "Insert an alert block to emphasize text",
-  icon: <RiAlertFill />,
+  icon: () => <RiAlertFill />,
   aliases: [
     "alert",
     "notification",


### PR DESCRIPTION
For some reason, NextJS 15 throws an error when rendering props (that aren't `children`) that are JSX elements, in some cases. In particular, the `icon` prop for suggestion menu items causes this error to be thrown.

The error should be thrown when trying to render an array or object as a JSX element, so I'm not sure why it's also being thrown for JSX elements, which should work just fine.

What's worse is that copying the exact same code and icons to a local file vs importing them from BlockNote also stops the error from being thrown. Unfortunately, I couldn't find any information on why this is happening. Maybe it's worth submitting an issue in NextJS? Note that this doesn't seem to be an issue in base React 19, but specifically NextJS 15.

Either way, this PR changes props which aren't `children` that have type `JSX.Element` to the type `FC` to fix the issue.

Closes #1347 