### PR TITLE
fix: Mantine CSS variables element

### DIFF
--- a/packages/mantine/src/BlockNoteView.tsx
+++ b/packages/mantine/src/BlockNoteView.tsx
@@ -12,7 +12,7 @@ import {
   usePrefersColorScheme,
 } from "@blocknote/react";
 import { MantineProvider } from "@mantine/core";
-import { useCallback } from "react";
+import { useCallback, useRef } from "react";
 import {
   applyBlockNoteCSSVariablesFromTheme,
   removeBlockNoteCSSVariables,
@@ -74,24 +74,28 @@ export const BlockNoteView = <
     [defaultColorScheme, theme]
   );
 
+  const mantineCssVariablesRef = useRef<HTMLDivElement>(null);
+
   return (
     <ComponentsContext.Provider value={components}>
-      {/* `cssVariablesSelector` scopes Mantine CSS variables to only the editor, */}
-      {/* as proposed here:  https://github.com/orgs/mantinedev/discussions/5685 */}
-      <MantineProvider
-        theme={mantineTheme}
-        cssVariablesSelector=".bn-mantine"
-        // This gets the element to set `data-mantine-color-scheme` on. Since we
-        // don't need this attribute (we use our own theming API), we return
-        // undefined here.
-        getRootElement={() => undefined}>
-        <BlockNoteViewRaw
-          className={mergeCSSClasses("bn-mantine", className || "")}
-          theme={typeof theme === "object" ? undefined : theme}
-          {...rest}
-          ref={ref}
-        />
-      </MantineProvider>
+      <div className={"bn-mantine-css-variables"} ref={mantineCssVariablesRef}>
+        {/* `cssVariablesSelector` scopes Mantine CSS variables to only the editor, */}
+        {/* as proposed here:  https://github.com/orgs/mantinedev/discussions/5685 */}
+        <MantineProvider
+          theme={mantineTheme}
+          cssVariablesSelector=".bn-mantine-css-variables"
+          // This gets the element to set `data-mantine-color-scheme` on. Since we
+          // don't need this attribute (we use our own theming API), we return
+          // undefined here.
+          getRootElement={() => mantineCssVariablesRef.current || undefined}>
+          <BlockNoteViewRaw
+            className={mergeCSSClasses("bn-mantine", className || "")}
+            theme={typeof theme === "object" ? undefined : theme}
+            {...rest}
+            ref={ref}
+          />
+        </MantineProvider>
+      </div>
     </ComponentsContext.Provider>
   );
 };

--- a/packages/mantine/src/BlockNoteView.tsx
+++ b/packages/mantine/src/BlockNoteView.tsx
@@ -78,9 +78,9 @@ export const BlockNoteView = <
 
   return (
     <ComponentsContext.Provider value={components}>
+      {/* `cssVariablesSelector` scopes Mantine CSS variables to only the editor, */}
+      {/* as proposed here:  https://github.com/orgs/mantinedev/discussions/5685 */}
       <div className={"bn-mantine-css-variables"} ref={mantineCssVariablesRef}>
-        {/* `cssVariablesSelector` scopes Mantine CSS variables to only the editor, */}
-        {/* as proposed here:  https://github.com/orgs/mantinedev/discussions/5685 */}
         <MantineProvider
           theme={mantineTheme}
           cssVariablesSelector=".bn-mantine-css-variables"

--- a/packages/mantine/src/BlockNoteView.tsx
+++ b/packages/mantine/src/BlockNoteView.tsx
@@ -12,7 +12,7 @@ import {
   usePrefersColorScheme,
 } from "@blocknote/react";
 import { MantineProvider } from "@mantine/core";
-import { useCallback, useRef } from "react";
+import { useCallback } from "react";
 import {
   applyBlockNoteCSSVariablesFromTheme,
   removeBlockNoteCSSVariables,
@@ -74,28 +74,33 @@ export const BlockNoteView = <
     [defaultColorScheme, theme]
   );
 
-  const mantineCssVariablesRef = useRef<HTMLDivElement>(null);
+  const finalTheme =
+    typeof theme === "string"
+      ? theme
+      : defaultColorScheme !== "no-preference"
+      ? defaultColorScheme
+      : "light";
 
   return (
     <ComponentsContext.Provider value={components}>
-      {/* `cssVariablesSelector` scopes Mantine CSS variables to only the editor, */}
-      {/* as proposed here:  https://github.com/orgs/mantinedev/discussions/5685 */}
-      <div className={"bn-mantine-css-variables"} ref={mantineCssVariablesRef}>
-        <MantineProvider
-          theme={mantineTheme}
-          cssVariablesSelector=".bn-mantine-css-variables"
-          // This gets the element to set `data-mantine-color-scheme` on. Since we
-          // don't need this attribute (we use our own theming API), we return
-          // undefined here.
-          getRootElement={() => mantineCssVariablesRef.current || undefined}>
-          <BlockNoteViewRaw
-            className={mergeCSSClasses("bn-mantine", className || "")}
-            theme={typeof theme === "object" ? undefined : theme}
-            {...rest}
-            ref={ref}
-          />
-        </MantineProvider>
-      </div>
+      <MantineProvider
+        theme={mantineTheme}
+        // Scopes Mantine CSS variables to only the editor, as proposed here:
+        // https://github.com/orgs/mantinedev/discussions/5685
+        cssVariablesSelector=".bn-mantine"
+        // This gets the element to set `data-mantine-color-scheme` on. This
+        // element needs to already be rendered, so we can't set it to the
+        // editor container element. Instead, we set it to `undefined` and set it
+        // manually in `BlockNoteViewRaw`.
+        getRootElement={() => undefined}>
+        <BlockNoteViewRaw
+          data-mantine-color-scheme={finalTheme}
+          className={mergeCSSClasses("bn-mantine", className || "")}
+          theme={typeof theme === "object" ? undefined : theme}
+          {...rest}
+          ref={ref}
+        />
+      </MantineProvider>
     </ComponentsContext.Provider>
   );
 };


### PR DESCRIPTION
Mantine theme CSS variables aren't being set properly at the moment, which means that an editor using the Mantine `BlockNoteView` may not have the CSS variables it needs when not within an existing `MantineProvider`. This is because `getRootElement` returns no element, but we need it to set `data-mantine-color-scheme` on the `.bn-mantine` element. Since it's a child of the `MantineProvider` and can't be found on render, we have to set `data-mantine-color-scheme` manually through `BlockNoteViewRaw`.

We pretty much never use Mantine theme variables as we use the BlockNote theme variables instead, but the `Badge` components from the comments PR does use them. Maybe we also want to change this to use strictly BlockNote theme variables? (ofc in the comments PR, not this one)