### PR TITLE
fix: React custom blocks not valid drop targets

### DIFF
--- a/packages/react/src/schema/ReactBlockSpec.tsx
+++ b/packages/react/src/schema/ReactBlockSpec.tsx
@@ -71,6 +71,8 @@ export function BlockContentWrapper<
   return (
     // Creates `blockContent` element
     <NodeViewWrapper
+      onDragOver={(event: DragEvent) => event.preventDefault()}
+      // onDrop={(event) => event.preventDefault()}
       // Adds custom HTML attributes
       {...Object.fromEntries(
         Object.entries(props.domAttributes || {}).filter(


### PR DESCRIPTION
Dropping dragged blocks inside a React custom block may fail to actually fire a `drop` event. It seems like this is because they aren't seen as valid drop targets, so this PR makes them valid drop targets by adding the `dragover` listener.

The easiest way to see this is with the [alert](https://www.blocknotejs.org/examples/custom-schema/alert-block) block example. Try dragging a block from below it and dropping it on the alert type icon, so that the drop indicator is above the alert. The drop won't fire and the dragged block will return to its original position.

This doesn't seem to be necessary for vanilla JS custom blocks.