### PR TITLE
fix: shadcn button type

### DIFF
--- a/packages/shadcn/src/components/ui/button.tsx
+++ b/packages/shadcn/src/components/ui/button.tsx
@@ -47,6 +47,7 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
       <Comp
         className={cn(buttonVariants({ variant, size, className }))}
         ref={ref}
+        type="button"
         {...props}
       />
     );


### PR DESCRIPTION
Set the ShadCN Button component’s type to "button" to prevent unintended form submissions when the editor is used inside a form.