### PR TITLE
fix: Rollup config for `xl` and `server-util` packages

### DIFF
--- a/packages/server-util/vite.config.ts
+++ b/packages/server-util/vite.config.ts
@@ -4,7 +4,11 @@ import { defineConfig } from "vite";
 import pkg from "./package.json";
 // import eslintPlugin from "vite-plugin-eslint";
 
-const deps = Object.keys(pkg.dependencies);
+const deps = Object.keys({
+  ...pkg.dependencies,
+  ...pkg.peerDependencies,
+  ...pkg.devDependencies,
+});
 
 // https://vitejs.dev/config/
 export default defineConfig((conf) => ({

--- a/packages/server-util/vite.config.ts
+++ b/packages/server-util/vite.config.ts
@@ -37,7 +37,16 @@ export default defineConfig((conf) => ({
         if (deps.includes(source)) {
           return true;
         }
-        return source.startsWith("prosemirror-");
+
+        if (source === "react/jsx-runtime") {
+          return true;
+        }
+
+        if (source.startsWith("prosemirror-")) {
+          return true;
+        }
+
+        return false;
       },
       output: {
         // Provide global variables to use in the UMD build

--- a/packages/xl-docx-exporter/package.json
+++ b/packages/xl-docx-exporter/package.json
@@ -67,6 +67,10 @@
     "vitest": "^2.0.3",
     "xml-formatter": "^3.6.3"
   },
+  "peerDependencies": {
+    "react": "^18.0 || ^19.0 || >= 19.0.0-rc",
+    "react-dom": "^18.0 || ^19.0 || >= 19.0.0-rc"
+  },
   "eslintConfig": {
     "extends": [
       "../../.eslintrc.js"

--- a/packages/xl-docx-exporter/vite.config.ts
+++ b/packages/xl-docx-exporter/vite.config.ts
@@ -46,7 +46,16 @@ export default defineConfig((conf) => ({
         if (deps.includes(source)) {
           return true;
         }
-        return source.startsWith("prosemirror-");
+
+        if (source === "react/jsx-runtime") {
+          return true;
+        }
+
+        if (source.startsWith("prosemirror-")) {
+          return true;
+        }
+
+        return false;
       },
       output: {
         // Provide global variables to use in the UMD build

--- a/packages/xl-docx-exporter/vite.config.ts
+++ b/packages/xl-docx-exporter/vite.config.ts
@@ -4,7 +4,11 @@ import { defineConfig } from "vite";
 import pkg from "./package.json";
 // import eslintPlugin from "vite-plugin-eslint";
 
-const deps = Object.keys(pkg.dependencies);
+const deps = Object.keys({
+  ...pkg.dependencies,
+  ...pkg.peerDependencies,
+  ...pkg.devDependencies,
+});
 
 // https://vitejs.dev/config/
 export default defineConfig((conf) => ({

--- a/packages/xl-multi-column/package.json
+++ b/packages/xl-multi-column/package.json
@@ -67,6 +67,10 @@
     "vite-plugin-eslint": "^1.8.1",
     "vitest": "^2.0.3"
   },
+  "peerDependencies": {
+    "react": "^18.0 || ^19.0 || >= 19.0.0-rc",
+    "react-dom": "^18.0 || ^19.0 || >= 19.0.0-rc"
+  },
   "eslintConfig": {
     "extends": [
       "../../.eslintrc.js"

--- a/packages/xl-multi-column/vite.config.ts
+++ b/packages/xl-multi-column/vite.config.ts
@@ -4,7 +4,11 @@ import { defineConfig } from "vite";
 import pkg from "./package.json";
 // import eslintPlugin from "vite-plugin-eslint";
 
-const deps = Object.keys(pkg.dependencies);
+const deps = Object.keys({
+  ...pkg.dependencies,
+  ...pkg.peerDependencies,
+  ...pkg.devDependencies,
+});
 
 // https://vitejs.dev/config/
 export default defineConfig((conf) => ({
@@ -36,7 +40,16 @@ export default defineConfig((conf) => ({
         if (deps.includes(source)) {
           return true;
         }
-        return source.startsWith("prosemirror-");
+
+        if (source === "react/jsx-runtime") {
+          return true;
+        }
+
+        if (source.startsWith("prosemirror-")) {
+          return true;
+        }
+
+        return false;
       },
       output: {
         // Provide global variables to use in the UMD build

--- a/packages/xl-pdf-exporter/vite.config.ts
+++ b/packages/xl-pdf-exporter/vite.config.ts
@@ -53,7 +53,16 @@ export default defineConfig((conf) => ({
         if (deps.includes(source)) {
           return true;
         }
-        return source.startsWith("prosemirror-");
+
+        if (source === "react/jsx-runtime") {
+          return true;
+        }
+
+        if (source.startsWith("prosemirror-")) {
+          return true;
+        }
+
+        return false;
       },
       output: {
         // Provide global variables to use in the UMD build

--- a/packages/xl-pdf-exporter/vite.config.ts
+++ b/packages/xl-pdf-exporter/vite.config.ts
@@ -4,7 +4,11 @@ import { defineConfig } from "vite";
 import pkg from "./package.json";
 // import eslintPlugin from "vite-plugin-eslint";
 
-const deps = Object.keys(pkg.dependencies);
+const deps = Object.keys({
+  ...pkg.dependencies,
+  ...pkg.peerDependencies,
+  ...pkg.devDependencies,
+});
 
 // https://vitejs.dev/config/
 export default defineConfig((conf) => ({


### PR DESCRIPTION
Currently, some BlockNote packages include code from React in their built files. Apart from being unnecessary, the code can cause a version mismatch of React, leading to issues. This PR fixes the rollup config so that no React code is included in built files.

Closes #1347 