### PR TITLE
fix: restrict auto-numbered list conversion to paragraph blocks

### DIFF
--- a/packages/core/src/blocks/ListItemBlockContent/NumberedListItemBlockContent/NumberedListItemBlockContent.ts
+++ b/packages/core/src/blocks/ListItemBlockContent/NumberedListItemBlockContent/NumberedListItemBlockContent.ts
@@ -47,11 +47,7 @@ const NumberedListItemBlockContent = createStronglyTypedTiptapNode({
         find: new RegExp(`^(\\d+)\\.\\s$`),
         handler: ({ state, chain, range, match }) => {
           const blockInfo = getBlockInfoFromSelection(state);
-          if (
-            !blockInfo.isBlockContainer ||
-            blockInfo.blockContent.node.type.spec.content !== "inline*" ||
-            blockInfo.blockNoteType === "numberedListItem"
-          ) {
+           if (blockInfo.blockNoteType !== "paragraph") {
             return;
           }
           const startIndex = parseInt(match[1]);


### PR DESCRIPTION
## Description
When users type "1." at the beginning of a block, BlockNote automatically converts it into a numbered list.
Previously, this conversion would trigger in any block with inline content, including headings.
This was disruptive when users wanted to start headings or other blocks with numbers.

This change restricts the auto-conversion to numbered list to paragraph blocks only,
preserving numerical inputs in other block types as plain text.

## Changes
- Modified the input rule condition in NumberedListItemBlockContent.ts to check for paragraph blocks specifically, instead of checking for any block with inline content

## Testing
The following scenarios should be tested:

1. In a heading block:
   - Type "1." at the start
   - Expected: Text remains as "1." without converting to a numbered list

2. In a paragraph block:
   - Type "1." at the start
   - Expected: Block converts to a numbered list item