### PR TITLE
feat: split out localization files for optimized bundle

### DIFF
--- a/docs/components/pages/landing/hero/DemoEditor.tsx
+++ b/docs/components/pages/landing/hero/DemoEditor.tsx
@@ -2,9 +2,9 @@ import {
   BlockNoteSchema,
   combineByGroup,
   filterSuggestionItems,
-  locales,
   uploadToTmpFilesDotOrg_DEV_ONLY,
 } from "@blocknote/core";
+import { locales } from "@blocknote/core/locales";
 import "@blocknote/core/fonts/inter.css";
 import {
   getDefaultReactSlashMenuItems,

--- a/docs/components/pages/landing/hero/DemoEditor.tsx
+++ b/docs/components/pages/landing/hero/DemoEditor.tsx
@@ -4,7 +4,7 @@ import {
   filterSuggestionItems,
   uploadToTmpFilesDotOrg_DEV_ONLY,
 } from "@blocknote/core";
-import { locales } from "@blocknote/core/locales";
+import * as locales from "@blocknote/core/locales";
 import "@blocknote/core/fonts/inter.css";
 import {
   getDefaultReactSlashMenuItems,

--- a/examples/01-basic/03-multi-column/App.tsx
+++ b/examples/01-basic/03-multi-column/App.tsx
@@ -2,8 +2,8 @@ import {
   BlockNoteSchema,
   combineByGroup,
   filterSuggestionItems,
-  locales,
 } from "@blocknote/core";
+import { locales } from "@blocknote/core/locales";
 import "@blocknote/core/fonts/inter.css";
 import { BlockNoteView } from "@blocknote/mantine";
 import "@blocknote/mantine/style.css";

--- a/examples/01-basic/03-multi-column/App.tsx
+++ b/examples/01-basic/03-multi-column/App.tsx
@@ -3,7 +3,7 @@ import {
   combineByGroup,
   filterSuggestionItems,
 } from "@blocknote/core";
-import { locales } from "@blocknote/core/locales";
+import * as locales from "@blocknote/core/locales";
 import "@blocknote/core/fonts/inter.css";
 import { BlockNoteView } from "@blocknote/mantine";
 import "@blocknote/mantine/style.css";

--- a/examples/01-basic/10-localization/App.tsx
+++ b/examples/01-basic/10-localization/App.tsx
@@ -1,4 +1,4 @@
-import { locales } from "@blocknote/core/locales";
+import { nl } from "@blocknote/core/locales";
 import "@blocknote/core/fonts/inter.css";
 import { BlockNoteView } from "@blocknote/mantine";
 import "@blocknote/mantine/style.css";
@@ -12,7 +12,7 @@ export default function App() {
     // Passes the Dutch (NL) dictionary to the editor instance.
     // You can also provide your own dictionary here to customize the strings used in the editor,
     // or submit a Pull Request to add support for your language of your choice
-    dictionary: locales.nl,
+    dictionary: nl,
     // dictionary: locales[lang as keyof typeof locales], // Use the language from the i18n library dynamically
   });
 

--- a/examples/01-basic/10-localization/App.tsx
+++ b/examples/01-basic/10-localization/App.tsx
@@ -1,4 +1,4 @@
-import { locales } from "@blocknote/core";
+import { locales } from "@blocknote/core/locales";
 import "@blocknote/core/fonts/inter.css";
 import { BlockNoteView } from "@blocknote/mantine";
 import "@blocknote/mantine/style.css";

--- a/examples/01-basic/11-custom-placeholder/App.tsx
+++ b/examples/01-basic/11-custom-placeholder/App.tsx
@@ -1,4 +1,4 @@
-import { locales } from "@blocknote/core";
+import { en } from "@blocknote/core/locales";
 import "@blocknote/core/fonts/inter.css";
 import { BlockNoteView } from "@blocknote/mantine";
 import "@blocknote/mantine/style.css";
@@ -6,7 +6,7 @@ import { useCreateBlockNote } from "@blocknote/react";
 
 export default function App() {
   // We use the English, default dictionary
-  const locale = locales["en"];
+  const locale = en;
 
   // Creates a new editor instance.
   const editor = useCreateBlockNote({

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -49,6 +49,11 @@
       "types": "./types/src/comments/index.d.ts",
       "import": "./dist/comments.js",
       "require": "./dist/comments.cjs"
+    },
+    "./locales": {
+      "types": "./types/src/i18n/index.d.ts",
+      "import": "./dist/locales.js",
+      "require": "./dist/locales.cjs"
     }
   },
   "scripts": {

--- a/packages/core/src/i18n/index.ts
+++ b/packages/core/src/i18n/index.ts
@@ -1,2 +1,3 @@
 export * as locales from "./locales/index.js";
+export * from "./locales/index.js";
 export * from "./dictionary.js";

--- a/packages/core/src/i18n/index.ts
+++ b/packages/core/src/i18n/index.ts
@@ -1,3 +1,2 @@
-export * as locales from "./locales/index.js";
 export * from "./locales/index.js";
 export * from "./dictionary.js";

--- a/packages/core/src/i18n/index.ts
+++ b/packages/core/src/i18n/index.ts
@@ -1,0 +1,2 @@
+export * as locales from "./locales/index.js";
+export * from "./dictionary.js";

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,4 +1,3 @@
-import * as locales from "./i18n/locales/index.js";
 export * from "./api/blockManipulation/commands/updateBlock/updateBlock.js";
 export * from "./api/exporters/html/externalHTMLExporter.js";
 export * from "./api/exporters/html/internalHTMLSerializer.js";
@@ -57,7 +56,6 @@ export * from "./util/table.js";
 export * from "./util/string.js";
 export * from "./util/typescript.js";
 export { UnreachableCaseError, assertEmpty } from "./util/typescript.js";
-export { locales };
 
 // for testing from react (TODO: move):
 export * from "./api/nodeConversions/blockToNode.js";
@@ -69,4 +67,3 @@ export * from "./extensions/UniqueID/UniqueID.js";
 export * from "./api/exporters/markdown/markdownExporter.js";
 export * from "./api/parsers/html/parseHTML.js";
 export * from "./api/parsers/markdown/parseMarkdown.js";
-

--- a/packages/core/vite.config.ts
+++ b/packages/core/vite.config.ts
@@ -19,6 +19,7 @@ export default defineConfig({
       entry: {
         blocknote: path.resolve(__dirname, "src/index.ts"),
         comments: path.resolve(__dirname, "src/comments/index.ts"),
+        locales: path.resolve(__dirname, "src/i18n/index.ts"),
       },
       name: "blocknote",
       formats: ["es", "cjs"],


### PR DESCRIPTION
Is a breaking change, since I had to change the export, but an easy one to make

Before:
```txt
vite v5.3.4 building for production...
✓ 168 modules transformed.
dist/webpack-stats.json   14.00 kB │ gzip:  2.39 kB
dist/style.css            11.63 kB │ gzip:  2.82 kB
dist/comments.js          17.39 kB │ gzip:  3.51 kB │ map:    49.43 kB
dist/blocknote.js        416.35 kB │ gzip: 93.27 kB │ map: 1,103.85 kB
dist/webpack-stats.json   14.01 kB │ gzip:  2.41 kB
dist/style.css            11.63 kB │ gzip:  2.82 kB
dist/comments.cjs         11.72 kB │ gzip:  2.85 kB │ map:    47.30 kB
dist/blocknote.cjs       273.46 kB │ gzip: 72.57 kB │ map: 1,044.26 kB
✓ built in 506ms
```

After:

```txt
vite v5.3.4 building for production...
✓ 170 modules transformed.
dist/webpack-stats.json   14.50 kB │ gzip:  2.52 kB
dist/style.css            11.63 kB │ gzip:  2.82 kB
dist/en-BEb_5vQO.js        7.78 kB │ gzip:  1.91 kB │ map:  14.03 kB
dist/comments.js          17.39 kB │ gzip:  3.51 kB │ map:  49.43 kB
dist/locales.js          135.64 kB │ gzip: 27.15 kB │ map: 238.90 kB
dist/blocknote.js        274.20 kB │ gzip: 65.23 kB │ map: 853.96 kB
dist/webpack-stats.json   14.51 kB │ gzip:  2.52 kB
dist/style.css            11.63 kB │ gzip:  2.82 kB
dist/en-DoDAHwFo.cjs       5.34 kB │ gzip:  1.76 kB │ map:  12.34 kB
dist/comments.cjs         11.72 kB │ gzip:  2.85 kB │ map:  47.30 kB
dist/locales.cjs          93.50 kB │ gzip: 24.76 kB │ map: 210.56 kB
dist/blocknote.cjs       175.52 kB │ gzip: 47.01 kB │ map: 823.91 kB
✓ built in 588ms
```

Shaved ~100kb from cjs


Now, to import locales you can either do it individually like:

```js
import { en, nl, de } from '@blocknote/core/locales';
```

Or, all together like:

```js
import * as locales from '@blocknote/core/locales';
```