### PR TITLE
refactor: add renderEditor boolean to BlockNoteView

### DIFF
--- a/packages/core/src/util/browser.ts
+++ b/packages/core/src/util/browser.ts
@@ -12,7 +12,7 @@ export function formatKeyboardShortcut(shortcut: string, ctrlText = "Ctrl") {
   }
 }
 
-export function mergeCSSClasses(...classes: string[]) {
+export function mergeCSSClasses(...classes: (string | undefined)[]) {
   return classes.filter((c) => c).join(" ");
 }
 

--- a/packages/react/src/editor/BlockNoteContext.ts
+++ b/packages/react/src/editor/BlockNoteContext.ts
@@ -10,7 +10,7 @@ import {
 } from "@blocknote/core";
 import { createContext, useContext, useState } from "react";
 
-type BlockNoteContextValue<
+export type BlockNoteContextValue<
   BSchema extends BlockSchema = DefaultBlockSchema,
   ISchema extends InlineContentSchema = DefaultInlineContentSchema,
   SSchema extends StyleSchema = DefaultStyleSchema

--- a/packages/react/src/editor/BlockNoteView.tsx
+++ b/packages/react/src/editor/BlockNoteView.tsx
@@ -18,11 +18,19 @@ import React, {
 import { useEditorChange } from "../hooks/useEditorChange.js";
 import { useEditorSelectionChange } from "../hooks/useEditorSelectionChange.js";
 import { usePrefersColorScheme } from "../hooks/usePrefersColorScheme.js";
-import { BlockNoteContext, useBlockNoteContext } from "./BlockNoteContext.js";
+import {
+  BlockNoteContext,
+  BlockNoteContextValue,
+  useBlockNoteContext,
+} from "./BlockNoteContext.js";
 import {
   BlockNoteDefaultUI,
   BlockNoteDefaultUIProps,
 } from "./BlockNoteDefaultUI.js";
+import {
+  BlockNoteViewContext,
+  useBlockNoteViewContext,
+} from "./BlockNoteViewContext.js";
 import { Portals, getContentComponent } from "./EditorContent.js";
 import { ElementRenderer } from "./ElementRenderer.js";
 import "./styles.css";
@@ -41,7 +49,17 @@ export type BlockNoteViewProps<
   theme?: "light" | "dark";
 
   /**
+   * Whether to render the editor element itself.
+   * When `false`, you're responsible for rendering the editor yourself using the `BlockNoteViewEditor` component.
+   *
+   * @default true
+   */
+  renderEditor?: boolean;
+
+  /**
    * Locks the editor from being editable by the user if set to `false`.
+   *
+   * @default true
    */
   editable?: boolean;
   /**
@@ -86,9 +104,12 @@ function BlockNoteViewComponent<
     sideMenu,
     filePanel,
     tableHandles,
+    autoFocus,
+    renderEditor,
     ...rest
   } = props;
 
+  const doRenderEditor = renderEditor ?? true;
   // Used so other components (suggestion menu) can set
   // aria related props to the contenteditable div
   const [contentEditableProps, setContentEditableProps] =
@@ -109,40 +130,6 @@ function BlockNoteViewComponent<
     editor.isEditable = editable !== false;
   }, [editable, editor]);
 
-  const renderChildren = useMemo(() => {
-    return (
-      <>
-        {children}
-        <BlockNoteDefaultUI
-          formattingToolbar={formattingToolbar}
-          linkToolbar={linkToolbar}
-          slashMenu={slashMenu}
-          emojiPicker={emojiPicker}
-          sideMenu={sideMenu}
-          filePanel={filePanel}
-          tableHandles={tableHandles}
-        />
-      </>
-    );
-  }, [
-    children,
-    formattingToolbar,
-    linkToolbar,
-    slashMenu,
-    emojiPicker,
-    sideMenu,
-    filePanel,
-    tableHandles,
-  ]);
-
-  const context = useMemo(() => {
-    return {
-      ...existingContext,
-      editor,
-      setContentEditableProps,
-    };
-  }, [existingContext, editor]);
-
   const setElementRenderer = useCallback(
     (ref: (typeof editor)["elementRenderer"]) => {
       editor.elementRenderer = ref;
@@ -161,31 +148,57 @@ function BlockNoteViewComponent<
     [editor, portalManager]
   );
 
+  // The BlockNoteContext makes sure the editor and some helper methods
+  // are always available to nesteed compoenents
+  const blockNoteContext: BlockNoteContextValue<any, any, any> = useMemo(() => {
+    return {
+      ...existingContext,
+      editor,
+      setContentEditableProps,
+    };
+  }, [existingContext, editor]);
+
+  // We set defaultUIProps and editorProps on a different context, the BlockNoteViewContext.
+  // This BlockNoteViewContext is used to render the editor and the default UI.
+  const defaultUIProps = {
+    formattingToolbar,
+    linkToolbar,
+    slashMenu,
+    emojiPicker,
+    sideMenu,
+    filePanel,
+    tableHandles,
+  };
+
+  const editorProps = {
+    autoFocus,
+    className,
+    editorColorScheme,
+    mount,
+    contentEditableProps,
+    ref,
+    ...rest,
+  };
+
   return (
-    <BlockNoteContext.Provider value={context as any}>
-      <ElementRenderer ref={setElementRenderer} />
-      {!editor.headless && (
-        <>
-          <Portals contentComponent={portalManager} />
-          <div
-            className={mergeCSSClasses(
-              "bn-container",
-              editorColorScheme || "",
-              className || ""
+    <BlockNoteContext.Provider value={blockNoteContext}>
+      <BlockNoteViewContext.Provider
+        value={{
+          editorProps,
+          defaultUIProps,
+        }}>
+        <ElementRenderer ref={setElementRenderer} />
+        {!editor.headless && (
+          <>
+            <Portals contentComponent={portalManager} />
+            {doRenderEditor ? (
+              <BlockNoteViewEditor>{children}</BlockNoteViewEditor>
+            ) : (
+              children
             )}
-            data-color-scheme={editorColorScheme}
-            {...rest}
-            ref={ref}>
-            <div
-              aria-autocomplete="list"
-              aria-haspopup="listbox"
-              ref={mount}
-              {...contentEditableProps}
-            />
-            {renderChildren}
-          </div>
-        </>
-      )}
+          </>
+        )}
+      </BlockNoteViewContext.Provider>
     </BlockNoteContext.Provider>
   );
 }
@@ -200,3 +213,60 @@ export const BlockNoteViewRaw = React.forwardRef(BlockNoteViewComponent) as <
     ref?: React.ForwardedRef<HTMLDivElement>;
   }
 ) => ReturnType<typeof BlockNoteViewComponent<BSchema, ISchema, SSchema>>;
+
+/**
+ * Renders the editor itself and the default UI elements
+ */
+export const BlockNoteViewEditor = (props: { children: ReactNode }) => {
+  const ctx = useBlockNoteViewContext()!;
+  return (
+    <EditorElement {...ctx.editorProps} {...props}>
+      {/* Renders the UI elements such as formatting toolbar, etc, unless they have been explicitly disabled  in defaultUIProps */}
+      <BlockNoteDefaultUI {...ctx.defaultUIProps} />
+      {/* Manually passed in children, such as customized UI elements / controllers */}
+      {props.children}
+    </EditorElement>
+  );
+};
+
+/**
+ * Renders the container div + contentEditable div.
+ */
+const EditorElement = (
+  props: {
+    className?: string;
+    editorColorScheme?: string;
+    autoFocus?: boolean;
+    mount: (element: HTMLElement | null) => void;
+    contentEditableProps?: Record<string, any>;
+    children: ReactNode;
+  } & HTMLAttributes<HTMLDivElement>
+) => {
+  const {
+    className,
+    editorColorScheme,
+    autoFocus,
+    mount,
+    children,
+    contentEditableProps,
+    ...rest
+  } = props;
+  return (
+    // The container wraps the contentEditable div and UI Elements such as sidebar, formatting toolbar, etc.
+    <div
+      className={mergeCSSClasses("bn-container", editorColorScheme, className)}
+      data-color-scheme={editorColorScheme}
+      {...rest}>
+      {/* The actual contentEditable that Prosemirror mounts to */}
+      <div
+        aria-autocomplete="list"
+        aria-haspopup="listbox"
+        data-bn-autofocus={autoFocus}
+        ref={mount}
+        {...contentEditableProps}
+      />
+      {/* The UI elements such as sidebar, formatting toolbar, etc. */}
+      {children}
+    </div>
+  );
+};

--- a/packages/react/src/editor/BlockNoteViewContext.ts
+++ b/packages/react/src/editor/BlockNoteViewContext.ts
@@ -1,0 +1,19 @@
+import { createContext, useContext } from "react";
+import { BlockNoteDefaultUIProps } from "./BlockNoteDefaultUI.js";
+
+export type BlockNoteViewContextValue = {
+  editorProps: any;
+  defaultUIProps: BlockNoteDefaultUIProps;
+};
+
+export const BlockNoteViewContext = createContext<
+  BlockNoteViewContextValue | undefined
+>(undefined);
+
+export function useBlockNoteViewContext():
+  | BlockNoteViewContextValue
+  | undefined {
+  const context = useContext(BlockNoteViewContext) as any;
+
+  return context;
+}


### PR DESCRIPTION
This PR cleans up the BlockNoteView code a bit and adds support for `renderEditor={false}`

The idea is that the consumer can then "position" (render) the editor themselves, but still access the Context values that BlockNoteView is setting up. 

Example usage on a different branch: https://github.com/TypeCellOS/BlockNote/blob/42cdbd1a3c5c580465bb9430a9b81eaaa065aa2f/examples/07-collaboration/04-comments/App.tsx#L150