### PR TITLE
fix: immediately add nodeviews to fix flushSync error

### DIFF
--- a/packages/core/src/editor/BlockNoteTipTapEditor.ts
+++ b/packages/core/src/editor/BlockNoteTipTapEditor.ts
@@ -174,18 +174,20 @@ export class BlockNoteTipTapEditor extends TiptapEditor {
         dispatchTransaction: this.dispatchTransaction.bind(this),
         state: this.state,
         markViews,
+        nodeViews: this.extensionManager.nodeViews,
       }
     );
 
     // `editor.view` is not yet available at this time.
-    // Therefore we will add all plugins and node views directly afterwards.
+    // Therefore we will add all plugins directly afterwards.
+    //
+    // To research: this is the default tiptap behavior, but might actually not be necessary
+    // it feels like it's a workaround for plugins that don't account for the view not being available yet
     const newState = this.state.reconfigure({
       plugins: this.extensionManager.plugins,
     });
 
     this.view.updateState(newState);
-
-    this.createNodeViews();
 
     // emit the created event, call here manually because we blocked the default call in the constructor
     // (https://github.com/ueberdosis/tiptap/blob/45bac803283446795ad1b03f43d3746fa54a68ff/packages/core/src/Editor.ts#L117)


### PR DESCRIPTION
closes https://github.com/TypeCellOS/BlockNote/issues/1513

This only happened for custom react inline content, and not for custom blocks.

The issue was that the creation of the EditorView triggered a prosemirror render calling `renderHTML` on these elements because the nodeviews hadn't been registered yet. For react inline content / react styles, this is implemented by calling `renderToDOMSpec` which triggers a `flushSync`. With this fix, the call to `renderHTML` is avoided as the NodeView will be triggered instead.

A different way to fix this would actually to not use `renderToDOMSpec`  in `renderHTML`, but make it more similar to how we do it for custom blocks. This goes deep into the internals, but would require implementing `toInternalHTML` and `toExternalHTML` for inline content / styles - which I think is out of scope for now. If we were to revisit that, we'd also need to see if that approach still makes sense or whether for HTML serialization we can go all in on the approach we have for pdf / docx exporters