### PR TITLE
fix: insertblocks when no type is provided

### DIFF
--- a/packages/core/src/api/blockManipulation/commands/insertBlocks/__snapshots__/insertBlocks.test.ts.snap
+++ b/packages/core/src/api/blockManipulation/commands/insertBlocks/__snapshots__/insertBlocks.test.ts.snap
@@ -1538,6 +1538,498 @@ exports[`Test insertBlocks > Insert single basic block after 1`] = `
 ]
 `;
 
+exports[`Test insertBlocks > Insert single basic block before (without type) 1`] = `
+[
+  {
+    "children": [],
+    "content": [
+      {
+        "styles": {},
+        "text": "test",
+        "type": "text",
+      },
+    ],
+    "id": "0",
+    "props": {
+      "backgroundColor": "default",
+      "textAlignment": "left",
+      "textColor": "default",
+    },
+    "type": "paragraph",
+  },
+  {
+    "children": [],
+    "content": [
+      {
+        "styles": {},
+        "text": "Paragraph 0",
+        "type": "text",
+      },
+    ],
+    "id": "paragraph-0",
+    "props": {
+      "backgroundColor": "default",
+      "textAlignment": "left",
+      "textColor": "default",
+    },
+    "type": "paragraph",
+  },
+  {
+    "children": [],
+    "content": [
+      {
+        "styles": {},
+        "text": "Paragraph 1",
+        "type": "text",
+      },
+    ],
+    "id": "paragraph-1",
+    "props": {
+      "backgroundColor": "default",
+      "textAlignment": "left",
+      "textColor": "default",
+    },
+    "type": "paragraph",
+  },
+  {
+    "children": [
+      {
+        "children": [
+          {
+            "children": [],
+            "content": [
+              {
+                "styles": {},
+                "text": "Double Nested Paragraph 0",
+                "type": "text",
+              },
+            ],
+            "id": "double-nested-paragraph-0",
+            "props": {
+              "backgroundColor": "default",
+              "textAlignment": "left",
+              "textColor": "default",
+            },
+            "type": "paragraph",
+          },
+        ],
+        "content": [
+          {
+            "styles": {},
+            "text": "Nested Paragraph 0",
+            "type": "text",
+          },
+        ],
+        "id": "nested-paragraph-0",
+        "props": {
+          "backgroundColor": "default",
+          "textAlignment": "left",
+          "textColor": "default",
+        },
+        "type": "paragraph",
+      },
+    ],
+    "content": [
+      {
+        "styles": {},
+        "text": "Paragraph with children",
+        "type": "text",
+      },
+    ],
+    "id": "paragraph-with-children",
+    "props": {
+      "backgroundColor": "default",
+      "textAlignment": "left",
+      "textColor": "default",
+    },
+    "type": "paragraph",
+  },
+  {
+    "children": [],
+    "content": [
+      {
+        "styles": {},
+        "text": "Paragraph 2",
+        "type": "text",
+      },
+    ],
+    "id": "paragraph-2",
+    "props": {
+      "backgroundColor": "default",
+      "textAlignment": "left",
+      "textColor": "default",
+    },
+    "type": "paragraph",
+  },
+  {
+    "children": [],
+    "content": [
+      {
+        "styles": {},
+        "text": "Paragraph with props",
+        "type": "text",
+      },
+    ],
+    "id": "paragraph-with-props",
+    "props": {
+      "backgroundColor": "default",
+      "textAlignment": "center",
+      "textColor": "red",
+    },
+    "type": "paragraph",
+  },
+  {
+    "children": [],
+    "content": [
+      {
+        "styles": {},
+        "text": "Paragraph 3",
+        "type": "text",
+      },
+    ],
+    "id": "paragraph-3",
+    "props": {
+      "backgroundColor": "default",
+      "textAlignment": "left",
+      "textColor": "default",
+    },
+    "type": "paragraph",
+  },
+  {
+    "children": [],
+    "content": [
+      {
+        "styles": {
+          "bold": true,
+        },
+        "text": "Paragraph",
+        "type": "text",
+      },
+      {
+        "styles": {},
+        "text": " with styled ",
+        "type": "text",
+      },
+      {
+        "styles": {
+          "italic": true,
+        },
+        "text": "content",
+        "type": "text",
+      },
+    ],
+    "id": "paragraph-with-styled-content",
+    "props": {
+      "backgroundColor": "default",
+      "textAlignment": "left",
+      "textColor": "default",
+    },
+    "type": "paragraph",
+  },
+  {
+    "children": [],
+    "content": [
+      {
+        "styles": {},
+        "text": "Paragraph 4",
+        "type": "text",
+      },
+    ],
+    "id": "paragraph-4",
+    "props": {
+      "backgroundColor": "default",
+      "textAlignment": "left",
+      "textColor": "default",
+    },
+    "type": "paragraph",
+  },
+  {
+    "children": [],
+    "content": [
+      {
+        "styles": {},
+        "text": "Heading 1",
+        "type": "text",
+      },
+    ],
+    "id": "heading-0",
+    "props": {
+      "backgroundColor": "default",
+      "level": 1,
+      "textAlignment": "left",
+      "textColor": "default",
+    },
+    "type": "heading",
+  },
+  {
+    "children": [],
+    "content": [
+      {
+        "styles": {},
+        "text": "Paragraph 5",
+        "type": "text",
+      },
+    ],
+    "id": "paragraph-5",
+    "props": {
+      "backgroundColor": "default",
+      "textAlignment": "left",
+      "textColor": "default",
+    },
+    "type": "paragraph",
+  },
+  {
+    "children": [],
+    "content": undefined,
+    "id": "image-0",
+    "props": {
+      "backgroundColor": "default",
+      "caption": "",
+      "name": "",
+      "previewWidth": 512,
+      "showPreview": true,
+      "textAlignment": "left",
+      "url": "https://via.placeholder.com/150",
+    },
+    "type": "image",
+  },
+  {
+    "children": [],
+    "content": [
+      {
+        "styles": {},
+        "text": "Paragraph 6",
+        "type": "text",
+      },
+    ],
+    "id": "paragraph-6",
+    "props": {
+      "backgroundColor": "default",
+      "textAlignment": "left",
+      "textColor": "default",
+    },
+    "type": "paragraph",
+  },
+  {
+    "children": [],
+    "content": {
+      "columnWidths": [
+        undefined,
+        undefined,
+        undefined,
+      ],
+      "rows": [
+        {
+          "cells": [
+            [
+              {
+                "styles": {},
+                "text": "Cell 1",
+                "type": "text",
+              },
+            ],
+            [
+              {
+                "styles": {},
+                "text": "Cell 2",
+                "type": "text",
+              },
+            ],
+            [
+              {
+                "styles": {},
+                "text": "Cell 3",
+                "type": "text",
+              },
+            ],
+          ],
+        },
+        {
+          "cells": [
+            [
+              {
+                "styles": {},
+                "text": "Cell 4",
+                "type": "text",
+              },
+            ],
+            [
+              {
+                "styles": {},
+                "text": "Cell 5",
+                "type": "text",
+              },
+            ],
+            [
+              {
+                "styles": {},
+                "text": "Cell 6",
+                "type": "text",
+              },
+            ],
+          ],
+        },
+        {
+          "cells": [
+            [
+              {
+                "styles": {},
+                "text": "Cell 7",
+                "type": "text",
+              },
+            ],
+            [
+              {
+                "styles": {},
+                "text": "Cell 8",
+                "type": "text",
+              },
+            ],
+            [
+              {
+                "styles": {},
+                "text": "Cell 9",
+                "type": "text",
+              },
+            ],
+          ],
+        },
+      ],
+      "type": "tableContent",
+    },
+    "id": "table-0",
+    "props": {
+      "textColor": "default",
+    },
+    "type": "table",
+  },
+  {
+    "children": [],
+    "content": [
+      {
+        "styles": {},
+        "text": "Paragraph 7",
+        "type": "text",
+      },
+    ],
+    "id": "paragraph-7",
+    "props": {
+      "backgroundColor": "default",
+      "textAlignment": "left",
+      "textColor": "default",
+    },
+    "type": "paragraph",
+  },
+  {
+    "children": [],
+    "content": [],
+    "id": "empty-paragraph",
+    "props": {
+      "backgroundColor": "default",
+      "textAlignment": "left",
+      "textColor": "default",
+    },
+    "type": "paragraph",
+  },
+  {
+    "children": [],
+    "content": [
+      {
+        "styles": {},
+        "text": "Paragraph 8",
+        "type": "text",
+      },
+    ],
+    "id": "paragraph-8",
+    "props": {
+      "backgroundColor": "default",
+      "textAlignment": "left",
+      "textColor": "default",
+    },
+    "type": "paragraph",
+  },
+  {
+    "children": [
+      {
+        "children": [
+          {
+            "children": [],
+            "content": [
+              {
+                "styles": {},
+                "text": "Double Nested Paragraph 1",
+                "type": "text",
+              },
+            ],
+            "id": "double-nested-paragraph-1",
+            "props": {
+              "backgroundColor": "default",
+              "textAlignment": "left",
+              "textColor": "default",
+            },
+            "type": "paragraph",
+          },
+        ],
+        "content": [
+          {
+            "styles": {},
+            "text": "Nested Paragraph 1",
+            "type": "text",
+          },
+        ],
+        "id": "nested-paragraph-1",
+        "props": {
+          "backgroundColor": "default",
+          "textAlignment": "left",
+          "textColor": "default",
+        },
+        "type": "paragraph",
+      },
+    ],
+    "content": [
+      {
+        "styles": {
+          "bold": true,
+        },
+        "text": "Heading",
+        "type": "text",
+      },
+      {
+        "styles": {},
+        "text": " with styled ",
+        "type": "text",
+      },
+      {
+        "styles": {
+          "italic": true,
+        },
+        "text": "content",
+        "type": "text",
+      },
+    ],
+    "id": "heading-with-everything",
+    "props": {
+      "backgroundColor": "red",
+      "level": 2,
+      "textAlignment": "center",
+      "textColor": "red",
+    },
+    "type": "heading",
+  },
+  {
+    "children": [],
+    "content": [],
+    "id": "trailing-paragraph",
+    "props": {
+      "backgroundColor": "default",
+      "textAlignment": "left",
+      "textColor": "default",
+    },
+    "type": "paragraph",
+  },
+]
+`;
+
 exports[`Test insertBlocks > Insert single basic block before 1`] = `
 [
   {

--- a/packages/core/src/api/blockManipulation/commands/insertBlocks/insertBlocks.test.ts
+++ b/packages/core/src/api/blockManipulation/commands/insertBlocks/insertBlocks.test.ts
@@ -6,6 +6,12 @@ import { insertBlocks } from "./insertBlocks.js";
 const getEditor = setupTestEnv();
 
 describe("Test insertBlocks", () => {
+  it("Insert single basic block before (without type)", () => {
+    insertBlocks(getEditor(), [{ content: "test" }], "paragraph-0", "before");
+
+    expect(getEditor().document).toMatchSnapshot();
+  });
+
   it("Insert single basic block before", () => {
     insertBlocks(getEditor(), [{ type: "paragraph" }], "paragraph-0", "before");
 

--- a/packages/core/src/api/nodeConversions/blockToNode.ts
+++ b/packages/core/src/api/nodeConversions/blockToNode.ts
@@ -1,4 +1,4 @@
-import { Mark, Node, NodeType, Schema } from "@tiptap/pm/model";
+import { Mark, Node, Schema } from "@tiptap/pm/model";
 
 import UniqueID from "../../extensions/UniqueID/UniqueID.js";
 import type {
@@ -279,13 +279,11 @@ export function blockToNode(
     }
   }
 
-  const nodeTypeCorrespondingToBlock: NodeType | undefined =
-    schema.nodes[block.type];
+  const isBlockContent =
+    !block.type || // can happen if block.type is not defined (this should create the default node)
+    schema.nodes[block.type].isInGroup("blockContent");
 
-  if (
-    !nodeTypeCorrespondingToBlock || // can happen if block.type is not (this should create the default node)
-    nodeTypeCorrespondingToBlock.isInGroup("blockContent")
-  ) {
+  if (isBlockContent) {
     // Blocks with a type that matches "blockContent" group always need to be wrapped in a blockContainer
 
     const contentNode = blockOrInlineContentToContentNode(

--- a/packages/core/src/api/nodeConversions/blockToNode.ts
+++ b/packages/core/src/api/nodeConversions/blockToNode.ts
@@ -304,7 +304,7 @@ export function blockToNode(
       },
       groupNode ? [contentNode, groupNode] : contentNode
     );
-  } else if (nodeTypeCorrespondingToBlock.isInGroup("bnBlock")) {
+  } else if (schema.nodes[block.type].isInGroup("bnBlock")) {
     // this is a bnBlock node like Column or ColumnList that directly translates to a prosemirror node
     return schema.nodes[block.type].createChecked(
       {

--- a/packages/core/src/api/nodeConversions/blockToNode.ts
+++ b/packages/core/src/api/nodeConversions/blockToNode.ts
@@ -281,7 +281,10 @@ export function blockToNode(
 
   const nodeTypeCorrespondingToBlock = schema.nodes[block.type];
 
-  if (nodeTypeCorrespondingToBlock.isInGroup("blockContent")) {
+  if (
+    !nodeTypeCorrespondingToBlock || // can happen if block.type is not (this should create the default node)
+    nodeTypeCorrespondingToBlock.isInGroup("blockContent")
+  ) {
     // Blocks with a type that matches "blockContent" group always need to be wrapped in a blockContainer
 
     const contentNode = blockOrInlineContentToContentNode(

--- a/packages/core/src/api/nodeConversions/blockToNode.ts
+++ b/packages/core/src/api/nodeConversions/blockToNode.ts
@@ -1,4 +1,4 @@
-import { Mark, Node, Schema } from "@tiptap/pm/model";
+import { Mark, Node, NodeType, Schema } from "@tiptap/pm/model";
 
 import UniqueID from "../../extensions/UniqueID/UniqueID.js";
 import type {
@@ -279,7 +279,8 @@ export function blockToNode(
     }
   }
 
-  const nodeTypeCorrespondingToBlock = schema.nodes[block.type];
+  const nodeTypeCorrespondingToBlock: NodeType | undefined =
+    schema.nodes[block.type];
 
   if (
     !nodeTypeCorrespondingToBlock || // can happen if block.type is not (this should create the default node)


### PR DESCRIPTION
This addresses a regression after multi-column where `insertBlocks` (and `blockToNode`) would throw an error if no block type was provided in the partialblock. Also added unit test

closes #1408 