### PR TITLE
fix: allow opening another suggestion menu if another is triggered #1473

### DIFF
--- a/packages/core/src/extensions/SuggestionMenu/SuggestionPlugin.ts
+++ b/packages/core/src/extensions/SuggestionMenu/SuggestionPlugin.ts
@@ -260,7 +260,11 @@ export class SuggestionMenuProseMirrorPlugin<
             transaction.getMeta("pointer") ||
             // Moving the caret before the character which triggered the menu should hide it.
             (prev.triggerCharacter !== undefined &&
-              newState.selection.from < prev.queryStartPos())
+              newState.selection.from < prev.queryStartPos()) ||
+            // Moving the caret to a new block should hide the menu.
+            !newState.selection.$from.sameParent(
+              newState.doc.resolve(prev.queryStartPos())
+            )
           ) {
             return undefined;
           }

--- a/packages/core/src/extensions/SuggestionMenu/SuggestionPlugin.ts
+++ b/packages/core/src/extensions/SuggestionMenu/SuggestionPlugin.ts
@@ -215,11 +215,9 @@ export class SuggestionMenuProseMirrorPlugin<
             ignoreQueryLength?: boolean;
           } | null = transaction.getMeta(suggestionMenuPluginKey);
 
-          // Only opens a menu of no menu is already open
           if (
             typeof suggestionPluginTransactionMeta === "object" &&
-            suggestionPluginTransactionMeta !== null &&
-            prev === undefined
+            suggestionPluginTransactionMeta !== null
           ) {
             const trackedPosition = trackPosition(
               editor,
@@ -281,14 +279,7 @@ export class SuggestionMenuProseMirrorPlugin<
 
       props: {
         handleTextInput(view, _from, _to, text) {
-          const suggestionPluginState: SuggestionPluginState = (
-            this as Plugin
-          ).getState(view.state);
-
-          if (
-            triggerCharacters.includes(text) &&
-            suggestionPluginState === undefined
-          ) {
+          if (triggerCharacters.includes(text)) {
             view.dispatch(
               view.state.tr
                 .insertText(text)

--- a/packages/core/src/extensions/SuggestionMenu/SuggestionPlugin.ts
+++ b/packages/core/src/extensions/SuggestionMenu/SuggestionPlugin.ts
@@ -196,7 +196,12 @@ export class SuggestionMenuProseMirrorPlugin<
         },
 
         // Apply changes to the plugin state from an editor transaction.
-        apply(transaction, prev, _oldState, newState): SuggestionPluginState {
+        apply: (
+          transaction,
+          prev,
+          _oldState,
+          newState
+        ): SuggestionPluginState => {
           // TODO: More clearly define which transactions should be ignored.
           if (transaction.getMeta("orderedListIndexing") !== undefined) {
             return prev;
@@ -219,6 +224,10 @@ export class SuggestionMenuProseMirrorPlugin<
             typeof suggestionPluginTransactionMeta === "object" &&
             suggestionPluginTransactionMeta !== null
           ) {
+            if (prev) {
+              // Close the previous menu if it exists
+              this.closeMenu();
+            }
             const trackedPosition = trackPosition(
               editor,
               newState.selection.from -


### PR DESCRIPTION
This resolves #1473 by allowing the suggestion plugin to switch from one menu to another if it encounters another trigger character

https://github.com/user-attachments/assets/48765b2c-0cce-46d8-9432-e7490d704a4f

This also resolves another issue I ran into personally.

If you type something that ends with `:` that menu is carried over to the new block, even though it shouldn't here is a video before & after.

Before:

https://github.com/user-attachments/assets/8123f0e1-8107-464a-9597-a5da187948de

After:

https://github.com/user-attachments/assets/276d380c-1a17-4a3c-b877-80715a76a1b5


