### PR TITLE
fix: Removed `@emoji-mart/react` dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3508,15 +3508,6 @@
       "resolved": "https://registry.npmjs.org/@emoji-mart/data/-/data-1.2.1.tgz",
       "integrity": "sha512-no2pQMWiBy6gpBEiqGeU77/bFejDqUTRY7KX+0+iur13op3bqUsXdnwoZs6Xb1zbv0gAj5VvS1PWoUUckSr5Dw=="
     },
-    "node_modules/@emoji-mart/react": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@emoji-mart/react/-/react-1.1.1.tgz",
-      "integrity": "sha512-NMlFNeWgv1//uPsvLxvGQoIerPuVdXwK/EUek8OOkJ6wVOWPUizRBJU0hDqWZCOROVpfBgCemaC3m6jDOXi03g==",
-      "peerDependencies": {
-        "emoji-mart": "^5.2",
-        "react": "^16.8 || ^17 || ^18"
-      }
-    },
     "node_modules/@emotion/babel-plugin": {
       "version": "11.12.0",
       "resolved": "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.12.0.tgz",
@@ -30602,11 +30593,11 @@
       "dependencies": {
         "@blocknote/core": "^0.24.2",
         "@emoji-mart/data": "^1.2.1",
-        "@emoji-mart/react": "^1.1.1",
         "@floating-ui/react": "^0.26.4",
         "@tiptap/core": "^2.7.1",
         "@tiptap/pm": "^2.7.1",
         "@tiptap/react": "^2.7.1",
+        "emoji-mart": "^5.6.0",
         "lodash.merge": "^4.6.2",
         "react-icons": "^5.2.1"
       },

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -54,11 +54,11 @@
   "dependencies": {
     "@blocknote/core": "^0.24.2",
     "@emoji-mart/data": "^1.2.1",
-    "@emoji-mart/react": "^1.1.1",
     "@floating-ui/react": "^0.26.4",
     "@tiptap/core": "^2.7.1",
     "@tiptap/react": "^2.7.1",
     "@tiptap/pm": "^2.7.1",
+    "emoji-mart": "^5.6.0",
     "lodash.merge": "^4.6.2",
     "react-icons": "^5.2.1"
   },

--- a/packages/react/src/components/Comments/EmojiMartPicker.tsx
+++ b/packages/react/src/components/Comments/EmojiMartPicker.tsx
@@ -1,0 +1,23 @@
+// From https://github.com/missive/emoji-mart/blob/main/packages/emoji-mart-react/react.tsx
+import React, { useEffect, useRef } from "react";
+import { Picker } from "emoji-mart";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export default function EmojiPicker(props: any) {
+  const ref = useRef(null);
+  const instance = useRef(null) as any;
+
+  if (instance.current) {
+    instance.current.update(props);
+  }
+
+  useEffect(() => {
+    instance.current = new Picker({ ...props, ref });
+
+    return () => {
+      instance.current = null;
+    };
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  return React.createElement("div", { ref });
+}

--- a/packages/react/src/components/Comments/EmojiPicker.tsx
+++ b/packages/react/src/components/Comments/EmojiPicker.tsx
@@ -1,8 +1,8 @@
-import Picker from "@emoji-mart/react";
 import { ReactNode, useState } from "react";
 
 import { useComponentsContext } from "../../editor/ComponentsContext.js";
 import { useBlockNoteContext } from "../../editor/BlockNoteContext.js";
+import Picker from "./EmojiMartPicker.js";
 
 export const EmojiPicker = (props: {
   onEmojiSelect: (emoji: { native: string }) => void;


### PR DESCRIPTION
`@emoji-mart/react` is not compatible with React 19 and is only one file, so this PR changes it from a dependency to just a copy of the file