### PR TITLE
fix: Drag & drop for blocks with iframes not working

### DIFF
--- a/packages/core/src/extensions/SideMenu/dragging.ts
+++ b/packages/core/src/extensions/SideMenu/dragging.ts
@@ -66,7 +66,6 @@ function blockPositionsFromSelection(selection: Selection, doc: Node) {
 }
 
 function setDragImage(view: EditorView, from: number, to = from) {
-  // debugger;
   if (from === to) {
     // Moves to position to be just after the first (and only) selected block.
     to += view.state.doc.resolve(from + 1).node().nodeSize;

--- a/packages/core/src/extensions/SideMenu/dragging.ts
+++ b/packages/core/src/extensions/SideMenu/dragging.ts
@@ -66,6 +66,7 @@ function blockPositionsFromSelection(selection: Selection, doc: Node) {
 }
 
 function setDragImage(view: EditorView, from: number, to = from) {
+  // debugger;
   if (from === to) {
     // Moves to position to be just after the first (and only) selected block.
     to += view.state.doc.resolve(from + 1).node().nodeSize;
@@ -98,6 +99,19 @@ function setDragImage(view: EditorView, from: number, to = from) {
   // dataTransfer.setDragImage(element) only works if element is attached to the DOM.
   unsetDragImage(view.root);
   dragImageElement = parentClone;
+
+  // Browsers may have CORS policies which prevents iframes from being
+  // manipulated, so better to stay on the safe side and remove them from the
+  // drag preview. The drag preview doesn't work with iframes anyway.
+  const iframes = dragImageElement.getElementsByTagName("iframe");
+  for (let i = 0; i < iframes.length; i++) {
+    const iframe = iframes[i];
+    const parent = iframe.parentElement;
+
+    if (parent) {
+      parent.removeChild(iframe);
+    }
+  }
 
   // TODO: This is hacky, need a better way of assigning classes to the editor so that they can also be applied to the
   //  drag preview.


### PR DESCRIPTION
Pretty self explanatory, only seems to be an issue for Chrome but disabled for all browsers since iframes don't correctly show in the drag preview anyway.