### PR TITLE
fix: Cut/copy handling in non-editable blocks and empty selections

### DIFF
--- a/packages/core/src/api/clipboard/toClipboard/copyExtension.ts
+++ b/packages/core/src/api/clipboard/toClipboard/copyExtension.ts
@@ -147,6 +147,34 @@ export function selectedFragmentToHTML<
   return { clipboardHTML, externalHTML, markdown };
 }
 
+const checkIfSelectionInNonEditableBlock = () => {
+  // Let browser handle event if selection is empty (nothing
+  // happens).
+  const selection = window.getSelection();
+  if (!selection || selection.isCollapsed) {
+    return true;
+  }
+
+  // Let browser handle event if it's within a non-editable
+  // "island". This means it's in selectable content within a
+  // non-editable block. We only need to check one node as it's
+  // not possible for the browser selection to start in an
+  // editable block and end in a non-editable one.
+  let node = selection.focusNode;
+  while (node) {
+    if (
+      node instanceof HTMLElement &&
+      node.getAttribute("contenteditable") === "false"
+    ) {
+      return true;
+    }
+
+    node = node.parentElement;
+  }
+
+  return false;
+};
+
 const copyToClipboard = <
   BSchema extends BlockSchema,
   I extends InlineContentSchema,
@@ -187,11 +215,19 @@ export const createCopyToClipboardExtension = <
           props: {
             handleDOMEvents: {
               copy(view, event) {
+                if (checkIfSelectionInNonEditableBlock()) {
+                  return true;
+                }
+
                 copyToClipboard(editor, view, event);
                 // Prevent default PM handler to be called
                 return true;
               },
               cut(view, event) {
+                if (checkIfSelectionInNonEditableBlock()) {
+                  return true;
+                }
+
                 copyToClipboard(editor, view, event);
                 if (view.editable) {
                   view.dispatch(view.state.tr.deleteSelection());


### PR DESCRIPTION
This PR does 2 things:

When the selection is empty, we no longer use our own cut/copy handling and instead let the browser handle the event (so nothing happens). Currently an error is thrown as we attempt to create clipboard data from an empty selection.

When the selection is within a descendant of a `"contenteditable"="false"` element, we no longer use our own cut/copy handling and instead let the browser handle the event. This means the user is selecting some content in a non-editable block. Currently the editor selection is copied instead as this scenario still triggers PM event handlers.

~TODO: Unit tests?~