### PR TITLE
fix: Drag & drop

### DIFF
--- a/packages/core/src/extensions/SideMenu/SideMenuPlugin.ts
+++ b/packages/core/src/extensions/SideMenu/SideMenuPlugin.ts
@@ -178,6 +178,11 @@ export class SideMenuView<
       this.onDrop as EventListener,
       true
     );
+    this.pmView.root.addEventListener(
+      "dragend",
+      this.onDragEnd as EventListener,
+      true
+    );
     initializeESMDependencies();
 
     // Shows or updates menu position whenever the cursor moves, if the menu isn't frozen.
@@ -300,8 +305,8 @@ export class SideMenuView<
       // a block from a different editor is being dropped, this causes some
       // issues that the code below fixes:
       if (!this.isDragOrigin && this.pmView.dom === parentEditorElement) {
-        // 1. Because the editor selection is unrelated to the dragged content,
-        // we don't want PM to delete its content. Therefore, we collapse the
+        // Because the editor selection is unrelated to the dragged content, we
+        // don't want PM to delete its content. Therefore, we collapse the
         // selection.
         this.pmView.dispatch(
           this.pmView.state.tr.setSelection(
@@ -312,8 +317,8 @@ export class SideMenuView<
           )
         );
       } else if (this.isDragOrigin && this.pmView.dom !== parentEditorElement) {
-        // 2. Because the editor from which the block originates doesn't get a
-        // drop event on it, PM doesn't delete its selected content. Therefore, we
+        // Because the editor from which the block originates doesn't get a drop
+        // event on it, PM doesn't delete its selected content. Therefore, we
         // need to do so manually.
         //
         // Note: Deleting the selected content from the editor from which the
@@ -328,11 +333,6 @@ export class SideMenuView<
           0
         );
       }
-      // 3. PM only clears `view.dragging` on the editor that the block was
-      // dropped, so we manually have to clear it on all the others. However,
-      // PM also needs to read `view.dragging` while handling the event, so we
-      // use a `setTimeout` to ensure it's only cleared after that.
-      setTimeout(() => (this.pmView.dragging = null), 0);
     }
 
     if (
@@ -358,6 +358,14 @@ export class SideMenuView<
       // console.log("dispatch fake drop");
       this.pmView.dom.dispatchEvent(evt);
     }
+  };
+
+  onDragEnd = () => {
+    // When the user starts dragging a block, `view.dragging` is set on all
+    // BlockNote editors. However, when the drag ends, only the editor that the
+    // drag originated in automatically clears `view.dragging`. Therefore, we
+    // have to manually clear it on all editors.
+    this.pmView.dragging = null;
   };
 
   /**
@@ -578,6 +586,11 @@ export class SideMenuView<
     this.pmView.root.removeEventListener(
       "drop",
       this.onDrop as EventListener,
+      true
+    );
+    this.pmView.root.removeEventListener(
+      "dragend",
+      this.onDragEnd as EventListener,
       true
     );
     this.pmView.root.removeEventListener(

--- a/packages/xl-multi-column/src/extensions/DropCursor/MultiColumnDropCursorPlugin.ts
+++ b/packages/xl-multi-column/src/extensions/DropCursor/MultiColumnDropCursorPlugin.ts
@@ -163,6 +163,12 @@ export function multiColumnDropCursor(
             editor.schema.styleSchema
           );
 
+          // The user is dropping next to the original block being dragged - do
+          // nothing.
+          if (block.id === draggedBlock.id) {
+            return;
+          }
+
           const blocks =
             position === "left" ? [draggedBlock, block] : [block, draggedBlock];
           editor.removeBlocks([draggedBlock]);


### PR DESCRIPTION
This PR fixes 2 additional issues with drag & drop that we didn't previously catch:

1. When using the multi-column extension, it's possible to drag a block and drop it next to itself. BlockNote will attempt to create 2 columns containing the same block, but will throw an error it tries to remove the same block twice. This edge case has been fixed and now, nothing happens.
2. It's possible that a dragged block is dropped in an element that is not a valid drop target. In this case, only a `dragend` event fires, and not a `drop`. Since we only clear `view.dragging` on drop events, BlockNote will throw an error the next time the user attempts to drag a block, as it will think that a block is already being dragged. Therefore, this has been fixed by making `view.dragging` get cleared on `dragend` events instead.