### PR TITLE
fix: Link toolbar update error

### DIFF
--- a/packages/core/src/extensions/LinkToolbar/LinkToolbarPlugin.ts
+++ b/packages/core/src/extensions/LinkToolbar/LinkToolbarPlugin.ts
@@ -52,7 +52,7 @@ class LinkToolbarView implements PluginView {
 
     this.startMenuUpdateTimer = () => {
       this.menuUpdateTimer = setTimeout(() => {
-        this.update(this.pmView);
+        this.update(this.pmView, undefined, true);
       }, 250);
     };
 
@@ -190,7 +190,7 @@ class LinkToolbarView implements PluginView {
     }
   }
 
-  update(view: EditorView, oldState?: EditorState) {
+  update(view: EditorView, oldState?: EditorState, fromMouseOver = false) {
     const { state } = view;
 
     const isSame =
@@ -235,7 +235,7 @@ class LinkToolbarView implements PluginView {
       }
     }
 
-    if (this.mouseHoveredLinkMark) {
+    if (this.mouseHoveredLinkMark && fromMouseOver) {
       this.linkMark = this.mouseHoveredLinkMark;
       this.linkMarkRange = this.mouseHoveredLinkMarkRange;
     }


### PR DESCRIPTION
This PR fixes an bug with the link toolbar, where `mouseHoveredLinkMark` may be defined even when the mouse cursor isn't hovering any links. This is because the plugin would check if a link is currently hovered by the keyboard or mouse on every state update. State updates may cause the link under the mouse cursor move or be removed outright (such as moving blocks up & down, where it's briefly removed when replacing blocks). However, as no `mouseover` event is fired, `mouseHoveredLinkMark` doesn't get cleared and so an error is thrown if the link doesn't exist.

Therefore, this PR changes the behaviour so that only `keyboardHoveredLinkMark` is considered when updating the link toolbar, unless the update was explicitly called by the `mouseover` handler.

Closes #1479 