### PR TITLE
fix: Force pasting plain text in code block

### DIFF
--- a/packages/core/src/api/clipboard/fromClipboard/pasteExtension.ts
+++ b/packages/core/src/api/clipboard/fromClipboard/pasteExtension.ts
@@ -39,9 +39,9 @@ function defaultPasteHandler({
 
     if (data) {
       editor.pasteText(data);
-    }
 
-    return true;
+      return true;
+    }
   }
 
   let format: (typeof acceptedMIMETypes)[number] | undefined;

--- a/packages/core/src/api/clipboard/fromClipboard/pasteExtension.ts
+++ b/packages/core/src/api/clipboard/fromClipboard/pasteExtension.ts
@@ -34,12 +34,10 @@ function defaultPasteHandler({
   // formatting, so we force pasting plain text.
   const selection = editor.prosemirrorView?.state.selection;
   if (selection) {
-    const { isBlockContainer, blockNoteType } = getBlockInfoFromSelection(
-      editor.prosemirrorView.state
-    );
+    const blockInfo = getBlockInfoFromSelection(editor.prosemirrorView.state);
 
     const selectionInCodeBlock =
-      isBlockContainer && blockNoteType === "codeBlock";
+      blockInfo.isBlockContainer && blockInfo.blockContent.node.type.spec.code;
 
     if (selectionInCodeBlock) {
       const data = event.clipboardData?.getData("text/plain");


### PR DESCRIPTION
This PR forces pasting plain text from the clipboard inside code blocks, as it cannot be formatted anyway and can otherwise result in unexpected behaviour.

Note: No unit test for this has been added as our you have to explicitly choose the clipboard data format for paste tests, which doesn't support this scenario. I think this is fine as it's an explicit edge case anyway.

Closes #1594