### PR TITLE
refactor: from the `@blocknote/core/comments` package, export the CommentMark

### DIFF
--- a/packages/core/src/comments/index.ts
+++ b/packages/core/src/comments/index.ts
@@ -7,3 +7,4 @@ export * from "./threadstore/yjs/RESTYjsThreadStore.js";
 export * from "./threadstore/yjs/YjsThreadStore.js";
 export * from "./threadstore/yjs/YjsThreadStoreBase.js";
 export * from "./types.js";
+export { CommentMark } from "../extensions/Comments/CommentMark.js";


### PR DESCRIPTION
This exposes the CommentMark to get around the need to instantiate the editor with comments in the schema
