### PR TITLE
fix: ignore falsy values in boolean prop schema

### DIFF
--- a/packages/core/src/api/nodeConversions/blockToNode.ts
+++ b/packages/core/src/api/nodeConversions/blockToNode.ts
@@ -44,7 +44,9 @@ function styledTextToNodes<T extends StyleSchema>(
         marks.push(schema.mark(style));
       }
     } else if (config.propSchema === "string") {
-      marks.push(schema.mark(style, { stringValue: value }));
+      if (value) {
+        marks.push(schema.mark(style, { stringValue: value }));
+      }
     } else {
       throw new UnreachableCaseError(config.propSchema);
     }

--- a/tests/src/unit/core/formatConversion/export/__snapshots__/blocknoteHTML/malformed/JSON.html
+++ b/tests/src/unit/core/formatConversion/export/__snapshots__/blocknoteHTML/malformed/JSON.html
@@ -1,0 +1,16 @@
+<div class="bn-block-group" data-node-type="blockGroup">
+  <div class="bn-block-outer" data-node-type="blockOuter" data-id="1">
+    <div class="bn-block" data-node-type="blockContainer" data-id="1">
+      <div class="bn-block-content" data-content-type="paragraph">
+        <p class="bn-inline-content">
+          Text1
+          <br />
+          Text2
+          <br />
+          Text3
+          <br />
+        </p>
+      </div>
+    </div>
+  </div>
+</div>

--- a/tests/src/unit/core/formatConversion/export/__snapshots__/html/malformed/JSON.html
+++ b/tests/src/unit/core/formatConversion/export/__snapshots__/html/malformed/JSON.html
@@ -1,0 +1,8 @@
+<p>
+  Text1
+  <br />
+  Text2
+  <br />
+  Text3
+  <br />
+</p>

--- a/tests/src/unit/core/formatConversion/export/__snapshots__/markdown/malformed/JSON.md
+++ b/tests/src/unit/core/formatConversion/export/__snapshots__/markdown/malformed/JSON.md
@@ -1,0 +1,3 @@
+Text1\
+Text2\
+Text3

--- a/tests/src/unit/core/formatConversion/export/__snapshots__/nodes/malformed/JSON.json
+++ b/tests/src/unit/core/formatConversion/export/__snapshots__/nodes/malformed/JSON.json
@@ -1,0 +1,41 @@
+[
+  {
+    "attrs": {
+      "backgroundColor": "default",
+      "id": "1",
+      "textColor": "default",
+    },
+    "content": [
+      {
+        "attrs": {
+          "textAlignment": "left",
+        },
+        "content": [
+          {
+            "text": "Text1",
+            "type": "text",
+          },
+          {
+            "type": "hardBreak",
+          },
+          {
+            "text": "Text2",
+            "type": "text",
+          },
+          {
+            "type": "hardBreak",
+          },
+          {
+            "text": "Text3",
+            "type": "text",
+          },
+          {
+            "type": "hardBreak",
+          },
+        ],
+        "type": "paragraph",
+      },
+    ],
+    "type": "blockContainer",
+  },
+]

--- a/tests/src/unit/core/formatConversion/export/exportTestInstances.ts
+++ b/tests/src/unit/core/formatConversion/export/exportTestInstances.ts
@@ -1592,6 +1592,43 @@ export const exportTestInstancesBlockNoteHTML: TestInstance<
     },
     executeTest: testExportBlockNoteHTML,
   },
+  {
+    testCase: {
+      name: "malformed/JSON",
+      content: [
+        {
+          // id: UniqueID.options.generateID(),
+          type: "paragraph",
+          content: [
+            {
+              type: "text",
+              text: "Text1\n",
+              styles: {
+                bold: false,
+              },
+            },
+            {
+              type: "text",
+              text: "Text2\n",
+              styles: {
+                italic: false,
+                fontSize: "",
+              },
+            },
+            {
+              type: "text",
+              text: "Text3\n",
+              styles: {
+                italic: false,
+                code: false,
+              },
+            },
+          ],
+        },
+      ],
+    },
+    executeTest: testExportBlockNoteHTML,
+  },
 ];
 
 export const exportTestInstancesHTML: TestInstance<

--- a/tests/src/unit/shared/formatConversion/exportParseEquality/exportParseEqualityTestExecutors.ts
+++ b/tests/src/unit/shared/formatConversion/exportParseEquality/exportParseEqualityTestExecutors.ts
@@ -29,9 +29,16 @@ export const testExportParseEqualityBlockNoteHTML = async <
 
   const exported = await editor.blocksToFullHTML(testCase.content);
 
-  expect(await editor.tryParseHTMLToBlocks(exported)).toStrictEqual(
-    partialBlocksToBlocksForTesting(editor.schema, testCase.content),
-  );
+  if (testCase.name.startsWith("malformed/")) {
+    // We purposefully are okay with malformed response, we know they won't match
+    expect(await editor.tryParseHTMLToBlocks(exported)).not.toStrictEqual(
+      partialBlocksToBlocksForTesting(editor.schema, testCase.content),
+    );
+  } else {
+    expect(await editor.tryParseHTMLToBlocks(exported)).toStrictEqual(
+      partialBlocksToBlocksForTesting(editor.schema, testCase.content),
+    );
+  }
 };
 
 export const testExportParseEqualityNodes = async <


### PR DESCRIPTION
This fixes an issue where if a key is defined at all, it is always interpreted as being truthy, without checking it's actual value
