### PR TITLE
fix: export react components #1509

### DIFF
--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -18,6 +18,8 @@ export * from "./blocks/ImageBlockContent/ImageBlockContent.js";
 export * from "./blocks/PageBreakBlockContent/getPageBreakReactSlashMenuItems.js";
 export * from "./blocks/VideoBlockContent/VideoBlockContent.js";
 
+export * from "./components/FormattingToolbar/DefaultButtons/AddCommentButton.js";
+export * from "./components/FormattingToolbar/DefaultButtons/AddTiptapCommentButton.js";
 export * from "./components/FormattingToolbar/DefaultButtons/BasicTextStyleButton.js";
 export * from "./components/FormattingToolbar/DefaultButtons/ColorStyleButton.js";
 export * from "./components/FormattingToolbar/DefaultButtons/CreateLinkButton.js";
@@ -28,6 +30,7 @@ export * from "./components/FormattingToolbar/DefaultButtons/FilePreviewButton.j
 export * from "./components/FormattingToolbar/DefaultButtons/FileRenameButton.js";
 export * from "./components/FormattingToolbar/DefaultButtons/FileReplaceButton.js";
 export * from "./components/FormattingToolbar/DefaultButtons/NestBlockButtons.js";
+export * from "./components/FormattingToolbar/DefaultButtons/TableCellMergeButton.js";
 export * from "./components/FormattingToolbar/DefaultButtons/TextAlignButton.js";
 export * from "./components/FormattingToolbar/DefaultSelects/BlockTypeSelect.js";
 export * from "./components/FormattingToolbar/FormattingToolbar.js";
@@ -81,6 +84,13 @@ export * from "./components/TableHandles/ExtendButton/ExtendButton.js";
 export * from "./components/TableHandles/ExtendButton/ExtendButtonProps.js";
 export * from "./components/TableHandles/hooks/useExtendButtonsPositioning.js";
 export * from "./components/TableHandles/hooks/useTableHandlesPositioning.js";
+
+export * from "./components/TableHandles/TableCellMenu/DefaultButtons/ColorPicker.js";
+export * from "./components/TableHandles/TableCellMenu/DefaultButtons/SplitButton.js";
+export * from "./components/TableHandles/TableCellMenu/TableCellMenu.js";
+export * from "./components/TableHandles/TableCellMenu/TableCellMenuProps.js";
+export * from "./components/TableHandles/TableCellButton.js";
+export * from "./components/TableHandles/TableCellButtonProps.js";
 
 export * from "./components/TableHandles/TableHandleMenu/DefaultButtons/AddButton.js";
 export * from "./components/TableHandles/TableHandleMenu/DefaultButtons/DeleteButton.js";


### PR DESCRIPTION
This exports some of the new components we added in v0.25.0 that we forgot to export.

This exporting strategy is a bit of a mess, should consider revisiting this at some point
