### PR TITLE
fix: Side menu scrolling

### DIFF
--- a/packages/core/src/extensions/SideMenu/SideMenuPlugin.ts
+++ b/packages/core/src/extensions/SideMenu/SideMenuPlugin.ts
@@ -187,6 +187,11 @@ export class SideMenuView<
       this.onKeyDown as EventListener,
       true
     );
+
+    // Setting capture=true ensures that any parent container of the editor that
+    // gets scrolled will trigger the scroll event. Scroll events do not bubble
+    // and so won't propagate to the document by default.
+    pmView.root.addEventListener("scroll", this.onScroll, true);
   }
 
   updateState = (state: SideMenuState<BSchema, I, S>) => {
@@ -473,6 +478,13 @@ export class SideMenuView<
     return evt;
   }
 
+  onScroll = () => {
+    if (this.state?.show) {
+      this.state.referencePos = this.hoveredBlock!.getBoundingClientRect();
+      this.emitUpdate(this.state);
+    }
+  };
+
   // Needed in cases where the editor state updates without the mouse cursor
   // moving, as some state updates can require a side menu update. For example,
   // adding a button to the side menu which removes the block can cause the
@@ -515,6 +527,7 @@ export class SideMenuView<
       this.onKeyDown as EventListener,
       true
     );
+    this.pmView.root.removeEventListener("scroll", this.onScroll, true);
   }
 }
 


### PR DESCRIPTION
This PR fixes the side menu not scrolling with the editor, if the editor is within a scrollable container (works when scrolling document body).

The PR just adds a scroll listener, which is present on all the other UI element plugins.

I spent quite some time playing around with Floating UI to try and get things working without a scroll listener, e.g. by setting [`contextElement`](https://floating-ui.com/docs/virtual-elements#contextelement) as well as `getBoundingClientRect` in `setReference`/`setPositionReference`. I also tried using [`autoUpdate`](https://floating-ui.com/docs/autoupdate), but again had no luck.

I think in general it might be better to keep the scroll listeners though, since it's at least clear in the codebase how those position updates are happening, whereas letting Floating UI handle them makes it less obvious what's going on.