### PR TITLE
Delay Formatting Toolbar Until After Mouseup and Enable Right-Click Selection

### DIFF
--- a/packages/core/src/extensions/FormattingToolbar/FormattingToolbarPlugin.ts
+++ b/packages/core/src/extensions/FormattingToolbar/FormattingToolbarPlugin.ts
@@ -130,7 +130,10 @@ export class FormattingToolbarView implements PluginView {
   };
 
   viewMousedownHandler = (e: MouseEvent) => {
-    if (!this.isElementWithinEditorWrapper(e.target as Node)) {
+    if (
+      !this.isElementWithinEditorWrapper(e.target as Node) ||
+      e.button === 0
+    ) {
       this.preventShow = true;
     }
   };


### PR DESCRIPTION
This allows users to select text without immediately showing the formatting toolbar, and also enables the formatting toolbar to appear when selecting text via right-click.