### PR TITLE
fix: Restrict auto list conversion to paragraphs

### DIFF
--- a/packages/core/src/blocks/ListItemBlockContent/BulletListItemBlockContent/BulletListItemBlockContent.ts
+++ b/packages/core/src/blocks/ListItemBlockContent/BulletListItemBlockContent/BulletListItemBlockContent.ts
@@ -29,7 +29,12 @@ const BulletListItemBlockContent = createStronglyTypedTiptapNode({
         find: new RegExp(`^[-+*]\\s$`),
         handler: ({ state, chain, range }) => {
           const blockInfo = getBlockInfoFromSelection(state);
-          if (blockInfo.blockNoteType !== "paragraph") {
+          if (
+            !blockInfo.isBlockContainer ||
+            blockInfo.blockContent.node.type.spec.content !== "inline*" ||
+            blockInfo.blockNoteType === "bulletListItem" ||
+            blockInfo.blockNoteType === "heading"
+          ) {
             return;
           }
 

--- a/packages/core/src/blocks/ListItemBlockContent/BulletListItemBlockContent/BulletListItemBlockContent.ts
+++ b/packages/core/src/blocks/ListItemBlockContent/BulletListItemBlockContent/BulletListItemBlockContent.ts
@@ -29,10 +29,7 @@ const BulletListItemBlockContent = createStronglyTypedTiptapNode({
         find: new RegExp(`^[-+*]\\s$`),
         handler: ({ state, chain, range }) => {
           const blockInfo = getBlockInfoFromSelection(state);
-          if (
-            !blockInfo.isBlockContainer ||
-            blockInfo.blockContent.node.type.spec.content !== "inline*"
-          ) {
+          if (blockInfo.blockNoteType !== "paragraph") {
             return;
           }
 

--- a/packages/core/src/blocks/ListItemBlockContent/NumberedListItemBlockContent/NumberedListItemBlockContent.ts
+++ b/packages/core/src/blocks/ListItemBlockContent/NumberedListItemBlockContent/NumberedListItemBlockContent.ts
@@ -47,7 +47,12 @@ const NumberedListItemBlockContent = createStronglyTypedTiptapNode({
         find: new RegExp(`^(\\d+)\\.\\s$`),
         handler: ({ state, chain, range, match }) => {
           const blockInfo = getBlockInfoFromSelection(state);
-           if (blockInfo.blockNoteType !== "paragraph") {
+           if (
+            !blockInfo.isBlockContainer ||
+            blockInfo.blockContent.node.type.spec.content !== "inline*" ||
+            blockInfo.blockNoteType === "numberedListItem" ||
+            blockInfo.blockNoteType === "heading"
+          ) {
             return;
           }
           const startIndex = parseInt(match[1]);

--- a/packages/core/src/blocks/ListItemBlockContent/NumberedListItemBlockContent/NumberedListItemBlockContent.ts
+++ b/packages/core/src/blocks/ListItemBlockContent/NumberedListItemBlockContent/NumberedListItemBlockContent.ts
@@ -47,11 +47,7 @@ const NumberedListItemBlockContent = createStronglyTypedTiptapNode({
         find: new RegExp(`^(\\d+)\\.\\s$`),
         handler: ({ state, chain, range, match }) => {
           const blockInfo = getBlockInfoFromSelection(state);
-          if (
-            !blockInfo.isBlockContainer ||
-            blockInfo.blockContent.node.type.spec.content !== "inline*" ||
-            blockInfo.blockNoteType === "numberedListItem"
-          ) {
+           if (blockInfo.blockNoteType !== "paragraph") {
             return;
           }
           const startIndex = parseInt(match[1]);


### PR DESCRIPTION
## Description
When users type list markers ("1." or "-/+/*") at the beginning of a block, BlockNote automatically converts it into a list.
Previously, this conversion would trigger in any block with inline content, including headings and custom blocks.
This was disruptive when users wanted to start headings or other blocks with numbers or list markers.

This change restricts the auto-conversion to list blocks to paragraph blocks only,
preserving these inputs in other block types as plain text.

Fixes #1710

## Changes
- Modified the input rule condition in NumberedListItemBlockContent.ts to check for paragraph blocks specifically
- Modified the input rule condition in BulletListItemBlockContent.ts to check for paragraph blocks specifically

## Testing
The following scenarios should be tested:

1. In a heading block:
   - Type "1." at the start
   - Expected: Text remains as "1." without converting to a numbered list
   - Type "-" or "+" at the start
   - Expected: Text remains as is without converting to a bullet list

2. In a paragraph block:
   - Type "1." at the start
   - Expected: Block converts to a numbered list item
   - Type "-" or "+" at the start
   - Expected: Block converts to a bullet list item

3. In a custom block (like alert block):
   - Type "1." or list markers (-/+/*)
   - Expected: Text remains as is without converting to any type of list