### PR TITLE
fix: Formatting toolbar `mouseup` handler

### DIFF
--- a/packages/core/src/extensions/FormattingToolbar/FormattingToolbarPlugin.ts
+++ b/packages/core/src/extensions/FormattingToolbar/FormattingToolbarPlugin.ts
@@ -67,7 +67,7 @@ export class FormattingToolbarView implements PluginView {
     };
 
     pmView.dom.addEventListener("mousedown", this.viewMousedownHandler);
-    pmView.dom.addEventListener("mouseup", this.viewMouseupHandler);
+    pmView.root.addEventListener("mouseup", this.mouseupHandler);
     pmView.dom.addEventListener("dragstart", this.dragHandler);
     pmView.dom.addEventListener("dragover", this.dragHandler);
     pmView.dom.addEventListener("blur", this.blurHandler);
@@ -113,9 +113,11 @@ export class FormattingToolbarView implements PluginView {
     this.preventShow = true;
   };
 
-  viewMouseupHandler = () => {
-    this.preventShow = false;
-    setTimeout(() => this.update(this.pmView));
+  mouseupHandler = () => {
+    if (this.preventShow) {
+      this.preventShow = false;
+      setTimeout(() => this.update(this.pmView));
+    }
   };
 
   // For dragging the whole editor.
@@ -193,7 +195,7 @@ export class FormattingToolbarView implements PluginView {
 
   destroy() {
     this.pmView.dom.removeEventListener("mousedown", this.viewMousedownHandler);
-    this.pmView.dom.removeEventListener("mouseup", this.viewMouseupHandler);
+    this.pmView.root.removeEventListener("mouseup", this.mouseupHandler);
     this.pmView.dom.removeEventListener("dragstart", this.dragHandler);
     this.pmView.dom.removeEventListener("dragover", this.dragHandler);
     this.pmView.dom.removeEventListener("blur", this.blurHandler);


### PR DESCRIPTION
Closes #1417
Closes #1333 