### PR TITLE
fix: do not close the menu on content/selection change

### DIFF
--- a/packages/react/src/components/FormattingToolbar/DefaultButtons/CreateLinkButton.tsx
+++ b/packages/react/src/components/FormattingToolbar/DefaultButtons/CreateLinkButton.tsx
@@ -54,7 +54,6 @@ export const CreateLinkButton = () => {
   const [text, setText] = useState<string>(editor.getSelectedText());
 
   useEditorContentOrSelectionChange(() => {
-    setOpened(false);
     setText(editor.getSelectedText() || "");
     setUrl(editor.getSelectedLinkUrl() || "");
   }, editor);


### PR DESCRIPTION
tbh, I'm not entirely sure why this was added in the first place with: https://github.com/TypeCellOS/BlockNote/pull/1304/files

But, the issue with this is that during collaboration, the link menu is closed on every content update made by a collaborator (closing this menu continously making a frustrating link experience).

Could use your insight here @matthewlipski
