### PR TITLE
feat: add support for tiptap / liveblocks comments

### DIFF
--- a/packages/core/src/api/nodeConversions/nodeToBlock.ts
+++ b/packages/core/src/api/nodeConversions/nodeToBlock.ts
@@ -131,9 +131,9 @@ export function contentNodeToInlineContent<
       } else {
         const config = styleSchema[mark.type.name];
         if (!config) {
-          if (mark.type.spec.group?.includes("blocknoteIgnore")) {
+          if (mark.type.spec.blocknoteIgnore) {
             // at this point, we don't want to show certain marks (such as comments)
-            // in the BlockNote JSON output. These marks should have "blocknoteIgnore" in their group
+            // in the BlockNote JSON output. These marks should be tagged with "blocknoteIgnore" in the spec
             continue;
           }
           throw new Error(`style ${mark.type.name} not found in styleSchema`);

--- a/packages/core/src/api/nodeConversions/nodeToBlock.ts
+++ b/packages/core/src/api/nodeConversions/nodeToBlock.ts
@@ -104,11 +104,12 @@ export function contentNodeToInlineContent<
       return;
     }
 
-    if (
-      node.type.name !== "link" &&
-      node.type.name !== "text" &&
-      inlineContentSchema[node.type.name]
-    ) {
+    if (node.type.name !== "link" && node.type.name !== "text") {
+      if (!inlineContentSchema[node.type.name]) {
+        // eslint-disable-next-line no-console
+        console.warn("unrecognized inline content type", node.type.name);
+        return;
+      }
       if (currentContent) {
         content.push(currentContent);
         currentContent = undefined;
@@ -130,6 +131,11 @@ export function contentNodeToInlineContent<
       } else {
         const config = styleSchema[mark.type.name];
         if (!config) {
+          if (mark.type.spec.group?.includes("blocknoteIgnore")) {
+            // at this point, we don't want to show certain marks (such as comments)
+            // in the BlockNote JSON output. These marks should have "blocknoteIgnore" in their group
+            continue;
+          }
           throw new Error(`style ${mark.type.name} not found in styleSchema`);
         }
         if (config.propSchema === "boolean") {

--- a/packages/core/src/editor/BlockNoteEditor.ts
+++ b/packages/core/src/editor/BlockNoteEditor.ts
@@ -938,7 +938,7 @@ export class BlockNoteEditor<
           // Links are not considered styles in blocknote
           mark.type.name !== "link" &&
           // "blocknoteIgnore" tagged marks (such as comments) are also not considered BlockNote "styles"
-          !mark.type.spec.group?.includes("blocknoteIgnore")
+          !mark.type.spec.blocknoteIgnore
         ) {
           // eslint-disable-next-line no-console
           console.warn("mark not found in styleschema", mark.type.name);

--- a/packages/core/src/editor/BlockNoteEditor.ts
+++ b/packages/core/src/editor/BlockNoteEditor.ts
@@ -489,7 +489,11 @@ export class BlockNoteEditor<
     this.resolveFileUrl = newOptions.resolveFileUrl;
     this.headless = newOptions._headless;
 
-    if (newOptions.collaboration && newOptions.initialContent) {
+    const collaborationEnabled =
+      "collaboration" in this.extensions ||
+      "liveblocksExtension" in this.extensions;
+
+    if (collaborationEnabled && newOptions.initialContent) {
       // eslint-disable-next-line no-console
       console.warn(
         "When using Collaboration, initialContent might cause conflicts, because changes should come from the collaboration provider"
@@ -498,7 +502,7 @@ export class BlockNoteEditor<
 
     const initialContent =
       newOptions.initialContent ||
-      (options.collaboration
+      (collaborationEnabled
         ? [
             {
               type: "paragraph",
@@ -930,7 +934,12 @@ export class BlockNoteEditor<
     for (const mark of marks) {
       const config = this.schema.styleSchema[mark.type.name];
       if (!config) {
-        if (mark.type.name !== "link") {
+        if (
+          // Links are not considered styles in blocknote
+          mark.type.name !== "link" &&
+          // "blocknoteIgnore" tagged marks (such as comments) are also not considered BlockNote "styles"
+          !mark.type.spec.group?.includes("blocknoteIgnore")
+        ) {
           // eslint-disable-next-line no-console
           console.warn("mark not found in styleschema", mark.type.name);
         }

--- a/packages/core/src/i18n/locales/ar.ts
+++ b/packages/core/src/i18n/locales/ar.ts
@@ -261,6 +261,9 @@ export const ar: Dictionary = {
     align_justify: {
       tooltip: "ضبط النص",
     },
+    comment: {
+      tooltip: "إضافة ملاحظة",
+    },
   },
   file_panel: {
     upload: {

--- a/packages/core/src/i18n/locales/de.ts
+++ b/packages/core/src/i18n/locales/de.ts
@@ -273,6 +273,9 @@ export const de = {
     align_justify: {
       tooltip: "Text Blocksatz",
     },
+    comment: {
+      tooltip: "Kommentar hinzufügen",
+    },
   },
   file_panel: {
     upload: {

--- a/packages/core/src/i18n/locales/en.ts
+++ b/packages/core/src/i18n/locales/en.ts
@@ -275,6 +275,9 @@ export const en = {
     align_justify: {
       tooltip: "Justify text",
     },
+    comment: {
+      tooltip: "Add comment",
+    },
   },
   file_panel: {
     upload: {

--- a/packages/core/src/i18n/locales/es.ts
+++ b/packages/core/src/i18n/locales/es.ts
@@ -272,6 +272,9 @@ export const es = {
     align_justify: {
       tooltip: "Justificar texto",
     },
+    comment: {
+      tooltip: "Agregar comentario",
+    },
   },
   file_panel: {
     upload: {

--- a/packages/core/src/i18n/locales/fr.ts
+++ b/packages/core/src/i18n/locales/fr.ts
@@ -300,6 +300,9 @@ export const fr: Dictionary = {
     align_justify: {
       tooltip: "Justifier le texte",
     },
+    comment: {
+      tooltip: "Ajouter un commentaire",
+    },
   },
   file_panel: {
     upload: {

--- a/packages/core/src/i18n/locales/hr.ts
+++ b/packages/core/src/i18n/locales/hr.ts
@@ -281,6 +281,9 @@ export const hr = {
     align_justify: {
       tooltip: "Poravnaj tekst obostrano",
     },
+    comment: {
+      tooltip: "Dodaj komentar",
+    },
   },
   file_panel: {
     upload: {

--- a/packages/core/src/i18n/locales/is.ts
+++ b/packages/core/src/i18n/locales/is.ts
@@ -268,6 +268,9 @@ export const is: Dictionary = {
     align_justify: {
       tooltip: "Jafna texta",
     },
+    comment: {
+      tooltip: "Bæta við athugun",
+    },
   },
   file_panel: {
     upload: {

--- a/packages/core/src/i18n/locales/it.ts
+++ b/packages/core/src/i18n/locales/it.ts
@@ -1,315 +1,317 @@
 export const it = {
-    slash_menu: {
-      heading: {
-        title: "Intestazione 1",
-        subtext: "Intestazione di primo livello",
-        aliases: ["h", "intestazione1", "h1"],
-        group: "Intestazioni",
-      },
-      heading_2: {
-        title: "Intestazione 2",
-        subtext: "Intestazione di sezione chiave",
-        aliases: ["h2", "intestazione2", "sottotitolo"],
-        group: "Intestazioni",
-      },
-      heading_3: {
-        title: "Intestazione 3",
-        subtext: "Intestazione di sottosezione e gruppo",
-        aliases: ["h3", "intestazione3", "sottotitolo"],
-        group: "Intestazioni",
-      },
-      numbered_list: {
-        title: "Elenco Numerato",
-        subtext: "Elenco con elementi ordinati",
-        aliases: ["ol", "li", "elenco", "elenconumerato", "elenco numerato"],
-        group: "Blocchi Base",
-      },
-      bullet_list: {
-        title: "Elenco Puntato",
-        subtext: "Elenco con elementi non ordinati",
-        aliases: ["ul", "li", "elenco", "elencopuntato", "elenco puntato"],
-        group: "Blocchi Base",
-      },
-      check_list: {
-        title: "Elenco di Controllo",
-        subtext: "Elenco con caselle di controllo",
-        aliases: [
-          "ul",
-          "li",
-          "elenco",
-          "elencocontrollo",
-          "elenco controllo",
-          "elenco verificato",
-          "casella di controllo",
-        ],
-        group: "Blocchi Base",
-      },
-      paragraph: {
-        title: "Paragrafo",
-        subtext: "Il corpo del tuo documento",
-        aliases: ["p", "paragrafo"],
-        group: "Blocchi Base",
-      },
-      code_block: {
-        title: "Blocco di Codice",
-        subtext: "Blocco di codice con evidenziazione della sintassi",
-        aliases: ["code", "pre"],
-        group: "Blocchi Base",
-      },
-      table: {
-        title: "Tabella",
-        subtext: "Tabella con celle modificabili",
-        aliases: ["tabella"],
-        group: "Avanzato",
-      },
-      image: {
-        title: "Immagine",
-        subtext: "Immagine ridimensionabile con didascalia",
-        aliases: [
-          "immagine",
-          "caricaImmagine",
-          "carica",
-          "img",
-          "foto",
-          "media",
-          "url",
-        ],
-        group: "Media",
-      },
-      video: {
-        title: "Video",
-        subtext: "Video ridimensionabile con didascalia",
-        aliases: [
-          "video",
-          "caricaVideo",
-          "carica",
-          "mp4",
-          "film",
-          "media",
-          "url",
-        ],
-        group: "Media",
-      },
-      audio: {
-        title: "Audio",
-        subtext: "Audio incorporato con didascalia",
-        aliases: [
-          "audio",
-          "caricaAudio",
-          "carica",
-          "mp3",
-          "suono",
-          "media",
-          "url",
-        ],
-        group: "Media",
-      },
-      file: {
-        title: "File",
-        subtext: "File incorporato",
-        aliases: ["file", "carica", "embed", "media", "url"],
-        group: "Media",
-      },
-      emoji: {
-        title: "Emoji",
-        subtext: "Cerca e inserisci un'emoji",
-        aliases: ["emoji", "emote", "emozione", "faccia"],
-        group: "Altri",
-      },
+  slash_menu: {
+    heading: {
+      title: "Intestazione 1",
+      subtext: "Intestazione di primo livello",
+      aliases: ["h", "intestazione1", "h1"],
+      group: "Intestazioni",
     },
-    placeholders: {
-      default: "Inserisci testo o digita '/' per i comandi",
-      heading: "Intestazione",
-      bulletListItem: "Elenco",
-      numberedListItem: "Elenco",
-      checkListItem: "Elenco",
+    heading_2: {
+      title: "Intestazione 2",
+      subtext: "Intestazione di sezione chiave",
+      aliases: ["h2", "intestazione2", "sottotitolo"],
+      group: "Intestazioni",
     },
-    file_blocks: {
-      image: {
-        add_button_text: "Aggiungi immagine",
-      },
-      video: {
-        add_button_text: "Aggiungi video",
-      },
-      audio: {
-        add_button_text: "Aggiungi audio",
-      },
-      file: {
-        add_button_text: "Aggiungi file",
-      },
+    heading_3: {
+      title: "Intestazione 3",
+      subtext: "Intestazione di sottosezione e gruppo",
+      aliases: ["h3", "intestazione3", "sottotitolo"],
+      group: "Intestazioni",
     },
-    // from react package:
-    side_menu: {
-      add_block_label: "Aggiungi blocco",
-      drag_handle_label: "Apri menu blocco",
+    numbered_list: {
+      title: "Elenco Numerato",
+      subtext: "Elenco con elementi ordinati",
+      aliases: ["ol", "li", "elenco", "elenconumerato", "elenco numerato"],
+      group: "Blocchi Base",
     },
-    drag_handle: {
-      delete_menuitem: "Elimina",
-      colors_menuitem: "Colori",
+    bullet_list: {
+      title: "Elenco Puntato",
+      subtext: "Elenco con elementi non ordinati",
+      aliases: ["ul", "li", "elenco", "elencopuntato", "elenco puntato"],
+      group: "Blocchi Base",
     },
-    table_handle: {
-      delete_column_menuitem: "Elimina colonna",
-      delete_row_menuitem: "Elimina riga",
-      add_left_menuitem: "Aggiungi colonna a sinistra",
-      add_right_menuitem: "Aggiungi colonna a destra",
-      add_above_menuitem: "Aggiungi riga sopra",
-      add_below_menuitem: "Aggiungi riga sotto",
+    check_list: {
+      title: "Elenco di Controllo",
+      subtext: "Elenco con caselle di controllo",
+      aliases: [
+        "ul",
+        "li",
+        "elenco",
+        "elencocontrollo",
+        "elenco controllo",
+        "elenco verificato",
+        "casella di controllo",
+      ],
+      group: "Blocchi Base",
     },
-    suggestion_menu: {
-      no_items_title: "Nessun elemento trovato",
-      loading: "Caricamento…",
+    paragraph: {
+      title: "Paragrafo",
+      subtext: "Il corpo del tuo documento",
+      aliases: ["p", "paragrafo"],
+      group: "Blocchi Base",
     },
-    color_picker: {
-      text_title: "Testo",
-      background_title: "Sfondo",
-      colors: {
-        default: "Predefinito",
-        gray: "Grigio",
-        brown: "Marrone",
-        red: "Rosso",
-        orange: "Arancione",
-        yellow: "Giallo",
-        green: "Verde",
-        blue: "Blu",
-        purple: "Viola",
-        pink: "Rosa",
-      },
+    code_block: {
+      title: "Blocco di Codice",
+      subtext: "Blocco di codice con evidenziazione della sintassi",
+      aliases: ["code", "pre"],
+      group: "Blocchi Base",
     },
-  
-    formatting_toolbar: {
-      bold: {
-        tooltip: "Grassetto",
-        secondary_tooltip: "Cmd+B",
-      },
-      italic: {
-        tooltip: "Corsivo",
-        secondary_tooltip: "Cmd+I",
-      },
-      underline: {
-        tooltip: "Sottolineato",
-        secondary_tooltip: "Cmd+U",
-      },
-      strike: {
-        tooltip: "Barrato",
-        secondary_tooltip: "Cmd+Shift+S",
-      },
-      code: {
-        tooltip: "Codice",
-        secondary_tooltip: "",
-      },
-      colors: {
-        tooltip: "Colori",
-      },
-      link: {
-        tooltip: "Crea link",
-        secondary_tooltip: "Cmd+K",
-      },
-      file_caption: {
-        tooltip: "Modifica didascalia",
-        input_placeholder: "Modifica didascalia",
-      },
-      file_replace: {
-        tooltip: {
-          image: "Sostituisci immagine",
-          video: "Sostituisci video",
-          audio: "Sostituisci audio",
-          file: "Sostituisci file",
-        } as Record<string, string>,
-      },
-      file_rename: {
-        tooltip: {
-          image: "Rinomina immagine",
-          video: "Rinomina video",
-          audio: "Rinomina audio",
-          file: "Rinomina file",
-        } as Record<string, string>,
-        input_placeholder: {
-          image: "Rinomina immagine",
-          video: "Rinomina video",
-          audio: "Rinomina audio",
-          file: "Rinomina file",
-        } as Record<string, string>,
-      },
-      file_download: {
-        tooltip: {
-          image: "Scarica immagine",
-          video: "Scarica video",
-          audio: "Scarica audio",
-          file: "Scarica file",
-        } as Record<string, string>,
-      },
-      file_delete: {
-        tooltip: {
-          image: "Elimina immagine",
-          video: "Elimina video",
-          audio: "Elimina audio",
-          file: "Elimina file",
-        } as Record<string, string>,
-      },
-      file_preview_toggle: {
-        tooltip: "Attiva/disattiva anteprima",
-      },
-      nest: {
-        tooltip: "Annida blocco",
-        secondary_tooltip: "Tab",
-      },
-      unnest: {
-        tooltip: "Disannida blocco",
-        secondary_tooltip: "Shift+Tab",
-      },
-      align_left: {
-        tooltip: "Allinea testo a sinistra",
-      },
-      align_center: {
-        tooltip: "Allinea testo al centro",
-      },
-      align_right: {
-        tooltip: "Allinea testo a destra",
-      },
-      align_justify: {
-        tooltip: "Giustifica testo",
-      },
+    table: {
+      title: "Tabella",
+      subtext: "Tabella con celle modificabili",
+      aliases: ["tabella"],
+      group: "Avanzato",
     },
-    file_panel: {
-      upload: {
-        title: "Carica",
-        file_placeholder: {
-          image: "Carica immagine",
-          video: "Carica video",
-          audio: "Carica audio",
-          file: "Carica file",
-        } as Record<string, string>,
-        upload_error: "Errore: Caricamento fallito",
-      },
-      embed: {
-        title: "Incorpora",
-        embed_button: {
-          image: "Incorpora immagine",
-          video: "Incorpora video",
-          audio: "Incorpora audio",
-          file: "Incorpora file",
-        } as Record<string, string>,
-        url_placeholder: "Inserisci URL",
-      },
+    image: {
+      title: "Immagine",
+      subtext: "Immagine ridimensionabile con didascalia",
+      aliases: [
+        "immagine",
+        "caricaImmagine",
+        "carica",
+        "img",
+        "foto",
+        "media",
+        "url",
+      ],
+      group: "Media",
     },
-    link_toolbar: {
-      delete: {
-        tooltip: "Rimuovi link",
-      },
-      edit: {
-        text: "Modifica link",
-        tooltip: "Modifica",
-      },
-      open: {
-        tooltip: "Apri in una nuova scheda",
-      },
-      form: {
-        title_placeholder: "Modifica titolo",
-        url_placeholder: "Modifica URL",
-      },
+    video: {
+      title: "Video",
+      subtext: "Video ridimensionabile con didascalia",
+      aliases: [
+        "video",
+        "caricaVideo",
+        "carica",
+        "mp4",
+        "film",
+        "media",
+        "url",
+      ],
+      group: "Media",
     },
-    generic: {
-      ctrl_shortcut: "Ctrl",
+    audio: {
+      title: "Audio",
+      subtext: "Audio incorporato con didascalia",
+      aliases: [
+        "audio",
+        "caricaAudio",
+        "carica",
+        "mp3",
+        "suono",
+        "media",
+        "url",
+      ],
+      group: "Media",
     },
-  };
-  
+    file: {
+      title: "File",
+      subtext: "File incorporato",
+      aliases: ["file", "carica", "embed", "media", "url"],
+      group: "Media",
+    },
+    emoji: {
+      title: "Emoji",
+      subtext: "Cerca e inserisci un'emoji",
+      aliases: ["emoji", "emote", "emozione", "faccia"],
+      group: "Altri",
+    },
+  },
+  placeholders: {
+    default: "Inserisci testo o digita '/' per i comandi",
+    heading: "Intestazione",
+    bulletListItem: "Elenco",
+    numberedListItem: "Elenco",
+    checkListItem: "Elenco",
+  },
+  file_blocks: {
+    image: {
+      add_button_text: "Aggiungi immagine",
+    },
+    video: {
+      add_button_text: "Aggiungi video",
+    },
+    audio: {
+      add_button_text: "Aggiungi audio",
+    },
+    file: {
+      add_button_text: "Aggiungi file",
+    },
+  },
+  // from react package:
+  side_menu: {
+    add_block_label: "Aggiungi blocco",
+    drag_handle_label: "Apri menu blocco",
+  },
+  drag_handle: {
+    delete_menuitem: "Elimina",
+    colors_menuitem: "Colori",
+  },
+  table_handle: {
+    delete_column_menuitem: "Elimina colonna",
+    delete_row_menuitem: "Elimina riga",
+    add_left_menuitem: "Aggiungi colonna a sinistra",
+    add_right_menuitem: "Aggiungi colonna a destra",
+    add_above_menuitem: "Aggiungi riga sopra",
+    add_below_menuitem: "Aggiungi riga sotto",
+  },
+  suggestion_menu: {
+    no_items_title: "Nessun elemento trovato",
+    loading: "Caricamento…",
+  },
+  color_picker: {
+    text_title: "Testo",
+    background_title: "Sfondo",
+    colors: {
+      default: "Predefinito",
+      gray: "Grigio",
+      brown: "Marrone",
+      red: "Rosso",
+      orange: "Arancione",
+      yellow: "Giallo",
+      green: "Verde",
+      blue: "Blu",
+      purple: "Viola",
+      pink: "Rosa",
+    },
+  },
+
+  formatting_toolbar: {
+    bold: {
+      tooltip: "Grassetto",
+      secondary_tooltip: "Cmd+B",
+    },
+    italic: {
+      tooltip: "Corsivo",
+      secondary_tooltip: "Cmd+I",
+    },
+    underline: {
+      tooltip: "Sottolineato",
+      secondary_tooltip: "Cmd+U",
+    },
+    strike: {
+      tooltip: "Barrato",
+      secondary_tooltip: "Cmd+Shift+S",
+    },
+    code: {
+      tooltip: "Codice",
+      secondary_tooltip: "",
+    },
+    colors: {
+      tooltip: "Colori",
+    },
+    link: {
+      tooltip: "Crea link",
+      secondary_tooltip: "Cmd+K",
+    },
+    file_caption: {
+      tooltip: "Modifica didascalia",
+      input_placeholder: "Modifica didascalia",
+    },
+    file_replace: {
+      tooltip: {
+        image: "Sostituisci immagine",
+        video: "Sostituisci video",
+        audio: "Sostituisci audio",
+        file: "Sostituisci file",
+      } as Record<string, string>,
+    },
+    file_rename: {
+      tooltip: {
+        image: "Rinomina immagine",
+        video: "Rinomina video",
+        audio: "Rinomina audio",
+        file: "Rinomina file",
+      } as Record<string, string>,
+      input_placeholder: {
+        image: "Rinomina immagine",
+        video: "Rinomina video",
+        audio: "Rinomina audio",
+        file: "Rinomina file",
+      } as Record<string, string>,
+    },
+    file_download: {
+      tooltip: {
+        image: "Scarica immagine",
+        video: "Scarica video",
+        audio: "Scarica audio",
+        file: "Scarica file",
+      } as Record<string, string>,
+    },
+    file_delete: {
+      tooltip: {
+        image: "Elimina immagine",
+        video: "Elimina video",
+        audio: "Elimina audio",
+        file: "Elimina file",
+      } as Record<string, string>,
+    },
+    file_preview_toggle: {
+      tooltip: "Attiva/disattiva anteprima",
+    },
+    nest: {
+      tooltip: "Annida blocco",
+      secondary_tooltip: "Tab",
+    },
+    unnest: {
+      tooltip: "Disannida blocco",
+      secondary_tooltip: "Shift+Tab",
+    },
+    align_left: {
+      tooltip: "Allinea testo a sinistra",
+    },
+    align_center: {
+      tooltip: "Allinea testo al centro",
+    },
+    align_right: {
+      tooltip: "Allinea testo a destra",
+    },
+    align_justify: {
+      tooltip: "Giustifica testo",
+    },
+    comment: {
+      tooltip: "Aggiungi commento",
+    },
+  },
+  file_panel: {
+    upload: {
+      title: "Carica",
+      file_placeholder: {
+        image: "Carica immagine",
+        video: "Carica video",
+        audio: "Carica audio",
+        file: "Carica file",
+      } as Record<string, string>,
+      upload_error: "Errore: Caricamento fallito",
+    },
+    embed: {
+      title: "Incorpora",
+      embed_button: {
+        image: "Incorpora immagine",
+        video: "Incorpora video",
+        audio: "Incorpora audio",
+        file: "Incorpora file",
+      } as Record<string, string>,
+      url_placeholder: "Inserisci URL",
+    },
+  },
+  link_toolbar: {
+    delete: {
+      tooltip: "Rimuovi link",
+    },
+    edit: {
+      text: "Modifica link",
+      tooltip: "Modifica",
+    },
+    open: {
+      tooltip: "Apri in una nuova scheda",
+    },
+    form: {
+      title_placeholder: "Modifica titolo",
+      url_placeholder: "Modifica URL",
+    },
+  },
+  generic: {
+    ctrl_shortcut: "Ctrl",
+  },
+};

--- a/packages/core/src/i18n/locales/ja.ts
+++ b/packages/core/src/i18n/locales/ja.ts
@@ -296,6 +296,9 @@ export const ja: Dictionary = {
     align_justify: {
       tooltip: "両端揃え",
     },
+    comment: {
+      tooltip: "コメントを追加",
+    },
   },
   file_panel: {
     upload: {

--- a/packages/core/src/i18n/locales/ko.ts
+++ b/packages/core/src/i18n/locales/ko.ts
@@ -289,6 +289,9 @@ export const ko: Dictionary = {
     align_justify: {
       tooltip: "텍스트 양쪽 맞춤",
     },
+    comment: {
+      tooltip: "코멘트 추가",
+    },
   },
   file_panel: {
     upload: {

--- a/packages/core/src/i18n/locales/nl.ts
+++ b/packages/core/src/i18n/locales/nl.ts
@@ -275,6 +275,9 @@ export const nl: Dictionary = {
     align_justify: {
       tooltip: "Tekst uitvullen",
     },
+    comment: {
+      tooltip: "Commentaar toevoegen",
+    },
   },
   file_panel: {
     upload: {

--- a/packages/core/src/i18n/locales/pl.ts
+++ b/packages/core/src/i18n/locales/pl.ts
@@ -260,6 +260,9 @@ export const pl: Dictionary = {
     align_justify: {
       tooltip: "Wyjustuj tekst",
     },
+    comment: {
+      tooltip: "Dodaj komentarz",
+    },
   },
   file_panel: {
     upload: {

--- a/packages/core/src/i18n/locales/pt.ts
+++ b/packages/core/src/i18n/locales/pt.ts
@@ -268,6 +268,9 @@ export const pt: Dictionary = {
     align_justify: {
       tooltip: "Justificar texto",
     },
+    comment: {
+      tooltip: "Adicionar comentário",
+    },
   },
   file_panel: {
     upload: {

--- a/packages/core/src/i18n/locales/ru.ts
+++ b/packages/core/src/i18n/locales/ru.ts
@@ -303,6 +303,9 @@ export const ru: Dictionary = {
     align_justify: {
       tooltip: "По середине текст",
     },
+    comment: {
+      tooltip: "Добавить комментарий",
+    },
   },
   file_panel: {
     upload: {

--- a/packages/core/src/i18n/locales/uk.ts
+++ b/packages/core/src/i18n/locales/uk.ts
@@ -1,289 +1,348 @@
 import { Dictionary } from "../dictionary.js";
 
 export const uk: Dictionary = {
-    slash_menu: {
-        heading: {
-          title: "Заголовок 1",
-          subtext: "Заголовок найвищого рівня",
-          aliases: ["h", "heading1", "h1", "заголовок1"],
-          group: "Заголовки",
-        },
-        heading_2: {
-          title: "Заголовок 2",
-          subtext: "Основний заголовок розділу",
-          aliases: ["h2", "heading2", "subheading", "заголовок2"],
-          group: "Заголовки",
-        },
-        heading_3: {
-          title: "Заголовок 3",
-          subtext: "Підзаголовок і груповий заголовок",
-          aliases: ["h3", "heading3", "subheading", "заголовок3"],
-          group: "Заголовки",
-        },
-        numbered_list: {
-          title: "Нумерований список",
-          subtext: "Список із впорядкованими елементами",
-          aliases: ["ol", "li", "list", "numberedlist", "numbered list", "список", "нумерований список"],
-          group: "Базові блоки",
-        },
-        bullet_list: {
-          title: "Маркований список",
-          subtext: "Список із невпорядкованими елементами",
-          aliases: ["ul", "li", "list", "bulletlist", "bullet list", "список", "маркований список"],
-          group: "Базові блоки",
-        },
-        check_list: {
-          title: "Чек-лист",
-          subtext: "Список із чекбоксами",
-          aliases: ["ul", "li", "list", "checklist", "check list", "checked list", "checkbox", "чекбокс", "чек-лист"],
-          group: "Базові блоки",
-        },
-        paragraph: {
-          title: "Параграф",
-          subtext: "Основний текст документа",
-          aliases: ["p", "paragraph", "параграф"],
-          group: "Базові блоки",
-        },
-        code_block: {
-          title: "Блок коду",
-          subtext: "Блок коду з підсвіткою синтаксису",
-          aliases: ["code", "pre", "блок коду"],
-          group: "Базові блоки",
-        },
-        page_break: {
-          title: "Розрив сторінки",
-          subtext: "Роздільник сторінки",
-          aliases: ["page", "break", "separator", "розрив сторінки", "розділювач"],
-          group: "Базові блоки",
-        },
-        table: {
-          title: "Таблиця",
-          subtext: "Таблиця з редагованими клітинками",
-          aliases: ["table", "таблиця"],
-          group: "Розширені",
-        },
-        image: {
-          title: "Зображення",
-          subtext: "Масштабоване зображення з підписом",
-          aliases: ["image", "imageUpload", "upload", "img", "picture", "media", "url", "зображення", "медіа"],
-          group: "Медіа",
-        },
-        video: {
-          title: "Відео",
-          subtext: "Масштабоване відео з підписом",
-          aliases: ["video", "videoUpload", "upload", "mp4", "film", "media", "url", "відео", "медіа"],
-          group: "Медіа",
-        },
-        audio: {
-          title: "Аудіо",
-          subtext: "Вбудоване аудіо з підписом",
-          aliases: ["audio", "audioUpload", "upload", "mp3", "sound", "media", "url", "аудіо", "медіа"],
-          group: "Медіа",
-        },
-        file: {
-          title: "Файл",
-          subtext: "Вбудований файл",
-          aliases: ["file", "upload", "embed", "media", "url", "файл", "медіа"],
-          group: "Медіа",
-        },
-        emoji: {
-          title: "Емодзі",
-          subtext: "Пошук і вставка емодзі",
-          aliases: ["emoji", "emote", "emotion", "face", "смайлик", "емодзі"],
-          group: "Інше",
-        },
+  slash_menu: {
+    heading: {
+      title: "Заголовок 1",
+      subtext: "Заголовок найвищого рівня",
+      aliases: ["h", "heading1", "h1", "заголовок1"],
+      group: "Заголовки",
+    },
+    heading_2: {
+      title: "Заголовок 2",
+      subtext: "Основний заголовок розділу",
+      aliases: ["h2", "heading2", "subheading", "заголовок2"],
+      group: "Заголовки",
+    },
+    heading_3: {
+      title: "Заголовок 3",
+      subtext: "Підзаголовок і груповий заголовок",
+      aliases: ["h3", "heading3", "subheading", "заголовок3"],
+      group: "Заголовки",
+    },
+    numbered_list: {
+      title: "Нумерований список",
+      subtext: "Список із впорядкованими елементами",
+      aliases: [
+        "ol",
+        "li",
+        "list",
+        "numberedlist",
+        "numbered list",
+        "список",
+        "нумерований список",
+      ],
+      group: "Базові блоки",
+    },
+    bullet_list: {
+      title: "Маркований список",
+      subtext: "Список із невпорядкованими елементами",
+      aliases: [
+        "ul",
+        "li",
+        "list",
+        "bulletlist",
+        "bullet list",
+        "список",
+        "маркований список",
+      ],
+      group: "Базові блоки",
+    },
+    check_list: {
+      title: "Чек-лист",
+      subtext: "Список із чекбоксами",
+      aliases: [
+        "ul",
+        "li",
+        "list",
+        "checklist",
+        "check list",
+        "checked list",
+        "checkbox",
+        "чекбокс",
+        "чек-лист",
+      ],
+      group: "Базові блоки",
+    },
+    paragraph: {
+      title: "Параграф",
+      subtext: "Основний текст документа",
+      aliases: ["p", "paragraph", "параграф"],
+      group: "Базові блоки",
+    },
+    code_block: {
+      title: "Блок коду",
+      subtext: "Блок коду з підсвіткою синтаксису",
+      aliases: ["code", "pre", "блок коду"],
+      group: "Базові блоки",
+    },
+    page_break: {
+      title: "Розрив сторінки",
+      subtext: "Роздільник сторінки",
+      aliases: ["page", "break", "separator", "розрив сторінки", "розділювач"],
+      group: "Базові блоки",
+    },
+    table: {
+      title: "Таблиця",
+      subtext: "Таблиця з редагованими клітинками",
+      aliases: ["table", "таблиця"],
+      group: "Розширені",
+    },
+    image: {
+      title: "Зображення",
+      subtext: "Масштабоване зображення з підписом",
+      aliases: [
+        "image",
+        "imageUpload",
+        "upload",
+        "img",
+        "picture",
+        "media",
+        "url",
+        "зображення",
+        "медіа",
+      ],
+      group: "Медіа",
+    },
+    video: {
+      title: "Відео",
+      subtext: "Масштабоване відео з підписом",
+      aliases: [
+        "video",
+        "videoUpload",
+        "upload",
+        "mp4",
+        "film",
+        "media",
+        "url",
+        "відео",
+        "медіа",
+      ],
+      group: "Медіа",
+    },
+    audio: {
+      title: "Аудіо",
+      subtext: "Вбудоване аудіо з підписом",
+      aliases: [
+        "audio",
+        "audioUpload",
+        "upload",
+        "mp3",
+        "sound",
+        "media",
+        "url",
+        "аудіо",
+        "медіа",
+      ],
+      group: "Медіа",
+    },
+    file: {
+      title: "Файл",
+      subtext: "Вбудований файл",
+      aliases: ["file", "upload", "embed", "media", "url", "файл", "медіа"],
+      group: "Медіа",
+    },
+    emoji: {
+      title: "Емодзі",
+      subtext: "Пошук і вставка емодзі",
+      aliases: ["emoji", "emote", "emotion", "face", "смайлик", "емодзі"],
+      group: "Інше",
+    },
+  },
+  placeholders: {
+    default: "Введіть текст або наберіть '/' для команд",
+    heading: "Заголовок",
+    bulletListItem: "Список",
+    numberedListItem: "Список",
+    checkListItem: "Список",
+  },
+  file_blocks: {
+    image: {
+      add_button_text: "Додати зображення",
+    },
+    video: {
+      add_button_text: "Додати відео",
+    },
+    audio: {
+      add_button_text: "Додати аудіо",
+    },
+    file: {
+      add_button_text: "Додати файл",
+    },
+  },
+  // from react package:
+  side_menu: {
+    add_block_label: "Додати блок",
+    drag_handle_label: "Відкрити меню блока",
+  },
+  drag_handle: {
+    delete_menuitem: "Видалити",
+    colors_menuitem: "Кольори",
+  },
+  table_handle: {
+    delete_column_menuitem: "Видалити стовпець",
+    delete_row_menuitem: "Видалити рядок",
+    add_left_menuitem: "Додати стовпець зліва",
+    add_right_menuitem: "Додати стовпець справа",
+    add_above_menuitem: "Додати рядок вище",
+    add_below_menuitem: "Додати рядок нижче",
+  },
+  suggestion_menu: {
+    no_items_title: "Нічого не знайдено",
+    loading: "Завантаження…",
+  },
+  color_picker: {
+    text_title: "Текст",
+    background_title: "Фон",
+    colors: {
+      default: "За замовчуванням",
+      gray: "Сірий",
+      brown: "Коричневий",
+      red: "Червоний",
+      orange: "Помаранчевий",
+      yellow: "Жовтий",
+      green: "Зелений",
+      blue: "Блакитний",
+      purple: "Фіолетовий",
+      pink: "Рожевий",
+    },
+  },
+  formatting_toolbar: {
+    bold: {
+      tooltip: "Жирний",
+      secondary_tooltip: "Mod+B",
+    },
+    italic: {
+      tooltip: "Курсив",
+      secondary_tooltip: "Mod+I",
+    },
+    underline: {
+      tooltip: "Підкреслений",
+      secondary_tooltip: "Mod+U",
+    },
+    strike: {
+      tooltip: "Закреслений",
+      secondary_tooltip: "Mod+Shift+X",
+    },
+    code: {
+      tooltip: "Код",
+      secondary_tooltip: "",
+    },
+    colors: {
+      tooltip: "Кольори",
+    },
+    link: {
+      tooltip: "Створити посилання",
+      secondary_tooltip: "Mod+K",
+    },
+    file_caption: {
+      tooltip: "Редагувати підпис",
+      input_placeholder: "Редагувати підпис",
+    },
+    file_replace: {
+      tooltip: {
+        image: "Замінити зображення",
+        video: "Замінити відео",
+        audio: "Замінити аудіо",
+        file: "Замінити файл",
       },
-      placeholders: {
-        default: "Введіть текст або наберіть '/' для команд",
-        heading: "Заголовок",
-        bulletListItem: "Список",
-        numberedListItem: "Список",
-        checkListItem: "Список",
+    },
+    file_rename: {
+      tooltip: {
+        image: "Перейменувати зображення",
+        video: "Перейменувати відео",
+        audio: "Перейменувати аудіо",
+        file: "Перейменувати файл",
       },
-      file_blocks: {
-        image: {
-          add_button_text: "Додати зображення",
-        },
-        video: {
-          add_button_text: "Додати відео",
-        },
-        audio: {
-          add_button_text: "Додати аудіо",
-        },
-        file: {
-          add_button_text: "Додати файл",
-        },
+      input_placeholder: {
+        image: "Перейменувати зображення",
+        video: "Перейменувати відео",
+        audio: "Перейменувати аудіо",
+        file: "Перейменувати файл",
       },
-      // from react package:
-      side_menu: {
-        add_block_label: "Додати блок",
-        drag_handle_label: "Відкрити меню блока",
+    },
+    file_download: {
+      tooltip: {
+        image: "Завантажити зображення",
+        video: "Завантажити відео",
+        audio: "Завантажити аудіо",
+        file: "Завантажити файл",
       },
-      drag_handle: {
-        delete_menuitem: "Видалити",
-        colors_menuitem: "Кольори",
+    },
+    file_delete: {
+      tooltip: {
+        image: "Видалити зображення",
+        video: "Видалити відео",
+        audio: "Видалити аудіо",
+        file: "Видалити файл",
       },
-      table_handle: {
-        delete_column_menuitem: "Видалити стовпець",
-        delete_row_menuitem: "Видалити рядок",
-        add_left_menuitem: "Додати стовпець зліва",
-        add_right_menuitem: "Додати стовпець справа",
-        add_above_menuitem: "Додати рядок вище",
-        add_below_menuitem: "Додати рядок нижче",
+    },
+    file_preview_toggle: {
+      tooltip: "Перемкнути попередній перегляд",
+    },
+    nest: {
+      tooltip: "Вкладений блок",
+      secondary_tooltip: "Tab",
+    },
+    unnest: {
+      tooltip: "Розгрупувати блок",
+      secondary_tooltip: "Shift+Tab",
+    },
+    align_left: {
+      tooltip: "Вирівняти за лівим краєм",
+    },
+    align_center: {
+      tooltip: "Вирівняти по центру",
+    },
+    align_right: {
+      tooltip: "Вирівняти за правим краєм",
+    },
+    align_justify: {
+      tooltip: "Вирівняти за шириною",
+    },
+    comment: {
+      tooltip: "Додати коментар",
+    },
+  },
+  file_panel: {
+    upload: {
+      title: "Завантажити",
+      file_placeholder: {
+        image: "Завантажити зображення",
+        video: "Завантажити відео",
+        audio: "Завантажити аудіо",
+        file: "Завантажити файл",
       },
-      suggestion_menu: {
-        no_items_title: "Нічого не знайдено",
-        loading: "Завантаження…",
+      upload_error: "Помилка: не вдалося завантажити",
+    },
+    embed: {
+      title: "Вставити",
+      embed_button: {
+        image: "Вставити зображення",
+        video: "Вставити відео",
+        audio: "Вставити аудіо",
+        file: "Вставити файл",
       },
-      color_picker: {
-        text_title: "Текст",
-        background_title: "Фон",
-        colors: {
-          default: "За замовчуванням",
-          gray: "Сірий",
-          brown: "Коричневий",
-          red: "Червоний",
-          orange: "Помаранчевий",
-          yellow: "Жовтий",
-          green: "Зелений",
-          blue: "Блакитний",
-          purple: "Фіолетовий",
-          pink: "Рожевий",
-        },
-      },
-      formatting_toolbar: {
-        bold: {
-          tooltip: "Жирний",
-          secondary_tooltip: "Mod+B",
-        },
-        italic: {
-          tooltip: "Курсив",
-          secondary_tooltip: "Mod+I",
-        },
-        underline: {
-          tooltip: "Підкреслений",
-          secondary_tooltip: "Mod+U",
-        },
-        strike: {
-          tooltip: "Закреслений",
-          secondary_tooltip: "Mod+Shift+X",
-        },
-        code: {
-          tooltip: "Код",
-          secondary_tooltip: "",
-        },
-        colors: {
-          tooltip: "Кольори",
-        },
-        link: {
-          tooltip: "Створити посилання",
-          secondary_tooltip: "Mod+K",
-        },
-        file_caption: {
-          tooltip: "Редагувати підпис",
-          input_placeholder: "Редагувати підпис",
-        },
-        file_replace: {
-          tooltip: {
-            image: "Замінити зображення",
-            video: "Замінити відео",
-            audio: "Замінити аудіо",
-            file: "Замінити файл",
-          },
-        },
-        file_rename: {
-          tooltip: {
-            image: "Перейменувати зображення",
-            video: "Перейменувати відео",
-            audio: "Перейменувати аудіо",
-            file: "Перейменувати файл",
-          },
-          input_placeholder: {
-            image: "Перейменувати зображення",
-            video: "Перейменувати відео",
-            audio: "Перейменувати аудіо",
-            file: "Перейменувати файл",
-          },
-        },
-        file_download: {
-          tooltip: {
-            image: "Завантажити зображення",
-            video: "Завантажити відео",
-            audio: "Завантажити аудіо",
-            file: "Завантажити файл",
-          },
-        },
-        file_delete: {
-          tooltip: {
-            image: "Видалити зображення",
-            video: "Видалити відео",
-            audio: "Видалити аудіо",
-            file: "Видалити файл",
-          },
-        },
-        file_preview_toggle: {
-          tooltip: "Перемкнути попередній перегляд",
-        },
-        nest: {
-          tooltip: "Вкладений блок",
-          secondary_tooltip: "Tab",
-        },
-        unnest: {
-          tooltip: "Розгрупувати блок",
-          secondary_tooltip: "Shift+Tab",
-        },
-        align_left: {
-          tooltip: "Вирівняти за лівим краєм",
-        },
-        align_center: {
-          tooltip: "Вирівняти по центру",
-        },
-        align_right: {
-          tooltip: "Вирівняти за правим краєм",
-        },
-        align_justify: {
-          tooltip: "Вирівняти за шириною",
-        },
-      },
-      file_panel: {
-        upload: {
-          title: "Завантажити",
-          file_placeholder: {
-            image: "Завантажити зображення",
-            video: "Завантажити відео",
-            audio: "Завантажити аудіо",
-            file: "Завантажити файл",
-          },
-          upload_error: "Помилка: не вдалося завантажити",
-        },
-        embed: {
-          title: "Вставити",
-          embed_button: {
-            image: "Вставити зображення",
-            video: "Вставити відео",
-            audio: "Вставити аудіо",
-            file: "Вставити файл",
-          },
-          url_placeholder: "Введіть URL",
-        },
-      },
-      link_toolbar: {
-        delete: {
-          tooltip: "Видалити посилання",
-        },
-        edit: {
-          text: "Редагувати посилання",
-          tooltip: "Редагувати",
-        },
-        open: {
-          tooltip: "Відкрити в новій вкладці",
-        },
-        form: {
-          title_placeholder: "Редагувати заголовок",
-          url_placeholder: "Редагувати URL",
-        },
-      },
-      generic: {
-        ctrl_shortcut: "Ctrl",
-      },
+      url_placeholder: "Введіть URL",
+    },
+  },
+  link_toolbar: {
+    delete: {
+      tooltip: "Видалити посилання",
+    },
+    edit: {
+      text: "Редагувати посилання",
+      tooltip: "Редагувати",
+    },
+    open: {
+      tooltip: "Відкрити в новій вкладці",
+    },
+    form: {
+      title_placeholder: "Редагувати заголовок",
+      url_placeholder: "Редагувати URL",
+    },
+  },
+  generic: {
+    ctrl_shortcut: "Ctrl",
+  },
 };

--- a/packages/core/src/i18n/locales/vi.ts
+++ b/packages/core/src/i18n/locales/vi.ts
@@ -275,6 +275,9 @@ export const vi: Dictionary = {
     align_justify: {
       tooltip: "Căn đều văn bản",
     },
+    comment: {
+      tooltip: "Thêm bình luận",
+    },
   },
   file_panel: {
     upload: {

--- a/packages/core/src/i18n/locales/zh.ts
+++ b/packages/core/src/i18n/locales/zh.ts
@@ -309,6 +309,9 @@ export const zh: Dictionary = {
     align_justify: {
       tooltip: "文本对齐",
     },
+    comment: {
+      tooltip: "添加评论",
+    },
   },
   file_panel: {
     upload: {

--- a/packages/react/src/components/FormattingToolbar/DefaultButtons/AddTiptapCommentButton.tsx
+++ b/packages/react/src/components/FormattingToolbar/DefaultButtons/AddTiptapCommentButton.tsx
@@ -1,0 +1,44 @@
+import { BlockSchema, InlineContentSchema, StyleSchema } from "@blocknote/core";
+import { useCallback } from "react";
+import { RiChat3Line } from "react-icons/ri";
+
+import { useComponentsContext } from "../../../editor/ComponentsContext.js";
+import { useBlockNoteEditor } from "../../../hooks/useBlockNoteEditor.js";
+import { useDictionary } from "../../../i18n/dictionary.js";
+
+/**
+ * This comment button shows when a addPendingComment command is available on the underlying tiptap editor.
+ */
+export const AddTiptapCommentButton = () => {
+  const dict = useDictionary();
+  const Components = useComponentsContext()!;
+
+  const editor = useBlockNoteEditor<
+    BlockSchema,
+    InlineContentSchema,
+    StyleSchema
+  >();
+
+  const onClick = useCallback(() => {
+    (editor._tiptapEditor as any).chain().focus().addPendingComment().run();
+  }, [editor]);
+
+  if (
+    // We manually check if a comment extension (like liveblocks) is installed
+    // By adding default support for this, the user doesn't need to customize the formatting toolbar
+    !(editor._tiptapEditor.commands as any)["addPendingComment"] ||
+    !editor.isEditable
+  ) {
+    return null;
+  }
+
+  return (
+    <Components.FormattingToolbar.Button
+      className={"bn-button"}
+      label={dict.formatting_toolbar.comment.tooltip}
+      mainTooltip={dict.formatting_toolbar.comment.tooltip}
+      icon={<RiChat3Line />}
+      onClick={onClick}
+    />
+  );
+};

--- a/packages/react/src/components/FormattingToolbar/FormattingToolbar.tsx
+++ b/packages/react/src/components/FormattingToolbar/FormattingToolbar.tsx
@@ -17,6 +17,7 @@ import {
   BlockTypeSelectItem,
 } from "./DefaultSelects/BlockTypeSelect.js";
 
+import { AddTiptapCommentButton } from "./DefaultButtons/AddTiptapCommentButton.js";
 import { FileDownloadButton } from "./DefaultButtons/FileDownloadButton.js";
 import { FilePreviewButton } from "./DefaultButtons/FilePreviewButton.js";
 import { TextAlignButton } from "./DefaultButtons/TextAlignButton.js";
@@ -46,6 +47,7 @@ export const getFormattingToolbarItems = (
   <NestBlockButton key={"nestBlockButton"} />,
   <UnnestBlockButton key={"unnestBlockButton"} />,
   <CreateLinkButton key={"createLinkButton"} />,
+  <AddTiptapCommentButton key={"addTiptapCommentButton"} />,
 ];
 
 // TODO: props.blockTypeSelectItems should only be available if no children


### PR DESCRIPTION
This PR:
- adds an "add comment" button to the Formatting Toolbar if a commenting plugin has been registered on TipTap
- adds a support to tag certain Marks that are not relevant for BlockNote, such as Marks. TipTap / Liveblocks comment plugins currently rely on marks to associate Comments as annotations to the document, even though they're not really document content. By tagging Marks as `blocknoteIgnore` it's possible to use these marks while not affecting the rest of BlockNote. In Tiptap, this can be done like this:

```typescript
Mark.create(
...

extendMarkSchema(extension) {
    if (extension.name === "comment") { // "comment" is the name of the mark
      return {
        blocknoteIgnore: true,
      };
    }
    return {};
  }
...
```
