### PR TITLE
fix: some more sentry fixes

### DIFF
--- a/packages/core/src/editor/BlockNoteEditor.ts
+++ b/packages/core/src/editor/BlockNoteEditor.ts
@@ -1502,6 +1502,9 @@ export class BlockNoteEditor<
     if (!raw) {
       htmlToPaste = this.convertHtmlToBlockNoteHtml(html);
     }
+    if (!htmlToPaste) {
+      return;
+    }
     this.prosemirrorView?.pasteHTML(htmlToPaste);
   }
 

--- a/packages/core/src/extensions/SuggestionMenu/SuggestionPlugin.ts
+++ b/packages/core/src/extensions/SuggestionMenu/SuggestionPlugin.ts
@@ -86,7 +86,9 @@ class SuggestionMenuView<
     this.pluginState = stopped ? prev : next;
 
     if (stopped || !this.editor.isEditable) {
-      this.state!.show = false;
+      if (this.state) {
+        this.state.show = false;
+      }
       this.emitUpdate(this.pluginState!.triggerCharacter);
 
       return;

--- a/packages/react/src/components/Comments/ThreadsSidebar.tsx
+++ b/packages/react/src/components/Comments/ThreadsSidebar.tsx
@@ -44,7 +44,8 @@ const ThreadItem = React.memo(
         // If the focused element is within the action toolbar, we don't want to
         // blur the thread for UX reasons.
         if (
-          (event.relatedTarget as HTMLElement).closest(".bn-action-toolbar")
+          !event.relatedTarget ||
+          event.relatedTarget.closest(".bn-action-toolbar")
         ) {
           return;
         }


### PR DESCRIPTION
- **fix: check if relatedTarget exists first**
    Resolves: https://blocknote-js.sentry.io/issues/32235378/
- **fix: early exit if html ends up being empty**
    Resolves: https://blocknote-js.sentry.io/issues/32467184
- **fix: only set state if it exists**
   Resolves: https://blocknote-js.sentry.io/issues/33990038/?environment=vercel-production&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D&referrer=issue-stream&stream_index=23
