### PR TITLE
fix: Selection handling when clicking editor padding

### DIFF
--- a/examples/06-custom-schema/04-pdf-file-block/styles.css
+++ b/examples/06-custom-schema/04-pdf-file-block/styles.css
@@ -1,10 +1,4 @@
-[data-content-type="pdf"] .bn-file-block-content-wrapper,
-[data-content-type="pdf"] .bn-file-and-caption-wrapper {
-    height: 800px;
-    width: 100%;
-}
-
 [data-content-type="pdf"] embed {
-    height: 100%;
+    height: 800px;
     width: 100%;
 }

--- a/packages/core/src/blocks/FileBlockContent/helpers/render/createResizableFileBlockWrapper.ts
+++ b/packages/core/src/blocks/FileBlockContent/helpers/render/createResizableFileBlockWrapper.ts
@@ -87,7 +87,10 @@ export const createResizableFileBlockWrapper = (
 
     // Ensures the element is not wider than the editor and not narrower than a
     // predetermined minimum width.
-    width = Math.max(newWidth, minWidth);
+    width = Math.min(
+      Math.max(newWidth, minWidth),
+      editor.domElement?.firstElementChild?.clientWidth || Number.MAX_VALUE
+    );
     wrapper.style.width = `${width}px`;
   };
   // Stops mouse movements from resizing the element and updates the block's

--- a/packages/core/src/editor/Block.css
+++ b/packages/core/src/editor/Block.css
@@ -14,7 +14,6 @@ BASIC STYLES
 }
 
 .bn-block-content {
-  display: flex;
   padding: 3px 0;
   transition: font-size 0.2s;
   width: 100%;
@@ -163,6 +162,7 @@ NESTED BLOCKS
 .bn-block-content::before {
   margin-right: 0;
   content: "";
+  display: inline;
 }
 
 /* Ordered */

--- a/packages/react/src/blocks/FileBlockContent/helpers/render/ResizableFileBlockWrapper.tsx
+++ b/packages/react/src/blocks/FileBlockContent/helpers/render/ResizableFileBlockWrapper.tsx
@@ -66,11 +66,13 @@ export const ResizableFileBlockWrapper = (
 
       // Ensures the child is not wider than the editor and not narrower than a
       // predetermined minimum width.
-      if (newWidth < minWidth) {
-        setWidth(minWidth);
-      } else {
-        setWidth(newWidth);
-      }
+      setWidth(
+        Math.min(
+          Math.max(newWidth, minWidth),
+          props.editor.domElement?.firstElementChild?.clientWidth ||
+            Number.MAX_VALUE
+        )
+      );
     };
     // Stops mouse movements from resizing the child and updates the block's
     // `width` prop to the new value.


### PR DESCRIPTION
In #731, we broke some things with block styling & selection handling on click, which we didn't fix 100% correctly. One issue that still remains from these changes is the selection moving to the start of the block instead of the end, when clicking the padded area on the right of the area (see #1588 for more detail). The issue is specific to Chrome only.

The reason for this bug is due to the `:before` pseudo-element on each `.bn-block-content` element. Previously,  the `.bn-block-content` element was `display: block`, and so it's `:before` pseudo-element took on `display: inline`. However, we then changed `.bn-block-content` to be `display: flex`, forcing the `:before` pseudo-element to take on `display: block`. Because it was being displayed as a block, and therefore had the same height as the block, this confused Chrome's selection handling behaviour on click.

This PR reverts the `.bn-block-content` element to be `display: block`, which fixes the issue. I've made sure that all vanilla blocks still look identical, and that at least the custom blocks from our examples are all good too. Additionally, I've fixed some minor issues that we didn't notice before due to the `display: flex`.