### PR TITLE
docs: Update custom drag handle menu example

### DIFF
--- a/examples/03-ui-components/05-side-menu-drag-handle-items/App.tsx
+++ b/examples/03-ui-components/05-side-menu-drag-handle-items/App.tsx
@@ -4,6 +4,7 @@ import "@blocknote/mantine/style.css";
 import {
   BlockColorsItem,
   DragHandleMenu,
+  DragHandleMenuProps,
   RemoveBlockItem,
   SideMenu,
   SideMenuController,
@@ -11,6 +12,18 @@ import {
 } from "@blocknote/react";
 
 import { ResetBlockTypeItem } from "./ResetBlockTypeItem.js";
+
+// To avoid rendering issues, it's good practice to define your custom drag
+// handle menu in a separate component, instead of inline within the `sideMenu`
+// prop of `SideMenuController`.
+const CustomDragHandleMenu = (props: DragHandleMenuProps) => (
+  <DragHandleMenu {...props}>
+    <RemoveBlockItem {...props}>Delete</RemoveBlockItem>
+    <BlockColorsItem {...props}>Colors</BlockColorsItem>
+    {/* Item which resets the hovered block's type. */}
+    <ResetBlockTypeItem {...props}>Reset Type</ResetBlockTypeItem>
+  </DragHandleMenu>
+);
 
 export default function App() {
   // Creates a new editor instance.
@@ -40,17 +53,7 @@ export default function App() {
     <BlockNoteView editor={editor} sideMenu={false}>
       <SideMenuController
         sideMenu={(props) => (
-          <SideMenu
-            {...props}
-            dragHandleMenu={(props) => (
-              <DragHandleMenu {...props}>
-                <RemoveBlockItem {...props}>Delete</RemoveBlockItem>
-                <BlockColorsItem {...props}>Colors</BlockColorsItem>
-                {/* Item which resets the hovered block's type. */}
-                <ResetBlockTypeItem {...props}>Reset Type</ResetBlockTypeItem>
-              </DragHandleMenu>
-            )}
-          />
+          <SideMenu {...props} dragHandleMenu={CustomDragHandleMenu} />
         )}
       />
     </BlockNoteView>


### PR DESCRIPTION
The example for customizing drag handle menu items creates a new component for the custom drag handle menu inline in the `dragHandleMenu` prop in the `SideMenu` component. Because the component is basically recreated on each re-render, the drag handle menu itself gets unnecessarily re-rendered a lot, and this can lead to some issues. Namely the colors dropdown gets hidden while scrolling in the Mantine UI, while the drag handle menu doesn't open at all in the ShadCN UI.

This PR updates the example so that the drag handle component is now defined externally instead of inline, which fixes the re-rendering issues. Tbh I would consider refactoring all of the examples in this way as this is good practice for React, but there's a small trade-off in simplicity that we would be making. However, other UI elements don't have noticeable rendering issues because of this, unlike the drag handle menu.

Closes #1602 