### PR TITLE
fix: Backspace in empty block deletes previous block

### DIFF
--- a/packages/core/src/extensions/KeyboardShortcuts/KeyboardShortcutsExtension.ts
+++ b/packages/core/src/extensions/KeyboardShortcuts/KeyboardShortcutsExtension.ts
@@ -292,6 +292,24 @@ export const KeyboardShortcutsExtension = Extension.create<{
                 throw new Error(`todo`);
               }
 
+              const currentBlockNotTableAndNoContent =
+                blockInfo.blockContent.node.type.spec.content === "" ||
+                (blockInfo.blockContent.node.type.spec.content === "inline*" &&
+                  blockInfo.blockContent.node.childCount === 0);
+
+              if (currentBlockNotTableAndNoContent) {
+                const pos = state.tr.doc.resolve(
+                  blockInfo.bnBlock.beforePos - 2
+                );
+                state.tr.setSelection(new TextSelection(pos));
+                return chain()
+                  .deleteRange({
+                    from: blockInfo.bnBlock.beforePos,
+                    to: blockInfo.bnBlock.afterPos,
+                  })
+                  .run();
+              }
+
               const prevBlockNotTableAndNoContent =
                 bottomBlock.blockContent.node.type.spec.content === "" ||
                 (bottomBlock.blockContent.node.type.spec.content ===


### PR DESCRIPTION
This suggestion is for resolving some weird behaviour with the backspace like: Fixes #605 Fixes #1478 .
Also, when a block is empty and backspace is clicked, it makes more sense to remove the block as seen in here:

Old behaviour:
https://github.com/user-attachments/assets/85669900-267a-4f1f-8642-57585d2a77dd

New behaviour:
https://github.com/user-attachments/assets/9f7a8eff-83e0-4e06-af58-cdc275c162d6


