### PR TITLE
fix: small issues related to comments

### DIFF
--- a/packages/core/src/comments/threadstore/ThreadStore.ts
+++ b/packages/core/src/comments/threadstore/ThreadStore.ts
@@ -27,7 +27,7 @@ export abstract class ThreadStore {
         head: number;
         anchor: number;
       };
-      yjs: {
+      yjs?: {
         head: any;
         anchor: any;
       };

--- a/packages/core/src/editor/BlockNoteEditor.ts
+++ b/packages/core/src/editor/BlockNoteEditor.ts
@@ -587,12 +587,6 @@ export class BlockNoteEditor<
       );
     }
 
-    if (newOptions.comments && !collaborationEnabled) {
-      throw new Error(
-        "Comments are only supported when collaboration is enabled, please set the collaboration option"
-      );
-    }
-
     const initialContent =
       newOptions.initialContent ||
       (collaborationEnabled

--- a/packages/core/src/extensions/Comments/CommentMark.ts
+++ b/packages/core/src/extensions/Comments/CommentMark.ts
@@ -5,7 +5,6 @@ export const CommentMark = Mark.create({
   excludes: "",
   inclusive: false,
   keepOnSplit: true,
-  group: "blocknoteIgnore", // ignore in blocknote json
 
   addAttributes() {
     // Return an object with attribute configuration

--- a/packages/core/src/extensions/Comments/CommentsPlugin.ts
+++ b/packages/core/src/extensions/Comments/CommentsPlugin.ts
@@ -283,7 +283,9 @@ export class CommentsPlugin extends EventEmitter<any> {
           head: pmSelection.head,
           anchor: pmSelection.anchor,
         },
-        yjs: getRelativeSelection(ystate.binding, view.state),
+        yjs: ystate
+          ? getRelativeSelection(ystate.binding, view.state)
+          : undefined, // if we're not using yjs
       };
 
       await this.threadStore.addThreadToDocument({


### PR DESCRIPTION
- removes dependency + check for collaboration, so theoretically you should be able to use comments without yjs
- removes `blocknoteIgnore` (wasn't used, we directly use a property on the mark spec)