### PR TITLE
feat: support new table properties in PDF export

### DIFF
--- a/examples/05-interoperability/05-converting-blocks-to-pdf/App.tsx
+++ b/examples/05-interoperability/05-converting-blocks-to-pdf/App.tsx
@@ -29,6 +29,12 @@ export default function App() {
   // Creates a new editor instance with some initial content.
   const editor = useCreateBlockNote({
     schema: withPageBreak(BlockNoteSchema.create()),
+    tables: {
+      splitCells: true,
+      cellBackgroundColor: true,
+      cellTextColor: true,
+      headers: true,
+    },
     initialContent: [
       {
         type: "paragraph",

--- a/packages/xl-pdf-exporter/src/pdf/util/table/Table.tsx
+++ b/packages/xl-pdf-exporter/src/pdf/util/table/Table.tsx
@@ -30,6 +30,9 @@ const styles = StyleSheet.create({
     wordWrap: "break-word",
     whiteSpace: "pre-wrap",
   },
+  headerCell: {
+    fontWeight: "bold",
+  },
   bottomCell: {
     borderBottom: "1px solid #ddd",
   },
@@ -49,31 +52,55 @@ export const Table = (props: {
     any,
     any
   >;
-}) => (
-  <View style={styles.tableContainer} wrap={false}>
-    {props.data.rows.map((row, index) => (
-      <View
-        style={[
-          styles.row,
-          index === props.data.rows.length - 1 ? styles.bottomCell : {},
-        ]}
-        key={index}>
-        {row.cells.map((cell, index) => (
-          <View
-            style={[
-              styles.cell,
-              index === row.cells.length - 1 ? styles.rightCell : {},
-              props.data.columnWidths[index]
-                ? { width: props.data.columnWidths[index] }
-                : { flex: 1 },
-            ]}
-            key={index}>
-            {props.transformer.transformInlineContent(
-              mapTableCell(cell).content
-            )}
-          </View>
-        ))}
-      </View>
-    ))}
-  </View>
-);
+}) => {
+  // If headerRows is 1, then the first row is a header row
+  const headerRows = new Array(props.data.headerRows ?? 0).fill(true);
+  // If headerCols is 1, then the first column is a header column
+  const headerCols = new Array(props.data.headerCols ?? 0).fill(true);
+
+  return (
+    <View style={styles.tableContainer} wrap={false}>
+      {props.data.rows.map((row, rowIndex) => (
+        <View
+          style={[
+            styles.row,
+            rowIndex === props.data.rows.length - 1 ? styles.bottomCell : {},
+          ]}
+          key={rowIndex}>
+          {row.cells.map((c, colIndex) => {
+            const cell = mapTableCell(c);
+
+            const isHeaderRow = headerRows[rowIndex];
+            const isHeaderCol = headerCols[colIndex];
+
+            return (
+              <View
+                style={[
+                  styles.cell,
+                  isHeaderRow || isHeaderCol ? styles.headerCell : {},
+                  colIndex === row.cells.length - 1 ? styles.rightCell : {},
+                  props.data.columnWidths[colIndex]
+                    ? { width: props.data.columnWidths[colIndex] }
+                    : { flex: 1 },
+                  {
+                    color:
+                      cell.props.textColor === "default"
+                        ? undefined
+                        : cell.props.textColor,
+                    backgroundColor:
+                      cell.props.backgroundColor === "default"
+                        ? undefined
+                        : cell.props.backgroundColor,
+                    textAlign: cell.props.textAlignment,
+                  },
+                ]}
+                key={colIndex}>
+                {props.transformer.transformInlineContent(cell.content)}
+              </View>
+            );
+          })}
+        </View>
+      ))}
+    </View>
+  );
+};


### PR DESCRIPTION
This adds support for table cell text & background color, alignment, and header cells to the PDF export of tables.

One thing this does not support at the moment is rowspan & colspan tables, with the current approach it looks like it would take a good amount of work to get this to export properly
