### PR TITLE
fix: cursors will not break to new-line on firefox #1419

### DIFF
--- a/packages/core/src/editor/editor.css
+++ b/packages/core/src/editor/editor.css
@@ -121,7 +121,7 @@ Tippy popups that are appended to document.body directly
   max-height: 1.1rem;
   max-width: 20rem;
   padding: 0.1rem 0.3rem;
-  top: -19px;
+  top: -18px;
   left: -1px;
   border-radius: 3px 3px 3px 0;
 

--- a/packages/core/src/editor/editor.css
+++ b/packages/core/src/editor/editor.css
@@ -91,12 +91,13 @@ Tippy popups that are appended to document.body directly
 
 /* Render the username above the caret */
 .collaboration-cursor__label {
-  border-radius: 3px 3px 3px 0;
+  border-radius: 3px;
   font-size: 12px;
   font-style: normal;
   font-weight: 600;
   line-height: normal;
-  left: -1px;
+  left: 0;
+  transform: translate(-2px, -2px);
   overflow: hidden;
   position: absolute;
   white-space: nowrap;
@@ -106,9 +107,7 @@ Tippy popups that are appended to document.body directly
   max-width: 4px;
   padding: 0;
   top: 0;
-  
   transition: all 0.2s;
-
 }
 
 .collaboration-cursor__caret[data-active] > .collaboration-cursor__label {

--- a/packages/core/src/editor/editor.css
+++ b/packages/core/src/editor/editor.css
@@ -85,6 +85,17 @@ Tippy popups that are appended to document.body directly
   white-space: nowrap !important;
 }
 
+/* Allow the caret to be hovered over */
+.collaboration-cursor__caret::after {
+  content: "";
+  position: absolute;
+  top: 0;
+  right: 0;
+  left: 0;
+  bottom: 0;
+  width: 2px;
+}
+
 /* Render the username above the caret */
 .collaboration-cursor__label {
   border-radius: 0 1.5px 1.5px 0;

--- a/packages/core/src/editor/editor.css
+++ b/packages/core/src/editor/editor.css
@@ -79,7 +79,7 @@ Tippy popups that are appended to document.body directly
 
 /* Give a remote user a caret */
 .collaboration-cursor__caret {
-  outline: 0.5px solid #0d0d0d;
+  outline: 1px solid #0d0d0d;
   position: relative;
   word-break: normal;
   white-space: nowrap !important;
@@ -87,22 +87,21 @@ Tippy popups that are appended to document.body directly
 
 /* Render the username above the caret */
 .collaboration-cursor__label {
-  border-radius: 3px;
+  border-radius: 0 1.5px 1.5px 0;
   font-size: 12px;
   font-style: normal;
   font-weight: 600;
   line-height: normal;
   left: 0;
-  transform: translate(-2px, -2px);
   overflow: hidden;
   position: absolute;
   white-space: nowrap;
 
   color: transparent;
-  max-height: 4px;
+  max-height: 5px;
   max-width: 4px;
   padding: 0;
-  top: 0;
+  top: -1px;
   transition: all 0.2s;
 }
 
@@ -112,6 +111,7 @@ Tippy popups that are appended to document.body directly
   max-width: 20rem;
   padding: 0.1rem 0.3rem;
   top: -14px;
+  border-radius: 3px;
 
   transition: all 0.2s;
 }

--- a/packages/core/src/editor/editor.css
+++ b/packages/core/src/editor/editor.css
@@ -110,8 +110,9 @@ Tippy popups that are appended to document.body directly
   max-height: 1.1rem;
   max-width: 20rem;
   padding: 0.1rem 0.3rem;
-  top: -14px;
-  border-radius: 3px;
+  top: -19px;
+  left: -1px;
+  border-radius: 3px 3px 3px 0;
 
   transition: all 0.2s;
 }

--- a/packages/core/src/editor/editor.css
+++ b/packages/core/src/editor/editor.css
@@ -79,6 +79,7 @@ Tippy popups that are appended to document.body directly
 
 /* Give a remote user a caret */
 .collaboration-cursor__caret {
+  display: inline-block;
   border-left: 1px solid #0d0d0d;
   border-right: 1px solid #0d0d0d;
   margin-left: -1px;

--- a/packages/core/src/editor/editor.css
+++ b/packages/core/src/editor/editor.css
@@ -79,11 +79,7 @@ Tippy popups that are appended to document.body directly
 
 /* Give a remote user a caret */
 .collaboration-cursor__caret {
-  display: inline-block;
-  border-left: 1px solid #0d0d0d;
-  border-right: 1px solid #0d0d0d;
-  margin-left: -1px;
-  margin-right: -1px;
+  outline: 0.5px solid #0d0d0d;
   position: relative;
   word-break: normal;
   white-space: nowrap !important;

--- a/packages/core/src/extensions/Collaboration/createCollaborationExtensions.ts
+++ b/packages/core/src/extensions/Collaboration/createCollaborationExtensions.ts
@@ -66,7 +66,7 @@ export const createCollaborationExtensions = (collaboration: {
       const cursorElement = document.createElement("span");
 
       cursorElement.classList.add("collaboration-cursor__caret");
-      cursorElement.setAttribute("style", `border-color: ${user.color}`);
+      cursorElement.setAttribute("style", `outline-color: ${user.color}`);
       if (collaboration?.showCursorLabels === "always") {
         cursorElement.setAttribute("data-active", "");
       }


### PR DESCRIPTION
This resolves an issue where in Firefox the cursor's caret was breaking to a new line in specific scenarios. Resolves (#1419)

Original issue:

https://github.com/user-attachments/assets/680a8469-284e-4f1a-acde-863638a45f59


After fix is applied:


https://github.com/user-attachments/assets/04d4aa04-2c09-4fa7-95cf-79eb6cb61d99

You'll also notice I repositioned the label to actually line-up to the caret element. I felt like it just looked wrong otherwise. 

Before:

<img width="424" alt="image" src="https://github.com/user-attachments/assets/b1ab832e-c662-4fea-86ed-063b783248b8" />


After:

<img width="710" alt="image" src="https://github.com/user-attachments/assets/386ca3c3-04c2-4a1c-b9e0-d8789f3029ee" />


If this should be changed in another PR, then happy to do so, just wanted this to look great. Also willing to make the cursor thicker than 1 px it is right now
