### PR TITLE
fix: Typing improvements

### DIFF
--- a/packages/core/src/blocks/defaultBlockTypeGuards.ts
+++ b/packages/core/src/blocks/defaultBlockTypeGuards.ts
@@ -1,9 +1,11 @@
 import { CellSelection } from "prosemirror-tables";
 import type { BlockNoteEditor } from "../editor/BlockNoteEditor.js";
 import {
+  BlockConfig,
   BlockFromConfig,
   BlockSchema,
   FileBlockConfig,
+  InlineContentConfig,
   InlineContentSchema,
   StyleSchema,
 } from "../schema/index.js";
@@ -31,6 +33,20 @@ export function checkDefaultBlockTypeInSchema<
   );
 }
 
+export function checkBlockTypeInSchema<
+  BlockType extends string,
+  Config extends BlockConfig,
+>(
+  blockType: BlockType,
+  blockConfig: Config,
+  editor: BlockNoteEditor<any, any, any>,
+): editor is BlockNoteEditor<{ [T in BlockType]: Config }, any, any> {
+  return (
+    blockType in editor.schema.blockSchema &&
+    editor.schema.blockSchema[blockType] === blockConfig
+  );
+}
+
 export function checkDefaultInlineContentTypeInSchema<
   InlineContentType extends keyof DefaultInlineContentSchema,
   B extends BlockSchema,
@@ -47,6 +63,20 @@ export function checkDefaultInlineContentTypeInSchema<
     inlineContentType in editor.schema.inlineContentSchema &&
     editor.schema.inlineContentSchema[inlineContentType] ===
       defaultInlineContentSchema[inlineContentType]
+  );
+}
+
+export function checkInlineContentTypeInSchema<
+  InlineContentType extends string,
+  Config extends InlineContentConfig,
+>(
+  inlineContentType: InlineContentType,
+  inlineContentConfig: Config,
+  editor: BlockNoteEditor<any, any, any>,
+): editor is BlockNoteEditor<any, { [T in InlineContentType]: Config }, any> {
+  return (
+    inlineContentType in editor.schema.inlineContentSchema &&
+    editor.schema.inlineContentSchema[inlineContentType] === inlineContentConfig
   );
 }
 

--- a/packages/core/src/schema/inlineContent/types.ts
+++ b/packages/core/src/schema/inlineContent/types.ts
@@ -22,6 +22,13 @@ export type InlineContentImplementation<T extends InlineContentConfig> =
         node: Node;
       };
 
+export type InlineContentSchemaWithInlineContent<
+  IType extends string,
+  C extends InlineContentConfig,
+> = {
+  [k in IType]: C;
+};
+
 // Container for both the config and implementation of InlineContent,
 // and the type of `implementation` is based on that of the config
 export type InlineContentSpec<T extends InlineContentConfig> = {

--- a/packages/react/src/schema/ReactInlineContentSpec.tsx
+++ b/packages/react/src/schema/ReactInlineContentSpec.tsx
@@ -15,6 +15,7 @@ import {
   propsToAttributes,
   StyleSchema,
   BlockNoteEditor,
+  InlineContentSchemaWithInlineContent,
 } from "@blocknote/core";
 import {
   NodeViewProps,
@@ -27,19 +28,29 @@ import { FC } from "react";
 import { renderToDOMSpec } from "./@util/ReactRenderUtil.js";
 // this file is mostly analogoues to `customBlocks.ts`, but for React blocks
 
+export type ReactCustomInlineContentRenderProps<
+  T extends CustomInlineContentConfig,
+  S extends StyleSchema,
+> = {
+  inlineContent: InlineContentFromConfig<T, S>;
+  updateInlineContent: (
+    update: PartialCustomInlineContentFromConfig<T, S>,
+  ) => void;
+  editor: BlockNoteEditor<
+    any,
+    InlineContentSchemaWithInlineContent<T["type"], T>,
+    S
+  >;
+  contentRef: (node: HTMLElement | null) => void;
+};
+
 // extend BlockConfig but use a React render function
 export type ReactInlineContentImplementation<
   T extends CustomInlineContentConfig,
   // I extends InlineContentSchema,
   S extends StyleSchema,
 > = {
-  render: FC<{
-    inlineContent: InlineContentFromConfig<T, S>;
-    updateInlineContent: (
-      update: PartialCustomInlineContentFromConfig<T, S>,
-    ) => void;
-    contentRef: (node: HTMLElement | null) => void;
-  }>;
+  render: FC<ReactCustomInlineContentRenderProps<T, S>>;
   // TODO?
   // toExternalHTML?: FC<{
   //   block: BlockFromConfig<T, I, S>;
@@ -133,6 +144,7 @@ export function createReactInlineContentSpec<
             updateInlineContent={() => {
               // No-op
             }}
+            editor={editor}
             contentRef={refCB}
           />
         ),
@@ -168,6 +180,7 @@ export function createReactInlineContentSpec<
               >
                 <Content
                   contentRef={ref}
+                  editor={editor}
                   inlineContent={
                     nodeToCustomInlineContent(
                       props.node,


### PR DESCRIPTION
This PR adds a few minor improvements to typing:

- Type guards have been added to check if an arbitrary block is in an editor's schema.
- Some utility types for inline content have been added, that already exist for blocks.
- The `render` function for custom react inline content now provides the editor in its props.