### PR TITLE
fix: Re-added `display: flex` to block content

### DIFF
--- a/packages/core/src/editor/Block.css
+++ b/packages/core/src/editor/Block.css
@@ -14,6 +14,7 @@ BASIC STYLES
 }
 
 .bn-block-content {
+  display: flex;
   padding: 3px 0;
   transition: font-size 0.2s;
   width: 100%;


### PR DESCRIPTION
This style must have gotten removed somewhere.

Closes 

TODO #1687