### PR TITLE
fix: translation fix in fr.ts

### DIFF
--- a/packages/core/src/i18n/locales/fr.ts
+++ b/packages/core/src/i18n/locales/fr.ts
@@ -281,11 +281,11 @@ export const fr: Dictionary = {
       tooltip: "Basculer l'aperçu",
     },
     nest: {
-      tooltip: "Emboîter le bloc",
+      tooltip: "Augmenter le retrait du bloc",
       secondary_tooltip: "Tab",
     },
     unnest: {
-      tooltip: "Démboîter le bloc",
+      tooltip: "Diminuer le retait du bloc",
       secondary_tooltip: "Shift+Tab",
     },
     align_left: {


### PR DESCRIPTION
The tooltip for nest and unested was unaccurate opted for the libreoffice version.