### PR TITLE
fix: scope cursor caret CSS to be more specific

### DIFF
--- a/packages/core/src/editor/editor.css
+++ b/packages/core/src/editor/editor.css
@@ -86,11 +86,11 @@ Tippy popups that are appended to document.body directly
   opacity: 0.001;
 }
 
-.collaboration-cursor__base {
+.bn-editor .collaboration-cursor__base {
   position: relative;
 }
 
-.collaboration-cursor__caret {
+.bn-editor .collaboration-cursor__base .collaboration-cursor__caret {
   position: absolute;
   width: 2px;
   top: 1px;
@@ -98,7 +98,7 @@ Tippy popups that are appended to document.body directly
   left: -1px;
 }
 
-.collaboration-cursor__label {
+.bn-editor .collaboration-cursor__base .collaboration-cursor__label {
   pointer-events: none;
   border-radius: 0 1.5px 1.5px 0;
   font-size: 12px;
@@ -119,7 +119,9 @@ Tippy popups that are appended to document.body directly
   transition: all 0.2s;
 }
 
-.collaboration-cursor__base[data-active] .collaboration-cursor__label {
+.bn-editor
+  .collaboration-cursor__base[data-active]
+  .collaboration-cursor__label {
   color: #0d0d0d;
   max-height: 1.1rem;
   max-width: 20rem;


### PR DESCRIPTION
To help in our liveblocks integration, we are scoping the styles of our cursors to be more specific (based on the `.collaboration-cursor__base` classname) so that we do not conflict with the styles they have setup to style the default tiptap cursors

So, for their CSS to work properly, they will need to provide their own cursor rendering logic to match the default Tiptap one
