### PR TITLE
fix(ai): undo-redo after accepting/rejecting changes will undo as expected

### DIFF
--- a/packages/core/src/editor/BlockNoteExtensions.ts
+++ b/packages/core/src/editor/BlockNoteExtensions.ts
@@ -116,7 +116,7 @@ export const getBlockNoteExtensions = <
 
   if (opts.collaboration) {
     ret["ySyncPlugin"] = new SyncPlugin(opts.collaboration.fragment);
-    ret["yUndoPlugin"] = new UndoPlugin();
+    ret["yUndoPlugin"] = new UndoPlugin({ editor: opts.editor });
 
     if (opts.collaboration.provider?.awareness) {
       ret["yCursorPlugin"] = new CursorPlugin(opts.collaboration);

--- a/packages/core/src/extensions/Collaboration/UndoPlugin.ts
+++ b/packages/core/src/extensions/Collaboration/UndoPlugin.ts
@@ -1,4 +1,5 @@
 import { yUndoPlugin } from "y-prosemirror";
+import { BlockNoteEditor } from "../../editor/BlockNoteEditor.js";
 import { BlockNoteExtension } from "../../editor/BlockNoteExtension.js";
 
 export class UndoPlugin extends BlockNoteExtension {
@@ -6,9 +7,9 @@ export class UndoPlugin extends BlockNoteExtension {
     return "yUndoPlugin";
   }
 
-  constructor() {
+  constructor({ editor }: { editor: BlockNoteEditor<any, any, any> }) {
     super();
-    this.addProsemirrorPlugin(yUndoPlugin());
+    this.addProsemirrorPlugin(yUndoPlugin({ trackedOrigins: [editor] }));
   }
 
   public get priority() {


### PR DESCRIPTION
This PR preserves the Y.js UndoManager's undo stack across fork & merge operations. It is safe to copy the values because we can be certain that the new undo manager has an empty stack, and points to the exact same YXMLFragment as before the fork.

This additionally:
 - performs a diff merge (instead of trying to merge the entire Ydoc state) which is more performant for large documents.
 - Attaches a transaction origin, of the editor instance to better track where a change originated from
