### PR TITLE
fix: exclude non-table blocks from table handles

### DIFF
--- a/packages/core/src/extensions/TableHandles/TableHandlesPlugin.ts
+++ b/packages/core/src/extensions/TableHandles/TableHandlesPlugin.ts
@@ -538,6 +538,7 @@ export class TableHandlesView<
     this.state.block = this.editor.getBlock(this.state.block.id)!;
     if (
       !this.state.block ||
+      this.state.block.type !== "table" ||
       // when collaborating, the table element might be replaced and out of date
       // because yjs replaces the element when for example you change the color via the side menu
       !this.tableElement?.isConnected

--- a/packages/react/src/components/TableHandles/TableHandle.tsx
+++ b/packages/react/src/components/TableHandles/TableHandle.tsx
@@ -33,7 +33,7 @@ export const TableHandle = <
 
   const isDraggable = useMemo(() => {
     const tableHandles = props.editor.tableHandles;
-    if (!tableHandles || !props.block) {
+    if (!tableHandles || !props.block || props.block.type !== "table") {
       return false;
     }
 


### PR DESCRIPTION
This resolves #1650
