### PR TITLE
fix: dispatch suggestion menu as a separate transaction

### DIFF
--- a/packages/core/src/extensions/SuggestionMenu/SuggestionPlugin.ts
+++ b/packages/core/src/extensions/SuggestionMenu/SuggestionPlugin.ts
@@ -292,13 +292,13 @@ export class SuggestionMenuProseMirrorPlugin<
       props: {
         handleTextInput(view, _from, _to, text) {
           if (triggerCharacters.includes(text)) {
+            view.dispatch(view.state.tr.insertText(text));
             view.dispatch(
               view.state.tr
-                .insertText(text)
-                .scrollIntoView()
                 .setMeta(suggestionMenuPluginKey, {
                   triggerCharacter: text,
                 })
+                .scrollIntoView()
             );
 
             return true;


### PR DESCRIPTION
Dispatching in the same transaction that modified content could cause positions to be different because of appendedTransactions (e.g. Unique-id plugin)
So, this changes to only dispatch the menu in a separate transaction so that there will likely not be any other content modifications by a meta only dispatch
