### PR TITLE
fix: switch to only using transactions instead of prosemirrorState

### DIFF
--- a/packages/core/src/api/blockManipulation/commands/insertBlocks/__snapshots__/insertBlocks.test.ts.snap
+++ b/packages/core/src/api/blockManipulation/commands/insertBlocks/__snapshots__/insertBlocks.test.ts.snap
@@ -7,6 +7,62 @@ exports[`Test insertBlocks > Insert multiple blocks after 1`] = `
     "content": [
       {
         "styles": {},
+        "text": "Inserted paragraph 1",
+        "type": "text",
+      },
+    ],
+    "id": "0",
+    "props": {
+      "backgroundColor": "default",
+      "textAlignment": "left",
+      "textColor": "default",
+    },
+    "type": "paragraph",
+  },
+  {
+    "children": [],
+    "content": [
+      {
+        "styles": {},
+        "text": "Inserted paragraph 2",
+        "type": "text",
+      },
+    ],
+    "id": "1",
+    "props": {
+      "backgroundColor": "default",
+      "textAlignment": "left",
+      "textColor": "default",
+    },
+    "type": "paragraph",
+  },
+  {
+    "children": [],
+    "content": [
+      {
+        "styles": {},
+        "text": "Inserted paragraph 3",
+        "type": "text",
+      },
+    ],
+    "id": "2",
+    "props": {
+      "backgroundColor": "default",
+      "textAlignment": "left",
+      "textColor": "default",
+    },
+    "type": "paragraph",
+  },
+]
+`;
+
+exports[`Test insertBlocks > Insert multiple blocks after 2`] = `
+[
+  {
+    "children": [],
+    "content": [
+      {
+        "styles": {},
         "text": "Paragraph 0",
         "type": "text",
       },
@@ -671,6 +727,62 @@ exports[`Test insertBlocks > Insert multiple blocks before 1`] = `
     },
     "type": "paragraph",
   },
+]
+`;
+
+exports[`Test insertBlocks > Insert multiple blocks before 2`] = `
+[
+  {
+    "children": [],
+    "content": [
+      {
+        "styles": {},
+        "text": "Inserted paragraph 1",
+        "type": "text",
+      },
+    ],
+    "id": "0",
+    "props": {
+      "backgroundColor": "default",
+      "textAlignment": "left",
+      "textColor": "default",
+    },
+    "type": "paragraph",
+  },
+  {
+    "children": [],
+    "content": [
+      {
+        "styles": {},
+        "text": "Inserted paragraph 2",
+        "type": "text",
+      },
+    ],
+    "id": "1",
+    "props": {
+      "backgroundColor": "default",
+      "textAlignment": "left",
+      "textColor": "default",
+    },
+    "type": "paragraph",
+  },
+  {
+    "children": [],
+    "content": [
+      {
+        "styles": {},
+        "text": "Inserted paragraph 3",
+        "type": "text",
+      },
+    ],
+    "id": "2",
+    "props": {
+      "backgroundColor": "default",
+      "textAlignment": "left",
+      "textColor": "default",
+    },
+    "type": "paragraph",
+  },
   {
     "children": [],
     "content": [
@@ -1237,6 +1349,22 @@ exports[`Test insertBlocks > Insert multiple blocks before 1`] = `
 `;
 
 exports[`Test insertBlocks > Insert single basic block after 1`] = `
+[
+  {
+    "children": [],
+    "content": [],
+    "id": "0",
+    "props": {
+      "backgroundColor": "default",
+      "textAlignment": "left",
+      "textColor": "default",
+    },
+    "type": "paragraph",
+  },
+]
+`;
+
+exports[`Test insertBlocks > Insert single basic block after 2`] = `
 [
   {
     "children": [],
@@ -1833,6 +1961,28 @@ exports[`Test insertBlocks > Insert single basic block before (without type) 1`]
     },
     "type": "paragraph",
   },
+]
+`;
+
+exports[`Test insertBlocks > Insert single basic block before (without type) 2`] = `
+[
+  {
+    "children": [],
+    "content": [
+      {
+        "styles": {},
+        "text": "test",
+        "type": "text",
+      },
+    ],
+    "id": "0",
+    "props": {
+      "backgroundColor": "default",
+      "textAlignment": "left",
+      "textColor": "default",
+    },
+    "type": "paragraph",
+  },
   {
     "children": [],
     "content": [
@@ -2411,6 +2561,22 @@ exports[`Test insertBlocks > Insert single basic block before 1`] = `
     },
     "type": "paragraph",
   },
+]
+`;
+
+exports[`Test insertBlocks > Insert single basic block before 2`] = `
+[
+  {
+    "children": [],
+    "content": [],
+    "id": "0",
+    "props": {
+      "backgroundColor": "default",
+      "textAlignment": "left",
+      "textColor": "default",
+    },
+    "type": "paragraph",
+  },
   {
     "children": [],
     "content": [
@@ -2977,6 +3143,79 @@ exports[`Test insertBlocks > Insert single basic block before 1`] = `
 `;
 
 exports[`Test insertBlocks > Insert single complex block after 1`] = `
+[
+  {
+    "children": [
+      {
+        "children": [
+          {
+            "children": [],
+            "content": [
+              {
+                "styles": {},
+                "text": "Double Nested Paragraph 2",
+                "type": "text",
+              },
+            ],
+            "id": "inserted-double-nested-paragraph-2",
+            "props": {
+              "backgroundColor": "default",
+              "textAlignment": "left",
+              "textColor": "default",
+            },
+            "type": "paragraph",
+          },
+        ],
+        "content": [
+          {
+            "styles": {},
+            "text": "Nested Paragraph 2",
+            "type": "text",
+          },
+        ],
+        "id": "inserted-nested-paragraph-2",
+        "props": {
+          "backgroundColor": "default",
+          "textAlignment": "left",
+          "textColor": "default",
+        },
+        "type": "paragraph",
+      },
+    ],
+    "content": [
+      {
+        "styles": {
+          "bold": true,
+        },
+        "text": "Heading",
+        "type": "text",
+      },
+      {
+        "styles": {},
+        "text": " with styled ",
+        "type": "text",
+      },
+      {
+        "styles": {
+          "italic": true,
+        },
+        "text": "content",
+        "type": "text",
+      },
+    ],
+    "id": "inserted-heading-with-everything",
+    "props": {
+      "backgroundColor": "red",
+      "level": 2,
+      "textAlignment": "center",
+      "textColor": "red",
+    },
+    "type": "heading",
+  },
+]
+`;
+
+exports[`Test insertBlocks > Insert single complex block after 2`] = `
 [
   {
     "children": [],
@@ -3612,6 +3851,79 @@ exports[`Test insertBlocks > Insert single complex block after 1`] = `
 `;
 
 exports[`Test insertBlocks > Insert single complex block before 1`] = `
+[
+  {
+    "children": [
+      {
+        "children": [
+          {
+            "children": [],
+            "content": [
+              {
+                "styles": {},
+                "text": "Double Nested Paragraph 2",
+                "type": "text",
+              },
+            ],
+            "id": "inserted-double-nested-paragraph-2",
+            "props": {
+              "backgroundColor": "default",
+              "textAlignment": "left",
+              "textColor": "default",
+            },
+            "type": "paragraph",
+          },
+        ],
+        "content": [
+          {
+            "styles": {},
+            "text": "Nested Paragraph 2",
+            "type": "text",
+          },
+        ],
+        "id": "inserted-nested-paragraph-2",
+        "props": {
+          "backgroundColor": "default",
+          "textAlignment": "left",
+          "textColor": "default",
+        },
+        "type": "paragraph",
+      },
+    ],
+    "content": [
+      {
+        "styles": {
+          "bold": true,
+        },
+        "text": "Heading",
+        "type": "text",
+      },
+      {
+        "styles": {},
+        "text": " with styled ",
+        "type": "text",
+      },
+      {
+        "styles": {
+          "italic": true,
+        },
+        "text": "content",
+        "type": "text",
+      },
+    ],
+    "id": "inserted-heading-with-everything",
+    "props": {
+      "backgroundColor": "red",
+      "level": 2,
+      "textAlignment": "center",
+      "textColor": "red",
+    },
+    "type": "heading",
+  },
+]
+`;
+
+exports[`Test insertBlocks > Insert single complex block before 2`] = `
 [
   {
     "children": [

--- a/packages/core/src/api/blockManipulation/commands/insertBlocks/insertBlocks.test.ts
+++ b/packages/core/src/api/blockManipulation/commands/insertBlocks/insertBlocks.test.ts
@@ -7,131 +7,150 @@ const getEditor = setupTestEnv();
 
 describe("Test insertBlocks", () => {
   it("Insert single basic block before (without type)", () => {
-    insertBlocks(getEditor(), [{ content: "test" }], "paragraph-0", "before");
+    expect(
+      insertBlocks(getEditor(), [{ content: "test" }], "paragraph-0", "before")
+    ).toMatchSnapshot();
 
     expect(getEditor().document).toMatchSnapshot();
   });
 
   it("Insert single basic block before", () => {
-    insertBlocks(getEditor(), [{ type: "paragraph" }], "paragraph-0", "before");
+    expect(
+      insertBlocks(
+        getEditor(),
+        [{ type: "paragraph" }],
+        "paragraph-0",
+        "before"
+      )
+    ).toMatchSnapshot();
 
     expect(getEditor().document).toMatchSnapshot();
   });
 
   it("Insert single basic block after", () => {
-    insertBlocks(getEditor(), [{ type: "paragraph" }], "paragraph-0", "after");
+    expect(
+      insertBlocks(getEditor(), [{ type: "paragraph" }], "paragraph-0", "after")
+    ).toMatchSnapshot();
 
     expect(getEditor().document).toMatchSnapshot();
   });
 
   it("Insert multiple blocks before", () => {
-    insertBlocks(
-      getEditor(),
-      [
-        { type: "paragraph", content: "Inserted paragraph 1" },
-        { type: "paragraph", content: "Inserted paragraph 2" },
-        { type: "paragraph", content: "Inserted paragraph 3" },
-      ],
-      "paragraph-0",
-      "before"
-    );
+    expect(
+      insertBlocks(
+        getEditor(),
+        [
+          { type: "paragraph", content: "Inserted paragraph 1" },
+          { type: "paragraph", content: "Inserted paragraph 2" },
+          { type: "paragraph", content: "Inserted paragraph 3" },
+        ],
+        "paragraph-0",
+        "before"
+      )
+    ).toMatchSnapshot();
 
     expect(getEditor().document).toMatchSnapshot();
   });
 
   it("Insert multiple blocks after", () => {
-    insertBlocks(
-      getEditor(),
-      [
-        { type: "paragraph", content: "Inserted paragraph 1" },
-        { type: "paragraph", content: "Inserted paragraph 2" },
-        { type: "paragraph", content: "Inserted paragraph 3" },
-      ],
-      "paragraph-0",
-      "after"
-    );
+    expect(
+      insertBlocks(
+        getEditor(),
+        [
+          { type: "paragraph", content: "Inserted paragraph 1" },
+          { type: "paragraph", content: "Inserted paragraph 2" },
+          { type: "paragraph", content: "Inserted paragraph 3" },
+        ],
+        "paragraph-0",
+        "after"
+      )
+    ).toMatchSnapshot();
 
     expect(getEditor().document).toMatchSnapshot();
   });
 
   it("Insert single complex block before", () => {
-    insertBlocks(
-      getEditor(),
-      [
-        {
-          id: "inserted-heading-with-everything",
-          type: "heading",
-          props: {
-            backgroundColor: "red",
-            level: 2,
-            textAlignment: "center",
-            textColor: "red",
-          },
-          content: [
-            { type: "text", text: "Heading", styles: { bold: true } },
-            { type: "text", text: " with styled ", styles: {} },
-            { type: "text", text: "content", styles: { italic: true } },
-          ],
-          children: [
-            {
-              id: "inserted-nested-paragraph-2",
-              type: "paragraph",
-              content: "Nested Paragraph 2",
-              children: [
-                {
-                  id: "inserted-double-nested-paragraph-2",
-                  type: "paragraph",
-                  content: "Double Nested Paragraph 2",
-                },
-              ],
+    expect(
+      insertBlocks(
+        getEditor(),
+        [
+          {
+            id: "inserted-heading-with-everything",
+            type: "heading",
+            props: {
+              backgroundColor: "red",
+              level: 2,
+              textAlignment: "center",
+              textColor: "red",
             },
-          ],
-        },
-      ],
-      "paragraph-0",
-      "before"
-    );
+            content: [
+              { type: "text", text: "Heading", styles: { bold: true } },
+              { type: "text", text: " with styled ", styles: {} },
+              { type: "text", text: "content", styles: { italic: true } },
+            ],
+            children: [
+              {
+                id: "inserted-nested-paragraph-2",
+                type: "paragraph",
+                content: "Nested Paragraph 2",
+                children: [
+                  {
+                    id: "inserted-double-nested-paragraph-2",
+                    type: "paragraph",
+                    content: "Double Nested Paragraph 2",
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+        "paragraph-0",
+        "before"
+      )
+    ).toMatchSnapshot();
 
     expect(getEditor().document).toMatchSnapshot();
   });
 
   it("Insert single complex block after", () => {
-    insertBlocks(
-      getEditor(),
-      [
-        {
-          id: "inserted-heading-with-everything",
-          type: "heading",
-          props: {
-            backgroundColor: "red",
-            level: 2,
-            textAlignment: "center",
-            textColor: "red",
-          },
-          content: [
-            { type: "text", text: "Heading", styles: { bold: true } },
-            { type: "text", text: " with styled ", styles: {} },
-            { type: "text", text: "content", styles: { italic: true } },
-          ],
-          children: [
-            {
-              id: "inserted-nested-paragraph-2",
-              type: "paragraph",
-              content: "Nested Paragraph 2",
-              children: [
-                {
-                  id: "inserted-double-nested-paragraph-2",
-                  type: "paragraph",
-                  content: "Double Nested Paragraph 2",
-                },
-              ],
+    expect(
+      insertBlocks(
+        getEditor(),
+        [
+          {
+            id: "inserted-heading-with-everything",
+            type: "heading",
+            props: {
+              backgroundColor: "red",
+              level: 2,
+              textAlignment: "center",
+              textColor: "red",
             },
-          ],
-        },
-      ],
-      "paragraph-0",
-      "after"
-    );
+            content: [
+              { type: "text", text: "Heading", styles: { bold: true } },
+              { type: "text", text: " with styled ", styles: {} },
+              { type: "text", text: "content", styles: { italic: true } },
+            ],
+            children: [
+              {
+                id: "inserted-nested-paragraph-2",
+                type: "paragraph",
+                content: "Nested Paragraph 2",
+                children: [
+                  {
+                    id: "inserted-double-nested-paragraph-2",
+                    type: "paragraph",
+                    content: "Double Nested Paragraph 2",
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+        "paragraph-0",
+        "after"
+      )
+    ).toMatchSnapshot();
 
     expect(getEditor().document).toMatchSnapshot();
   });

--- a/packages/core/src/api/blockManipulation/commands/nestBlock/nestBlock.ts
+++ b/packages/core/src/api/blockManipulation/commands/nestBlock/nestBlock.ts
@@ -3,7 +3,7 @@ import { EditorState } from "prosemirror-state";
 import { ReplaceAroundStep } from "prosemirror-transform";
 
 import { BlockNoteEditor } from "../../../../editor/BlockNoteEditor.js";
-import { getBlockInfoFromSelection } from "../../../getBlockInfoFromPos.js";
+import { getBlockInfoFromTransaction } from "../../../getBlockInfoFromPos.js";
 
 // TODO: Unit tests
 /**
@@ -80,21 +80,15 @@ export function unnestBlock(editor: BlockNoteEditor<any, any, any>) {
 }
 
 export function canNestBlock(editor: BlockNoteEditor<any, any, any>) {
-  const { bnBlock: blockContainer } = getBlockInfoFromSelection(
-    editor.prosemirrorState
-  );
+  const tr = editor.transaction;
+  const { bnBlock: blockContainer } = getBlockInfoFromTransaction(tr);
 
-  return (
-    editor.prosemirrorState.doc.resolve(blockContainer.beforePos).nodeBefore !==
-    null
-  );
+  return tr.doc.resolve(blockContainer.beforePos).nodeBefore !== null;
 }
-export function canUnnestBlock(editor: BlockNoteEditor<any, any, any>) {
-  const { bnBlock: blockContainer } = getBlockInfoFromSelection(
-    editor.prosemirrorState
-  );
 
-  return (
-    editor.prosemirrorState.doc.resolve(blockContainer.beforePos).depth > 1
-  );
+export function canUnnestBlock(editor: BlockNoteEditor<any, any, any>) {
+  const tr = editor.transaction;
+  const { bnBlock: blockContainer } = getBlockInfoFromTransaction(tr);
+
+  return tr.doc.resolve(blockContainer.beforePos).depth > 1;
 }

--- a/packages/core/src/api/blockManipulation/commands/updateBlock/updateBlock.ts
+++ b/packages/core/src/api/blockManipulation/commands/updateBlock/updateBlock.ts
@@ -263,36 +263,34 @@ export function updateBlock<
 ): Block<BSchema, I, S> {
   const id =
     typeof blockToUpdate === "string" ? blockToUpdate : blockToUpdate.id;
-  return editor.transact(() => {
-    const tr = editor.transaction;
-    const posInfo = getNodeById(id, tr.doc);
-    if (!posInfo) {
-      throw new Error(`Block with ID ${id} not found`);
-    }
+  const tr = editor.transaction;
+  const posInfo = getNodeById(id, tr.doc);
+  if (!posInfo) {
+    throw new Error(`Block with ID ${id} not found`);
+  }
 
-    updateBlockCommand(
-      editor,
-      posInfo.posBeforeNode,
-      update
-    )({
-      tr,
-      dispatch: () => {
-        // no-op
-      },
-    });
-    // Actually dispatch that transaction
-    editor.dispatch(tr);
-
-    const blockContainerNode = tr.doc
-      .resolve(posInfo.posBeforeNode + 1) // TODO: clean?
-      .node();
-
-    return nodeToBlock(
-      blockContainerNode,
-      editor.schema.blockSchema,
-      editor.schema.inlineContentSchema,
-      editor.schema.styleSchema,
-      editor.blockCache
-    );
+  updateBlockCommand(
+    editor,
+    posInfo.posBeforeNode,
+    update
+  )({
+    tr,
+    dispatch: () => {
+      // no-op
+    },
   });
+  // Actually dispatch that transaction
+  editor.dispatch(tr);
+
+  const blockContainerNode = tr.doc
+    .resolve(posInfo.posBeforeNode + 1) // TODO: clean?
+    .node();
+
+  return nodeToBlock(
+    blockContainerNode,
+    editor.schema.blockSchema,
+    editor.schema.inlineContentSchema,
+    editor.schema.styleSchema,
+    editor.blockCache
+  );
 }

--- a/packages/core/src/api/blockManipulation/getBlock/getBlock.ts
+++ b/packages/core/src/api/blockManipulation/getBlock/getBlock.ts
@@ -20,7 +20,7 @@ export function getBlock<
   const id =
     typeof blockIdentifier === "string" ? blockIdentifier : blockIdentifier.id;
 
-  const posInfo = getNodeById(id, editor.prosemirrorState.doc);
+  const posInfo = getNodeById(id, editor.transaction.doc);
   if (!posInfo) {
     return undefined;
   }
@@ -44,15 +44,13 @@ export function getPrevBlock<
 ): Block<BSchema, I, S> | undefined {
   const id =
     typeof blockIdentifier === "string" ? blockIdentifier : blockIdentifier.id;
-
-  const posInfo = getNodeById(id, editor.prosemirrorState.doc);
+  const tr = editor.transaction;
+  const posInfo = getNodeById(id, tr.doc);
   if (!posInfo) {
     return undefined;
   }
 
-  const $posBeforeNode = editor.prosemirrorState.doc.resolve(
-    posInfo.posBeforeNode
-  );
+  const $posBeforeNode = tr.doc.resolve(posInfo.posBeforeNode);
   const nodeToConvert = $posBeforeNode.nodeBefore;
   if (!nodeToConvert) {
     return undefined;
@@ -77,13 +75,13 @@ export function getNextBlock<
 ): Block<BSchema, I, S> | undefined {
   const id =
     typeof blockIdentifier === "string" ? blockIdentifier : blockIdentifier.id;
-
-  const posInfo = getNodeById(id, editor.prosemirrorState.doc);
+  const tr = editor.transaction;
+  const posInfo = getNodeById(id, tr.doc);
   if (!posInfo) {
     return undefined;
   }
 
-  const $posAfterNode = editor.prosemirrorState.doc.resolve(
+  const $posAfterNode = tr.doc.resolve(
     posInfo.posBeforeNode + posInfo.node.nodeSize
   );
   const nodeToConvert = $posAfterNode.nodeAfter;
@@ -111,14 +109,13 @@ export function getParentBlock<
   const id =
     typeof blockIdentifier === "string" ? blockIdentifier : blockIdentifier.id;
 
-  const posInfo = getNodeById(id, editor.prosemirrorState.doc);
+  const tr = editor.transaction;
+  const posInfo = getNodeById(id, tr.doc);
   if (!posInfo) {
     return undefined;
   }
 
-  const $posBeforeNode = editor.prosemirrorState.doc.resolve(
-    posInfo.posBeforeNode
-  );
+  const $posBeforeNode = tr.doc.resolve(posInfo.posBeforeNode);
   const parentNode = $posBeforeNode.node();
   const grandparentNode = $posBeforeNode.node(-1);
   const nodeToConvert =

--- a/packages/core/src/api/blockManipulation/selections/selection.ts
+++ b/packages/core/src/api/blockManipulation/selections/selection.ts
@@ -21,17 +21,17 @@ export function getSelection<
 >(
   editor: BlockNoteEditor<BSchema, I, S>
 ): Selection<BSchema, I, S> | undefined {
-  const state = editor.prosemirrorState;
+  const tr = editor.transaction;
   // Return undefined if the selection is collapsed or a node is selected.
-  if (state.selection.empty || "node" in state.selection) {
+  if (tr.selection.empty || "node" in tr.selection) {
     return undefined;
   }
 
-  const $startBlockBeforePos = state.doc.resolve(
-    getNearestBlockPos(state.doc, state.selection.from).posBeforeNode
+  const $startBlockBeforePos = tr.doc.resolve(
+    getNearestBlockPos(tr.doc, tr.selection.from).posBeforeNode
   );
-  const $endBlockBeforePos = state.doc.resolve(
-    getNearestBlockPos(state.doc, state.selection.to).posBeforeNode
+  const $endBlockBeforePos = tr.doc.resolve(
+    getNearestBlockPos(tr.doc, tr.selection.to).posBeforeNode
   );
 
   // Converts the node at the given index and depth around `$startBlockBeforePos`
@@ -42,7 +42,7 @@ export function getSelection<
     depth?: number
   ): Block<BSchema, I, S> => {
     const pos = $startBlockBeforePos.posAtIndex(index, depth);
-    const node = state.doc.resolve(pos).nodeAfter;
+    const node = tr.doc.resolve(pos).nodeAfter;
 
     if (!node) {
       throw new Error(
@@ -136,7 +136,7 @@ export function getSelection<
 
   if (blocks.length === 0) {
     throw new Error(
-      `Error getting selection - selection doesn't span any blocks (${state.selection})`
+      `Error getting selection - selection doesn't span any blocks (${tr.selection})`
     );
   }
 

--- a/packages/core/src/api/clipboard/fromClipboard/handleFileInsertion.ts
+++ b/packages/core/src/api/clipboard/fromClipboard/handleFileInsertion.ts
@@ -160,10 +160,8 @@ export async function handleFileInsertion<
           return;
         }
 
-        const posInfo = getNearestBlockPos(
-          editor.prosemirrorState.doc,
-          pos.pos
-        );
+        const tr = editor.transaction;
+        const posInfo = getNearestBlockPos(tr.doc, pos.pos);
 
         insertedBlockId = insertOrUpdateBlock(
           editor,

--- a/packages/core/src/blocks/ListItemBlockContent/ListItemKeyboardShortcuts.ts
+++ b/packages/core/src/blocks/ListItemBlockContent/ListItemKeyboardShortcuts.ts
@@ -1,17 +1,17 @@
 import { splitBlockCommand } from "../../api/blockManipulation/commands/splitBlock/splitBlock.js";
 import { updateBlockCommand } from "../../api/blockManipulation/commands/updateBlock/updateBlock.js";
-import { getBlockInfoFromSelection } from "../../api/getBlockInfoFromPos.js";
+import { getBlockInfoFromTransaction } from "../../api/getBlockInfoFromPos.js";
 import { BlockNoteEditor } from "../../editor/BlockNoteEditor.js";
 
 export const handleEnter = (editor: BlockNoteEditor<any, any, any>) => {
-  const state = editor.prosemirrorState;
-  const blockInfo = getBlockInfoFromSelection(state);
+  const tr = editor.transaction;
+  const blockInfo = getBlockInfoFromTransaction(tr);
   if (!blockInfo.isBlockContainer) {
     return false;
   }
   const { bnBlock: blockContainer, blockContent } = blockInfo;
 
-  const selectionEmpty = state.selection.anchor === state.selection.head;
+  const selectionEmpty = tr.selection.anchor === tr.selection.head;
 
   if (
     !(

--- a/packages/core/src/editor/BlockNoteEditor.test.ts
+++ b/packages/core/src/editor/BlockNoteEditor.test.ts
@@ -10,7 +10,8 @@ import { BlockNoteEditor } from "./BlockNoteEditor.js";
  */
 it("creates an editor", () => {
   const editor = BlockNoteEditor.create();
-  const posInfo = getNearestBlockPos(editor.prosemirrorState.doc, 2);
+  const tr = editor.transaction;
+  const posInfo = getNearestBlockPos(tr.doc, 2);
   const info = getBlockInfo(posInfo);
   expect(info.blockNoteType).toEqual("paragraph");
 });


### PR DESCRIPTION
This attempts to implement a transaction system which only builds up the current transaction (without lying about editor state).

The drawback to this approach though, is that `appendedTransaction`s do not apply until after transaction is actually dispatched (`state.apply(tr)`).

One example where this comes up is that we have the `unique-id` plugin, which appends ids to anything that does not already have an ID attribute.

So, when reading from `tr.doc`, some newly inserted content can have no ID attached to it, when run within a transaction (because the ID has not yet been assigned).

I've included a test case here which would demonstrate the problem: 
