### PR TITLE
Fix import for buffer as per usage instructions

### DIFF
--- a/packages/xl-docx-exporter/src/docx/docxExporter.ts
+++ b/packages/xl-docx-exporter/src/docx/docxExporter.ts
@@ -154,7 +154,10 @@ export class DOCXExporter<
       geistMonoFont instanceof Uint8Array
     ) {
       // conversion with Polyfill needed because docxjs requires Buffer
-      const Buffer = (await import("buffer")).default.Buffer;
+      // NOTE: the buffer/ import is intentional and as documented in
+      // the `buffer` package usage instructions
+      // https://github.com/feross/buffer?tab=readme-ov-file#usage
+      const Buffer = (await import("buffer/")).Buffer;
 
       if (interFont instanceof ArrayBuffer) {
         interFont = Buffer.from(interFont);

--- a/shared/util/fileUtil.ts
+++ b/shared/util/fileUtil.ts
@@ -26,7 +26,7 @@ export async function loadFontDataUrl(requireUrl: { default: string }) {
 
 export async function loadFileBuffer(requireUrl: {
   default: string;
-}): Promise<Buffer | ArrayBuffer> {
+}) {
   if (import.meta.env.NODE_ENV === "test") {
     // in vitest, this is the url we need to load with readfilesync
     // eslint-disable-next-line


### PR DESCRIPTION
Doesn't show up in tests as this is browser only issue.

I have tested in my project though using `pnpm link` and it seems to be working for me now.

Fixes #1675 