### PR TITLE
Pass blockId to uploadFile in UploadTab

### DIFF
--- a/packages/core/src/editor/BlockNoteEditor.ts
+++ b/packages/core/src/editor/BlockNoteEditor.ts
@@ -625,15 +625,15 @@ export class BlockNoteEditor<
 
     if (newOptions.uploadFile) {
       const uploadFile = newOptions.uploadFile;
-      this.uploadFile = async (file, block) => {
+      this.uploadFile = async (file, blockId) => {
         this.onUploadStartCallbacks.forEach((callback) =>
-          callback.apply(this, [block])
+          callback.apply(this, [blockId])
         );
         try {
-          return await uploadFile(file, block);
+          return await uploadFile(file, blockId);
         } finally {
           this.onUploadEndCallbacks.forEach((callback) =>
-            callback.apply(this, [block])
+            callback.apply(this, [blockId])
           );
         }
       };

--- a/packages/react/src/components/FilePanel/DefaultTabs/UploadTab.tsx
+++ b/packages/react/src/components/FilePanel/DefaultTabs/UploadTab.tsx
@@ -50,7 +50,7 @@ export const UploadTab = <
 
         if (editor.uploadFile !== undefined) {
           try {
-            let updateData = await editor.uploadFile(file);
+            let updateData = await editor.uploadFile(file, block.id);
             if (typeof updateData === "string") {
               // received a url
               updateData = {


### PR DESCRIPTION
Implements change proposed in #1637

### Changes
- Inside the `UploadTab`, pass the block id as parameter to the `editor.uploadFile` function as expected in the function doc

- I also suggested a small variable renaming inside the uploadFule function of the editor because in the rest of the code and docs, `bloc` referres to an editor bloc which is an object but uploadFile expects a string as an input the blockId
```
/**
   * The `uploadFile` method is what the editor uses when files need to be uploaded (for example when selecting an image to upload).
   * This method should set when creating the editor as this is application-specific.
   *
   * `undefined` means the application doesn't support file uploads.
   *
   * @param file The file that should be uploaded.
   * @returns The URL of the uploaded file OR an object containing props that should be set on the file block (such as an id)
   */
  uploadFile: (
    file: File,
    blockId?: string
  ) => Promise<string | Record<string, any>>;
  ```