### PR TITLE
feat: add nodeview props in reactinline contentspec

### DIFF
--- a/packages/react/src/schema/ReactInlineContentSpec.tsx
+++ b/packages/react/src/schema/ReactInlineContentSpec.tsx
@@ -39,6 +39,9 @@ export type ReactInlineContentImplementation<
       update: PartialCustomInlineContentFromConfig<T, S>
     ) => void;
     contentRef: (node: HTMLElement | null) => void;
+    node: NodeViewProps["node"];
+    getPos: NodeViewProps["getPos"];
+    selected: NodeViewProps["selected"];
   }>;
   // TODO?
   // toExternalHTML?: FC<{
@@ -133,6 +136,9 @@ export function createReactInlineContentSpec<
               // No-op
             }}
             contentRef={refCB}
+            // @ts-expect-error
+            getPos={() => {}}
+            selected={false}
           />
         ),
         editor
@@ -188,6 +194,9 @@ export function createReactInlineContentSpec<
                       )
                     );
                   }}
+                  getPos={props.getPos}
+                  selected={props.selected}
+                  node={props.node}
                 />
               </InlineContentWrapper>
             );


### PR DESCRIPTION
This PR adds a few additional props to align feature parity between Tiptap and BlockNote's inline content handling.
While migrating from Tiptap to BlockNote, I encountered a few missing features that were previously supported in Tiptap. Specifically, some custom extensions relied on the `getPos` and `node` props that weren’t available in BlockNote's `createReactInlineContentSpec`'s `render` function.
This PR makes smoother migration paths from previous Tiptap users and achieve feature parity.