### PR TITLE
fix: Overlapping marks in comments

### DIFF
--- a/examples/07-collaboration/04-comments/style.css
+++ b/examples/07-collaboration/04-comments/style.css
@@ -11,7 +11,7 @@
 }
 
 .comments-main-container .bn-editor {
-  max-height: 100%;
+  height: 100%;
   max-width: 700px;
   overflow: auto;
   width: 100%;

--- a/package-lock.json
+++ b/package-lock.json
@@ -20225,9 +20225,9 @@
       }
     },
     "node_modules/lib0": {
-      "version": "0.2.94",
-      "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.94.tgz",
-      "integrity": "sha512-hZ3p54jL4Wpu7IOg26uC7dnEWiMyNlUrb9KoG7+xYs45WkQwpVvKFndVq2+pqLYKe1u8Fp3+zAfZHVvTK34PvQ==",
+      "version": "0.2.101",
+      "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.101.tgz",
+      "integrity": "sha512-LljA6+Ehf0Z7YnxhgSAvspzWALjW4wlWdN/W4iGiqYc1KvXQgOVXWI0xwlwqozIL5WRdKeUW2gq0DLhFsY+Xlw==",
       "dependencies": {
         "isomorphic.js": "^0.2.4"
       },
@@ -31034,11 +31034,11 @@
       }
     },
     "node_modules/y-prosemirror": {
-      "version": "1.2.17",
-      "resolved": "https://registry.npmjs.org/y-prosemirror/-/y-prosemirror-1.2.17.tgz",
-      "integrity": "sha512-9bmO5Vl6E3AH5JRQhJPWOmX4x0dwDZvfM86qd+w38G0j23VSV+ZvrKYBbKc1l44Tnyd7j7TWEuqBpzfOfbc4fw==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/y-prosemirror/-/y-prosemirror-1.3.0.tgz",
+      "integrity": "sha512-KOCwxdn+tHXauZxgbTWI5RtdL+c1ByzQ4pls6P5tKk+G1UfMqIMXByRYp4fDp23RSWsjbbkWeM5esyN8lN81xg==",
       "dependencies": {
-        "lib0": "^0.2.42"
+        "lib0": "^0.2.100"
       },
       "engines": {
         "node": ">=16.0.0",
@@ -31331,7 +31331,7 @@
         "remark-stringify": "^10.0.2",
         "unified": "^10.1.2",
         "uuid": "^8.3.2",
-        "y-prosemirror": "1.2.17",
+        "y-prosemirror": "1.3.0",
         "y-protocols": "^1.0.6",
         "yjs": "^13.6.15"
       },
@@ -31573,7 +31573,7 @@
         "@tiptap/core": "^2.7.1",
         "@tiptap/pm": "^2.7.1",
         "jsdom": "^25.0.1",
-        "y-prosemirror": "1.2.17",
+        "y-prosemirror": "1.3.0",
         "y-protocols": "^1.0.6",
         "yjs": "^13.6.15"
       },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -107,7 +107,7 @@
     "remark-stringify": "^10.0.2",
     "unified": "^10.1.2",
     "uuid": "^8.3.2",
-    "y-prosemirror": "1.2.17",
+    "y-prosemirror": "1.3.0",
     "y-protocols": "^1.0.6",
     "yjs": "^13.6.15"
   },

--- a/packages/core/src/extensions/Comments/CommentsPlugin.ts
+++ b/packages/core/src/extensions/Comments/CommentsPlugin.ts
@@ -106,7 +106,7 @@ export class CommentsPlugin extends EventEmitter<any> {
               pos + node.nodeSize,
               ttEditor.state.doc.content.size - 1
             );
-            tr.removeMark(trimmedFrom, trimmedTo, markType);
+            tr.removeMark(trimmedFrom, trimmedTo, mark);
             tr.addMark(
               trimmedFrom,
               trimmedTo,

--- a/packages/server-util/package.json
+++ b/packages/server-util/package.json
@@ -55,7 +55,7 @@
     "@tiptap/core": "^2.7.1",
     "@tiptap/pm": "^2.7.1",
     "jsdom": "^25.0.1",
-    "y-prosemirror": "1.2.17",
+    "y-prosemirror": "1.3.0",
     "y-protocols": "^1.0.6",
     "yjs": "^13.6.15"
   },


### PR DESCRIPTION
This PR updates y-prosemirror to v1.3.0, which adds support for overlapping marks. While updating the package does fix the issue, it seems to be pretty much incompatible with clients running the older version. Clients running the new version can still view, resolve, react to, reply to, and delete existing comments, but trying to create a new thread doesn't work properly.

The mark is created correctly and the thread + comment are added to the thread store, but the block containing the mark are deleted immediately after. I spent some time looking into this but could not figure out where this deletion is happening.

Documents which only have clients on the new version work fine.