### PR TITLE
fix: Formatting toolbar regression

### DIFF
--- a/packages/core/src/extensions/FormattingToolbar/FormattingToolbarPlugin.ts
+++ b/packages/core/src/extensions/FormattingToolbar/FormattingToolbarPlugin.ts
@@ -140,11 +140,9 @@ export class FormattingToolbarView implements PluginView {
     // Wrapping in a setTimeout gives enough time to wait for the blur event to
     // occur before updating the toolbar.
     const { state, composing } = view;
-    const { selection } = state;
+    const { doc, selection } = state;
     const isSame =
-      oldState &&
-      oldState.selection.from === state.selection.from &&
-      oldState.selection.to === state.selection.to;
+      oldState && oldState.doc.eq(doc) && oldState.selection.eq(selection);
 
     if (composing || isSame) {
       return;


### PR DESCRIPTION
This PR fixes a regression from #1285 that made it so we weren't updating the formatting toolbar if the document changed but the selection stayed the same.

Closes #1569. However, the toolbar positioning is still janky because it doesn't account for animations. This is a known issue though.