### PR TITLE
fix(docs): update key `strikethrough` to `strike` for the default `Styles` type

### DIFF
--- a/docs/pages/docs/editor-basics/default-schema.mdx
+++ b/docs/pages/docs/editor-basics/default-schema.mdx
@@ -195,7 +195,7 @@ type Styles = {
   bold: boolean;
   italic: boolean;
   underline: boolean;
-  strikethrough: boolean;
+  strike: boolean;
   textColor: string;
   backgroundColor: string;
 };


### PR DESCRIPTION
This fixes the documentation, update `Default Schema > Default Styles > type Style`'s key `strikethrough` to `strike`.

[Docs for Default Styles](https://www.blocknotejs.org/docs/editor-basics/default-schema#default-styles) shows:

```typescript
type Styles = {
  bold: boolean;
  italic: boolean;
  underline: boolean;
  strikethrough: boolean; // this sholud be `strike`
  textColor: string;
  backgroundColor: string;
};
```

Here's the partial JSON from a request body on `v0.14.0`. I have checked the current `main` branch as of today, and found the value `strike` is the same.

```json
{
    "note": [
        {
            // ... id, type, and props
            "content": [
                {
                    "type": "text",
                    "text": "main text ",
                    "styles": {}
                },
                {
                    "type": "link",
                    "href": "https://google.com",
                    "content": [
                        {
                            "type": "text",
                            "text": "link text",
                            "styles": {
                                "bold": true,
                                "italic": true,
                                "underline": true,
                                "strike": true, // SEE HERE
                                "textColor": "pink",
                                "backgroundColor": "orange"
                            }
                        }
                    ]
                }
            ],
            // ... rest
        }
    ]
}
```