### PR TITLE
feat: Improved collaboration cursor UX

### DIFF
--- a/packages/core/src/editor/BlockNoteEditor.ts
+++ b/packages/core/src/editor/BlockNoteEditor.ts
@@ -196,6 +196,13 @@ export type BlockNoteEditorOptions<
      * Optional function to customize how cursors of users are rendered
      */
     renderCursor?: (user: any) => HTMLElement;
+    /**
+     * Optional flag to set when the user label should be shown with the default
+     * collaboration cursor. Setting to "always" will always show the label,
+     * while "activity" will only show the label when the user moves the cursor
+     * or types. Defaults to "activity".
+     */
+    showCursorLabels?: "always" | "activity";
   };
 
   /**

--- a/packages/core/src/editor/BlockNoteExtensions.ts
+++ b/packages/core/src/editor/BlockNoteExtensions.ts
@@ -251,13 +251,14 @@ const getTipTapExtensions = <
         fragment: opts.collaboration.fragment,
       })
     );
-    if (opts.collaboration.provider?.awareness) {
+
+    const awareness = opts.collaboration?.provider.awareness as Awareness;
+
+    if (awareness) {
       const cursors = new Map<
         number,
         { element: HTMLElement; hideTimeout: NodeJS.Timeout | undefined }
       >();
-
-      const awareness = opts.collaboration!.provider.awareness as Awareness;
 
       awareness.on(
         "change",
@@ -282,7 +283,7 @@ const getTipTapExtensions = <
                 element: cursor.element,
                 hideTimeout: setTimeout(() => {
                   cursor.element.removeAttribute("data-active");
-                }, 1000),
+                }, 2000),
               });
             }
           }
@@ -330,7 +331,7 @@ const getTipTapExtensions = <
             element: cursor.element,
             hideTimeout: setTimeout(() => {
               cursor.element.removeAttribute("data-active");
-            }, 1000),
+            }, 2000),
           });
         });
 
@@ -354,10 +355,7 @@ const getTipTapExtensions = <
       };
       tiptapExtensions.push(
         CollaborationCursor.configure({
-          user: {
-            name: opts.collaboration.user.name,
-            color: opts.collaboration.user.color,
-          },
+          user: opts.collaboration.user,
           render: opts.collaboration.renderCursor || defaultRender,
           provider: opts.collaboration.provider,
         })

--- a/packages/core/src/editor/editor.css
+++ b/packages/core/src/editor/editor.css
@@ -83,7 +83,6 @@ Tippy popups that are appended to document.body directly
   border-right: 1px solid #0d0d0d;
   margin-left: -1px;
   margin-right: -1px;
-  pointer-events: none;
   position: relative;
   word-break: normal;
   white-space: nowrap !important;

--- a/packages/core/src/editor/editor.css
+++ b/packages/core/src/editor/editor.css
@@ -88,19 +88,75 @@ Tippy popups that are appended to document.body directly
   white-space: nowrap !important;
 }
 
+@keyframes label-collapse {
+  from {
+    border-radius: 3px 3px 3px 0;
+    color: #0d0d0d;
+    max-height: 1.1rem;
+    max-width: 10rem;
+    padding: 0.1rem 0.3rem;
+    top: -1.1rem;
+  }
+
+  to {
+    border-radius: 0 3px 3px 0;
+    color: transparent;
+    max-height: 4px;
+    max-width: 4px;
+    padding: 0;
+    top: 0;
+  }
+}
+
 /* Render the username above the caret */
 .collaboration-cursor__label {
-  border-radius: 3px 3px 3px 0;
-  color: #0d0d0d;
+  animation-name: label-collapse;
+  animation-duration: 0.2s;
+  border-radius: 0 3px 3px 0;
+  color: transparent;
   font-size: 12px;
   font-style: normal;
   font-weight: 600;
-  left: -1px;
   line-height: normal;
-  padding: 0.1rem 0.3rem;
+  left: -1px;
+  max-height: 4px;
+  max-width: 4px;
+  overflow: hidden;
+  padding: 0;
   position: absolute;
-  top: -1.4em;
+  top: 0;
   user-select: none;
+}
+
+@keyframes label-expand {
+  from {
+    border-radius: 0 3px 3px 0;
+    color: transparent;
+    max-height: 4px;
+    max-width: 4px;
+    padding: 0;
+    top: -4px;
+  }
+
+  to {
+    border-radius: 3px 3px 3px 0;
+    color: #0d0d0d;
+    max-height: 1.1rem;
+    max-width: 20rem;
+    padding: 0.1rem 0.3rem;
+    top: -1.1rem;
+  }
+}
+
+.collaboration-cursor__caret[data-active] > .collaboration-cursor__label {
+  animation-name: label-expand;
+  animation-duration: 0.2s;
+  border-radius: 3px 3px 3px 0;
+  color: #0d0d0d;
+  max-height: 1.1rem;
+  max-width: 20rem;
+  padding: 0.1rem 0.3rem;
+  top: -1.1rem;
   white-space: nowrap;
 }
 

--- a/packages/core/src/editor/editor.css
+++ b/packages/core/src/editor/editor.css
@@ -91,30 +91,33 @@ Tippy popups that are appended to document.body directly
 /* Render the username above the caret */
 .collaboration-cursor__label {
   border-radius: 3px 3px 3px 0;
-  color: transparent;
   font-size: 12px;
   font-style: normal;
   font-weight: 600;
   line-height: normal;
   left: -1px;
+  overflow: hidden;
+  position: absolute;
+  white-space: nowrap;
+
+  color: transparent;
   max-height: 4px;
   max-width: 4px;
-  overflow: hidden;
   padding: 0;
-  position: absolute;
   transform: translateY(3px);
+  
   transition: all 0.2s;
+
 }
 
 .collaboration-cursor__caret[data-active] > .collaboration-cursor__label {
-  border-radius: 3px 3px 3px 0;
   color: #0d0d0d;
   max-height: 1.1rem;
   max-width: 20rem;
   padding: 0.1rem 0.3rem;
   transform: translateY(-14px);
+
   transition: all 0.2s;
-  white-space: nowrap;
 }
 
 /* .tableWrapper {

--- a/packages/core/src/editor/editor.css
+++ b/packages/core/src/editor/editor.css
@@ -88,31 +88,9 @@ Tippy popups that are appended to document.body directly
   white-space: nowrap !important;
 }
 
-@keyframes label-collapse {
-  from {
-    border-radius: 3px 3px 3px 0;
-    color: #0d0d0d;
-    max-height: 1.1rem;
-    max-width: 10rem;
-    padding: 0.1rem 0.3rem;
-    top: -1.1rem;
-  }
-
-  to {
-    border-radius: 0 3px 3px 0;
-    color: transparent;
-    max-height: 4px;
-    max-width: 4px;
-    padding: 0;
-    top: 0;
-  }
-}
-
 /* Render the username above the caret */
 .collaboration-cursor__label {
-  animation-name: label-collapse;
-  animation-duration: 0.2s;
-  border-radius: 0 3px 3px 0;
+  border-radius: 3px 3px 3px 0;
   color: transparent;
   font-size: 12px;
   font-style: normal;
@@ -124,39 +102,18 @@ Tippy popups that are appended to document.body directly
   overflow: hidden;
   padding: 0;
   position: absolute;
-  top: 0;
-  user-select: none;
-}
-
-@keyframes label-expand {
-  from {
-    border-radius: 0 3px 3px 0;
-    color: transparent;
-    max-height: 4px;
-    max-width: 4px;
-    padding: 0;
-    top: -4px;
-  }
-
-  to {
-    border-radius: 3px 3px 3px 0;
-    color: #0d0d0d;
-    max-height: 1.1rem;
-    max-width: 20rem;
-    padding: 0.1rem 0.3rem;
-    top: -1.1rem;
-  }
+  transform: translateY(3px);
+  transition: all 0.2s;
 }
 
 .collaboration-cursor__caret[data-active] > .collaboration-cursor__label {
-  animation-name: label-expand;
-  animation-duration: 0.2s;
   border-radius: 3px 3px 3px 0;
   color: #0d0d0d;
   max-height: 1.1rem;
   max-width: 20rem;
   padding: 0.1rem 0.3rem;
-  top: -1.1rem;
+  transform: translateY(-14px);
+  transition: all 0.2s;
   white-space: nowrap;
 }
 


### PR DESCRIPTION
This PR improves the collaboration cursor UX so that the name tag no longer annoyingly blocks user text selection. The UX changes are summarized here: https://github.com/TypeCellOS/BlockNote/issues/1163#issuecomment-2504180222.

> User 1 and 2 collaborate in real-time, from user 1's perspective:
> - When user 2 writes, their name is displayed
> - After X seconds of user 2's inactivity, their name disappears
> - When user 1 hovers over user 2's cursor, user 2's name is displayed for X seconds
> - The cursor remains visible at all times. To improve its visibility, we can either add a dot as suggested by Virgile, or increase its thickness.

![ezgif-5-bce5e744ef](https://github.com/user-attachments/assets/07aa8626-10d8-4d6f-a9dd-a8d95b357f94)


Closes #1163 