### PR TITLE
feat: report `moves`, indents and outdents as changes when using `getChanges` #1757

### DIFF
--- a/packages/core/src/api/__snapshots__/blocks-indented-changed.json
+++ b/packages/core/src/api/__snapshots__/blocks-indented-changed.json
@@ -1,0 +1,129 @@
+[
+  {
+    "block": {
+      "children": [],
+      "content": [
+        {
+          "styles": {},
+          "text": "C",
+          "type": "text",
+        },
+      ],
+      "id": "double-nested-paragraph-0",
+      "props": {
+        "backgroundColor": "default",
+        "textAlignment": "left",
+        "textColor": "default",
+      },
+      "type": "paragraph",
+    },
+    "currentParent": {
+      "children": [
+        {
+          "children": [],
+          "content": [
+            {
+              "styles": {},
+              "text": "C",
+              "type": "text",
+            },
+          ],
+          "id": "double-nested-paragraph-0",
+          "props": {
+            "backgroundColor": "default",
+            "textAlignment": "left",
+            "textColor": "default",
+          },
+          "type": "paragraph",
+        },
+      ],
+      "content": [
+        {
+          "styles": {},
+          "text": "B",
+          "type": "text",
+        },
+      ],
+      "id": "nested-paragraph-0",
+      "props": {
+        "backgroundColor": "default",
+        "textAlignment": "left",
+        "textColor": "default",
+      },
+      "type": "paragraph",
+    },
+    "prevBlock": {
+      "children": [],
+      "content": [
+        {
+          "styles": {},
+          "text": "C",
+          "type": "text",
+        },
+      ],
+      "id": "double-nested-paragraph-0",
+      "props": {
+        "backgroundColor": "default",
+        "textAlignment": "left",
+        "textColor": "default",
+      },
+      "type": "paragraph",
+    },
+    "prevParent": {
+      "children": [
+        {
+          "children": [],
+          "content": [
+            {
+              "styles": {},
+              "text": "B",
+              "type": "text",
+            },
+          ],
+          "id": "nested-paragraph-0",
+          "props": {
+            "backgroundColor": "default",
+            "textAlignment": "left",
+            "textColor": "default",
+          },
+          "type": "paragraph",
+        },
+        {
+          "children": [],
+          "content": [
+            {
+              "styles": {},
+              "text": "C",
+              "type": "text",
+            },
+          ],
+          "id": "double-nested-paragraph-0",
+          "props": {
+            "backgroundColor": "default",
+            "textAlignment": "left",
+            "textColor": "default",
+          },
+          "type": "paragraph",
+        },
+      ],
+      "content": [
+        {
+          "styles": {},
+          "text": "A",
+          "type": "text",
+        },
+      ],
+      "id": "paragraph-with-children",
+      "props": {
+        "backgroundColor": "default",
+        "textAlignment": "left",
+        "textColor": "default",
+      },
+      "type": "paragraph",
+    },
+    "source": {
+      "type": "local",
+    },
+    "type": "indent",
+  },
+]

--- a/packages/core/src/api/__snapshots__/blocks-indented-changed.json
+++ b/packages/core/src/api/__snapshots__/blocks-indented-changed.json
@@ -124,6 +124,6 @@
     "source": {
       "type": "local",
     },
-    "type": "indent",
+    "type": "move",
   },
 ]

--- a/packages/core/src/api/__snapshots__/blocks-moved-deeper-into-nesting.json
+++ b/packages/core/src/api/__snapshots__/blocks-moved-deeper-into-nesting.json
@@ -159,6 +159,6 @@
     "source": {
       "type": "local",
     },
-    "type": "indent",
+    "type": "move",
   },
 ]

--- a/packages/core/src/api/__snapshots__/blocks-moved-deeper-into-nesting.json
+++ b/packages/core/src/api/__snapshots__/blocks-moved-deeper-into-nesting.json
@@ -1,0 +1,164 @@
+[
+  {
+    "block": {
+      "children": [],
+      "content": [
+        {
+          "styles": {},
+          "text": "Target",
+          "type": "text",
+        },
+      ],
+      "id": "target",
+      "props": {
+        "backgroundColor": "default",
+        "textAlignment": "left",
+        "textColor": "default",
+      },
+      "type": "paragraph",
+    },
+    "currentParent": {
+      "children": [
+        {
+          "children": [],
+          "content": [
+            {
+              "styles": {},
+              "text": "Level 2",
+              "type": "text",
+            },
+          ],
+          "id": "level-2",
+          "props": {
+            "backgroundColor": "default",
+            "textAlignment": "left",
+            "textColor": "default",
+          },
+          "type": "paragraph",
+        },
+        {
+          "children": [],
+          "content": [
+            {
+              "styles": {},
+              "text": "Target",
+              "type": "text",
+            },
+          ],
+          "id": "target",
+          "props": {
+            "backgroundColor": "default",
+            "textAlignment": "left",
+            "textColor": "default",
+          },
+          "type": "paragraph",
+        },
+      ],
+      "content": [
+        {
+          "styles": {},
+          "text": "Level 1",
+          "type": "text",
+        },
+      ],
+      "id": "level-1",
+      "props": {
+        "backgroundColor": "default",
+        "textAlignment": "left",
+        "textColor": "default",
+      },
+      "type": "paragraph",
+    },
+    "prevBlock": {
+      "children": [],
+      "content": [
+        {
+          "styles": {},
+          "text": "Target",
+          "type": "text",
+        },
+      ],
+      "id": "target",
+      "props": {
+        "backgroundColor": "default",
+        "textAlignment": "left",
+        "textColor": "default",
+      },
+      "type": "paragraph",
+    },
+    "prevParent": {
+      "children": [
+        {
+          "children": [
+            {
+              "children": [],
+              "content": [
+                {
+                  "styles": {},
+                  "text": "Level 2",
+                  "type": "text",
+                },
+              ],
+              "id": "level-2",
+              "props": {
+                "backgroundColor": "default",
+                "textAlignment": "left",
+                "textColor": "default",
+              },
+              "type": "paragraph",
+            },
+          ],
+          "content": [
+            {
+              "styles": {},
+              "text": "Level 1",
+              "type": "text",
+            },
+          ],
+          "id": "level-1",
+          "props": {
+            "backgroundColor": "default",
+            "textAlignment": "left",
+            "textColor": "default",
+          },
+          "type": "paragraph",
+        },
+        {
+          "children": [],
+          "content": [
+            {
+              "styles": {},
+              "text": "Target",
+              "type": "text",
+            },
+          ],
+          "id": "target",
+          "props": {
+            "backgroundColor": "default",
+            "textAlignment": "left",
+            "textColor": "default",
+          },
+          "type": "paragraph",
+        },
+      ],
+      "content": [
+        {
+          "styles": {},
+          "text": "Root",
+          "type": "text",
+        },
+      ],
+      "id": "root",
+      "props": {
+        "backgroundColor": "default",
+        "textAlignment": "left",
+        "textColor": "default",
+      },
+      "type": "paragraph",
+    },
+    "source": {
+      "type": "local",
+    },
+    "type": "indent",
+  },
+]

--- a/packages/core/src/api/__snapshots__/blocks-moved-multiple-in-same-transaction.json
+++ b/packages/core/src/api/__snapshots__/blocks-moved-multiple-in-same-transaction.json
@@ -90,7 +90,7 @@
     "source": {
       "type": "local",
     },
-    "type": "outdent",
+    "type": "move",
   },
   {
     "block": {
@@ -183,6 +183,6 @@
     "source": {
       "type": "local",
     },
-    "type": "outdent",
+    "type": "move",
   },
 ]

--- a/packages/core/src/api/__snapshots__/blocks-moved-multiple-in-same-transaction.json
+++ b/packages/core/src/api/__snapshots__/blocks-moved-multiple-in-same-transaction.json
@@ -1,0 +1,188 @@
+[
+  {
+    "block": {
+      "children": [],
+      "content": [
+        {
+          "styles": {},
+          "text": "Child 1",
+          "type": "text",
+        },
+      ],
+      "id": "child-1",
+      "props": {
+        "backgroundColor": "default",
+        "textAlignment": "left",
+        "textColor": "default",
+      },
+      "type": "paragraph",
+    },
+    "currentParent": undefined,
+    "prevBlock": {
+      "children": [],
+      "content": [
+        {
+          "styles": {},
+          "text": "Child 1",
+          "type": "text",
+        },
+      ],
+      "id": "child-1",
+      "props": {
+        "backgroundColor": "default",
+        "textAlignment": "left",
+        "textColor": "default",
+      },
+      "type": "paragraph",
+    },
+    "prevParent": {
+      "children": [
+        {
+          "children": [],
+          "content": [
+            {
+              "styles": {},
+              "text": "Child 1",
+              "type": "text",
+            },
+          ],
+          "id": "child-1",
+          "props": {
+            "backgroundColor": "default",
+            "textAlignment": "left",
+            "textColor": "default",
+          },
+          "type": "paragraph",
+        },
+        {
+          "children": [],
+          "content": [
+            {
+              "styles": {},
+              "text": "Child 2",
+              "type": "text",
+            },
+          ],
+          "id": "child-2",
+          "props": {
+            "backgroundColor": "default",
+            "textAlignment": "left",
+            "textColor": "default",
+          },
+          "type": "paragraph",
+        },
+      ],
+      "content": [
+        {
+          "styles": {},
+          "text": "Parent 1",
+          "type": "text",
+        },
+      ],
+      "id": "parent-1",
+      "props": {
+        "backgroundColor": "default",
+        "textAlignment": "left",
+        "textColor": "default",
+      },
+      "type": "paragraph",
+    },
+    "source": {
+      "type": "local",
+    },
+    "type": "outdent",
+  },
+  {
+    "block": {
+      "children": [],
+      "content": [
+        {
+          "styles": {},
+          "text": "Child 2",
+          "type": "text",
+        },
+      ],
+      "id": "child-2",
+      "props": {
+        "backgroundColor": "default",
+        "textAlignment": "left",
+        "textColor": "default",
+      },
+      "type": "paragraph",
+    },
+    "currentParent": undefined,
+    "prevBlock": {
+      "children": [],
+      "content": [
+        {
+          "styles": {},
+          "text": "Child 2",
+          "type": "text",
+        },
+      ],
+      "id": "child-2",
+      "props": {
+        "backgroundColor": "default",
+        "textAlignment": "left",
+        "textColor": "default",
+      },
+      "type": "paragraph",
+    },
+    "prevParent": {
+      "children": [
+        {
+          "children": [],
+          "content": [
+            {
+              "styles": {},
+              "text": "Child 1",
+              "type": "text",
+            },
+          ],
+          "id": "child-1",
+          "props": {
+            "backgroundColor": "default",
+            "textAlignment": "left",
+            "textColor": "default",
+          },
+          "type": "paragraph",
+        },
+        {
+          "children": [],
+          "content": [
+            {
+              "styles": {},
+              "text": "Child 2",
+              "type": "text",
+            },
+          ],
+          "id": "child-2",
+          "props": {
+            "backgroundColor": "default",
+            "textAlignment": "left",
+            "textColor": "default",
+          },
+          "type": "paragraph",
+        },
+      ],
+      "content": [
+        {
+          "styles": {},
+          "text": "Parent 1",
+          "type": "text",
+        },
+      ],
+      "id": "parent-1",
+      "props": {
+        "backgroundColor": "default",
+        "textAlignment": "left",
+        "textColor": "default",
+      },
+      "type": "paragraph",
+    },
+    "source": {
+      "type": "local",
+    },
+    "type": "outdent",
+  },
+]

--- a/packages/core/src/api/__snapshots__/blocks-moved-to-different-parent.json
+++ b/packages/core/src/api/__snapshots__/blocks-moved-to-different-parent.json
@@ -73,6 +73,6 @@
     "source": {
       "type": "local",
     },
-    "type": "outdent",
+    "type": "move",
   },
 ]

--- a/packages/core/src/api/__snapshots__/blocks-moved-to-different-parent.json
+++ b/packages/core/src/api/__snapshots__/blocks-moved-to-different-parent.json
@@ -1,0 +1,78 @@
+[
+  {
+    "block": {
+      "children": [],
+      "content": [
+        {
+          "styles": {},
+          "text": "Child 1",
+          "type": "text",
+        },
+      ],
+      "id": "child-1",
+      "props": {
+        "backgroundColor": "default",
+        "textAlignment": "left",
+        "textColor": "default",
+      },
+      "type": "paragraph",
+    },
+    "currentParent": undefined,
+    "prevBlock": {
+      "children": [],
+      "content": [
+        {
+          "styles": {},
+          "text": "Child 1",
+          "type": "text",
+        },
+      ],
+      "id": "child-1",
+      "props": {
+        "backgroundColor": "default",
+        "textAlignment": "left",
+        "textColor": "default",
+      },
+      "type": "paragraph",
+    },
+    "prevParent": {
+      "children": [
+        {
+          "children": [],
+          "content": [
+            {
+              "styles": {},
+              "text": "Child 1",
+              "type": "text",
+            },
+          ],
+          "id": "child-1",
+          "props": {
+            "backgroundColor": "default",
+            "textAlignment": "left",
+            "textColor": "default",
+          },
+          "type": "paragraph",
+        },
+      ],
+      "content": [
+        {
+          "styles": {},
+          "text": "Parent 1",
+          "type": "text",
+        },
+      ],
+      "id": "parent-1",
+      "props": {
+        "backgroundColor": "default",
+        "textAlignment": "left",
+        "textColor": "default",
+      },
+      "type": "paragraph",
+    },
+    "source": {
+      "type": "local",
+    },
+    "type": "outdent",
+  },
+]

--- a/packages/core/src/api/__snapshots__/blocks-moved-to-root-level.json
+++ b/packages/core/src/api/__snapshots__/blocks-moved-to-root-level.json
@@ -73,6 +73,6 @@
     "source": {
       "type": "local",
     },
-    "type": "outdent",
+    "type": "move",
   },
 ]

--- a/packages/core/src/api/__snapshots__/blocks-moved-to-root-level.json
+++ b/packages/core/src/api/__snapshots__/blocks-moved-to-root-level.json
@@ -1,0 +1,78 @@
+[
+  {
+    "block": {
+      "children": [],
+      "content": [
+        {
+          "styles": {},
+          "text": "Child",
+          "type": "text",
+        },
+      ],
+      "id": "child",
+      "props": {
+        "backgroundColor": "default",
+        "textAlignment": "left",
+        "textColor": "default",
+      },
+      "type": "paragraph",
+    },
+    "currentParent": undefined,
+    "prevBlock": {
+      "children": [],
+      "content": [
+        {
+          "styles": {},
+          "text": "Child",
+          "type": "text",
+        },
+      ],
+      "id": "child",
+      "props": {
+        "backgroundColor": "default",
+        "textAlignment": "left",
+        "textColor": "default",
+      },
+      "type": "paragraph",
+    },
+    "prevParent": {
+      "children": [
+        {
+          "children": [],
+          "content": [
+            {
+              "styles": {},
+              "text": "Child",
+              "type": "text",
+            },
+          ],
+          "id": "child",
+          "props": {
+            "backgroundColor": "default",
+            "textAlignment": "left",
+            "textColor": "default",
+          },
+          "type": "paragraph",
+        },
+      ],
+      "content": [
+        {
+          "styles": {},
+          "text": "Parent",
+          "type": "text",
+        },
+      ],
+      "id": "parent",
+      "props": {
+        "backgroundColor": "default",
+        "textAlignment": "left",
+        "textColor": "default",
+      },
+      "type": "paragraph",
+    },
+    "source": {
+      "type": "local",
+    },
+    "type": "outdent",
+  },
+]

--- a/packages/core/src/api/__snapshots__/blocks-outdented-changed.json
+++ b/packages/core/src/api/__snapshots__/blocks-outdented-changed.json
@@ -1,0 +1,129 @@
+[
+  {
+    "block": {
+      "children": [],
+      "content": [
+        {
+          "styles": {},
+          "text": "C",
+          "type": "text",
+        },
+      ],
+      "id": "double-nested-paragraph-0",
+      "props": {
+        "backgroundColor": "default",
+        "textAlignment": "left",
+        "textColor": "default",
+      },
+      "type": "paragraph",
+    },
+    "currentParent": {
+      "children": [
+        {
+          "children": [],
+          "content": [
+            {
+              "styles": {},
+              "text": "B",
+              "type": "text",
+            },
+          ],
+          "id": "nested-paragraph-0",
+          "props": {
+            "backgroundColor": "default",
+            "textAlignment": "left",
+            "textColor": "default",
+          },
+          "type": "paragraph",
+        },
+        {
+          "children": [],
+          "content": [
+            {
+              "styles": {},
+              "text": "C",
+              "type": "text",
+            },
+          ],
+          "id": "double-nested-paragraph-0",
+          "props": {
+            "backgroundColor": "default",
+            "textAlignment": "left",
+            "textColor": "default",
+          },
+          "type": "paragraph",
+        },
+      ],
+      "content": [
+        {
+          "styles": {},
+          "text": "A",
+          "type": "text",
+        },
+      ],
+      "id": "paragraph-with-children",
+      "props": {
+        "backgroundColor": "default",
+        "textAlignment": "left",
+        "textColor": "default",
+      },
+      "type": "paragraph",
+    },
+    "prevBlock": {
+      "children": [],
+      "content": [
+        {
+          "styles": {},
+          "text": "C",
+          "type": "text",
+        },
+      ],
+      "id": "double-nested-paragraph-0",
+      "props": {
+        "backgroundColor": "default",
+        "textAlignment": "left",
+        "textColor": "default",
+      },
+      "type": "paragraph",
+    },
+    "prevParent": {
+      "children": [
+        {
+          "children": [],
+          "content": [
+            {
+              "styles": {},
+              "text": "C",
+              "type": "text",
+            },
+          ],
+          "id": "double-nested-paragraph-0",
+          "props": {
+            "backgroundColor": "default",
+            "textAlignment": "left",
+            "textColor": "default",
+          },
+          "type": "paragraph",
+        },
+      ],
+      "content": [
+        {
+          "styles": {},
+          "text": "B",
+          "type": "text",
+        },
+      ],
+      "id": "nested-paragraph-0",
+      "props": {
+        "backgroundColor": "default",
+        "textAlignment": "left",
+        "textColor": "default",
+      },
+      "type": "paragraph",
+    },
+    "source": {
+      "type": "local",
+    },
+    "type": "outdent",
+  },
+]

--- a/packages/core/src/api/__snapshots__/blocks-outdented-changed.json
+++ b/packages/core/src/api/__snapshots__/blocks-outdented-changed.json
@@ -124,6 +124,6 @@
     "source": {
       "type": "local",
     },
-    "type": "outdent",
+    "type": "move",
   },
 ]

--- a/packages/core/src/api/nodeUtil.test.ts
+++ b/packages/core/src/api/nodeUtil.test.ts
@@ -6,7 +6,7 @@ import { BlockNoteEditor } from "../editor/BlockNoteEditor.js";
 
 const getEditor = setupTestEnv();
 
-describe("Test getBlocksChangedByTransaction", () => {
+describe("getBlocksChangedByTransaction", () => {
   let editor: BlockNoteEditor;
 
   beforeEach(() => {
@@ -223,6 +223,233 @@ describe("Test getBlocksChangedByTransaction", () => {
 
     await expect(blocksChanged).toMatchFileSnapshot(
       "__snapshots__/blocks-updated-content-inserted.json",
+    );
+  });
+
+  it("should return blocks which have been indented", async () => {
+    editor.replaceBlocks(editor.document, [
+      {
+        id: "paragraph-with-children",
+        type: "paragraph",
+        content: "A",
+        children: [
+          {
+            id: "nested-paragraph-0",
+            type: "paragraph",
+            content: "B",
+            children: [],
+          },
+          {
+            id: "double-nested-paragraph-0",
+            type: "paragraph",
+            content: "C",
+          },
+        ],
+      },
+    ]);
+    const blocksChanged = editor.transact((tr) => {
+      editor.setTextCursorPosition("double-nested-paragraph-0", "start");
+      editor.nestBlock();
+
+      return getBlocksChangedByTransaction(tr);
+    });
+
+    await expect(blocksChanged).toMatchFileSnapshot(
+      "__snapshots__/blocks-indented-changed.json",
+    );
+  });
+
+  it("should return blocks which have been outdented", async () => {
+    editor.replaceBlocks(editor.document, [
+      {
+        id: "paragraph-with-children",
+        type: "paragraph",
+        content: "A",
+        children: [
+          {
+            id: "nested-paragraph-0",
+            type: "paragraph",
+            content: "B",
+            children: [
+              {
+                id: "double-nested-paragraph-0",
+                type: "paragraph",
+                content: "C",
+              },
+            ],
+          },
+        ],
+      },
+    ]);
+
+    // This test is different from the other tests because it uses the onChange hook to get the blocks changed
+    // This is because unnesting a block is not allowed within a transaction
+    let blocksChanged: any = null;
+    const unsubscribe = editor.onChange((_e, { getChanges }) => {
+      blocksChanged = getChanges();
+    });
+
+    // Make the change
+    editor.setTextCursorPosition("double-nested-paragraph-0", "start");
+    editor.unnestBlock();
+
+    // Clean up
+    if (unsubscribe) {
+      unsubscribe();
+    }
+
+    await expect(blocksChanged).toMatchFileSnapshot(
+      "__snapshots__/blocks-outdented-changed.json",
+    );
+  });
+
+  it("should return blocks which have been moved to a different parent", async () => {
+    editor.replaceBlocks(editor.document, [
+      {
+        id: "parent-1",
+        type: "paragraph",
+        content: "Parent 1",
+        children: [
+          {
+            id: "child-1",
+            type: "paragraph",
+            content: "Child 1",
+          },
+        ],
+      },
+      {
+        id: "parent-2",
+        type: "paragraph",
+        content: "Parent 2",
+        children: [],
+      },
+    ]);
+
+    const blocksChanged = editor.transact((tr) => {
+      const childBlock = editor.getBlock("child-1");
+      editor.removeBlocks(["child-1"]);
+      editor.insertBlocks([{ ...childBlock }], "parent-2", "after");
+
+      return getBlocksChangedByTransaction(tr);
+    });
+
+    await expect(blocksChanged).toMatchFileSnapshot(
+      "__snapshots__/blocks-moved-to-different-parent.json",
+    );
+  });
+
+  it("should return blocks which have been moved to root level", async () => {
+    editor.replaceBlocks(editor.document, [
+      {
+        id: "parent",
+        type: "paragraph",
+        content: "Parent",
+        children: [
+          {
+            id: "child",
+            type: "paragraph",
+            content: "Child",
+          },
+        ],
+      },
+    ]);
+
+    const blocksChanged = editor.transact((tr) => {
+      const childBlock = editor.getBlock("child");
+      editor.removeBlocks(["child"]);
+      editor.insertBlocks([{ ...childBlock }], "parent", "after");
+
+      return getBlocksChangedByTransaction(tr);
+    });
+
+    await expect(blocksChanged).toMatchFileSnapshot(
+      "__snapshots__/blocks-moved-to-root-level.json",
+    );
+  });
+
+  it("should return blocks which have been moved deeper into nesting", async () => {
+    editor.replaceBlocks(editor.document, [
+      {
+        id: "root",
+        type: "paragraph",
+        content: "Root",
+        children: [
+          {
+            id: "level-1",
+            type: "paragraph",
+            content: "Level 1",
+            children: [
+              {
+                id: "level-2",
+                type: "paragraph",
+                content: "Level 2",
+              },
+            ],
+          },
+          {
+            id: "target",
+            type: "paragraph",
+            content: "Target",
+          },
+        ],
+      },
+    ]);
+
+    const blocksChanged = editor.transact((tr) => {
+      const targetBlock = editor.getBlock("target");
+      editor.removeBlocks(["target"]);
+      editor.insertBlocks([{ ...targetBlock }], "level-2", "after");
+
+      return getBlocksChangedByTransaction(tr);
+    });
+
+    await expect(blocksChanged).toMatchFileSnapshot(
+      "__snapshots__/blocks-moved-deeper-into-nesting.json",
+    );
+  });
+
+  it("should return multiple blocks when multiple blocks are moved in the same transaction", async () => {
+    editor.replaceBlocks(editor.document, [
+      {
+        id: "parent-1",
+        type: "paragraph",
+        content: "Parent 1",
+        children: [
+          {
+            id: "child-1",
+            type: "paragraph",
+            content: "Child 1",
+          },
+          {
+            id: "child-2",
+            type: "paragraph",
+            content: "Child 2",
+          },
+        ],
+      },
+      {
+        id: "parent-2",
+        type: "paragraph",
+        content: "Parent 2",
+        children: [],
+      },
+    ]);
+
+    const blocksChanged = editor.transact((tr) => {
+      const child1Block = editor.getBlock("child-1");
+      const child2Block = editor.getBlock("child-2");
+      editor.removeBlocks(["child-1", "child-2"]);
+      editor.insertBlocks(
+        [{ ...child1Block }, { ...child2Block }],
+        "parent-2",
+        "after",
+      );
+
+      return getBlocksChangedByTransaction(tr);
+    });
+
+    await expect(blocksChanged).toMatchFileSnapshot(
+      "__snapshots__/blocks-moved-multiple-in-same-transaction.json",
     );
   });
 });

--- a/packages/core/src/api/nodeUtil.ts
+++ b/packages/core/src/api/nodeUtil.ts
@@ -1,8 +1,4 @@
-import {
-  combineTransactionSteps,
-  findChildrenInRange,
-  getChangedRanges,
-} from "@tiptap/core";
+import { combineTransactionSteps } from "@tiptap/core";
 import type { Node } from "prosemirror-model";
 import type { Transaction } from "prosemirror-state";
 import {
@@ -16,6 +12,23 @@ import type { InlineContentSchema } from "../schema/inlineContent/types.js";
 import type { StyleSchema } from "../schema/styles/types.js";
 import { nodeToBlock } from "./nodeConversions/nodeToBlock.js";
 import { getPmSchema } from "./pmUtil.js";
+
+/**
+ * Gets the parent block of a node, if it has one.
+ */
+function getParentBlockId(doc: Node, pos: number): string | undefined {
+  if (pos === 0) {
+    return undefined;
+  }
+  const resolvedPos = doc.resolve(pos);
+  for (let i = resolvedPos.depth; i > 0; i--) {
+    const parent = resolvedPos.node(i);
+    if (isNodeBlock(parent)) {
+      return parent.attrs.id;
+    }
+  }
+  return undefined;
+}
 
 /**
  * Get a TipTap node by id
@@ -62,38 +75,11 @@ export function isNodeBlock(node: Node): boolean {
  * This attributes the changes to a specific source.
  */
 export type BlockChangeSource =
-  | {
-      /**
-       * When an event is triggered by the local user, the source is "local".
-       * This is the default source.
-       */
-      type: "local";
-    }
-  | {
-      /**
-       * When an event is triggered by a paste operation, the source is "paste".
-       */
-      type: "paste";
-    }
-  | {
-      /**
-       * When an event is triggered by a drop operation, the source is "drop".
-       */
-      type: "drop";
-    }
-  | {
-      /**
-       * When an event is triggered by an undo or redo operation, the source is "undo" or "redo".
-       * @note Y.js undo/redo are not differentiated.
-       */
-      type: "undo" | "redo" | "undo-redo";
-    }
-  | {
-      /**
-       * When an event is triggered by a remote user, the source is "remote".
-       */
-      type: "yjs-remote";
-    };
+  | { type: "local" }
+  | { type: "paste" }
+  | { type: "drop" }
+  | { type: "undo" | "redo" | "undo-redo" }
+  | { type: "yjs-remote" };
 
 export type BlocksChanged<
   BSchema extends BlockSchema = DefaultBlockSchema,
@@ -118,11 +104,26 @@ export type BlocksChanged<
         prevBlock: undefined;
       }
     | {
-        type: "update";
+        type: "update" | "move";
         /**
-         * The block before the update.
+         * The previous block.
          */
         prevBlock: Block<BSchema, ISchema, SSchema>;
+      }
+    | {
+        type: "indent" | "outdent";
+        /**
+         * The previous block.
+         */
+        prevBlock: Block<BSchema, ISchema, SSchema>;
+        /**
+         * The previous parent block (if it existed).
+         */
+        prevParent?: Block<BSchema, ISchema, SSchema>;
+        /**
+         * The current parent block (if it exists).
+         */
+        currentParent?: Block<BSchema, ISchema, SSchema>;
       }
   )
 >;
@@ -139,8 +140,6 @@ function areBlocksDifferentExcludingChildren<
   block1: Block<BSchema, ISchema, SSchema>,
   block2: Block<BSchema, ISchema, SSchema>,
 ): boolean {
-  // TODO use an actual diff algorithm
-  // Compare all properties except children
   return (
     block1.id !== block2.id ||
     block1.type !== block2.type ||
@@ -149,11 +148,60 @@ function areBlocksDifferentExcludingChildren<
   );
 }
 
+function determineChangeSource(transaction: Transaction): BlockChangeSource {
+  if (transaction.getMeta("paste")) {
+    return { type: "paste" };
+  }
+  if (transaction.getMeta("uiEvent") === "drop") {
+    return { type: "drop" };
+  }
+  if (transaction.getMeta("history$")) {
+    return {
+      type: transaction.getMeta("history$").redo ? "redo" : "undo",
+    };
+  }
+  if (transaction.getMeta("y-sync$")) {
+    if (transaction.getMeta("y-sync$").isUndoRedoOperation) {
+      return { type: "undo-redo" };
+    }
+    return { type: "yjs-remote" };
+  }
+  return { type: "local" };
+}
+
+type BlockInfo<
+  BSchema extends BlockSchema,
+  ISchema extends InlineContentSchema,
+  SSchema extends StyleSchema,
+> = {
+  block: Block<BSchema, ISchema, SSchema>;
+  parentId: string | undefined;
+  depth: number;
+};
+
+function collectAllBlocks<
+  BSchema extends BlockSchema,
+  ISchema extends InlineContentSchema,
+  SSchema extends StyleSchema,
+>(doc: Node): Record<string, BlockInfo<BSchema, ISchema, SSchema>> {
+  const blocks: Record<string, BlockInfo<BSchema, ISchema, SSchema>> = {};
+  const pmSchema = getPmSchema(doc);
+  doc.descendants((node, pos) => {
+    if (isNodeBlock(node)) {
+      const parentId = getParentBlockId(doc, pos);
+      blocks[node.attrs.id] = {
+        block: nodeToBlock(node, pmSchema),
+        parentId,
+        depth: doc.resolve(pos).depth,
+      };
+    }
+    return true;
+  });
+  return blocks;
+}
+
 /**
  * Get the blocks that were changed by a transaction.
- * @param transaction The transaction to get the changes from.
- * @param editor The editor to get the changes from.
- * @returns The blocks that were changed by the transaction.
  */
 export function getBlocksChangedByTransaction<
   BSchema extends BlockSchema = DefaultBlockSchema,
@@ -163,109 +211,101 @@ export function getBlocksChangedByTransaction<
   transaction: Transaction,
   appendedTransactions: Transaction[] = [],
 ): BlocksChanged<BSchema, ISchema, SSchema> {
-  let source: BlockChangeSource = { type: "local" };
-
-  if (transaction.getMeta("paste")) {
-    source = { type: "paste" };
-  } else if (transaction.getMeta("uiEvent") === "drop") {
-    source = { type: "drop" };
-  } else if (transaction.getMeta("history$")) {
-    source = {
-      type: transaction.getMeta("history$").redo ? "redo" : "undo",
-    };
-  } else if (transaction.getMeta("y-sync$")) {
-    if (transaction.getMeta("y-sync$").isUndoRedoOperation) {
-      source = {
-        type: "undo-redo",
-      };
-    } else {
-      source = {
-        type: "yjs-remote",
-      };
-    }
-  }
-
-  // Get affected blocks before and after the change
-  const pmSchema = getPmSchema(transaction);
+  const source = determineChangeSource(transaction);
   const combinedTransaction = combineTransactionSteps(transaction.before, [
     transaction,
     ...appendedTransactions,
   ]);
 
-  const changedRanges = getChangedRanges(combinedTransaction);
-  const prevAffectedBlocks = changedRanges
-    .flatMap((range) => {
-      return findChildrenInRange(
-        combinedTransaction.before,
-        range.oldRange,
-        isNodeBlock,
-      );
-    })
-    .map(({ node }) => nodeToBlock(node, pmSchema));
-
-  const nextAffectedBlocks = changedRanges
-    .flatMap((range) => {
-      return findChildrenInRange(
-        combinedTransaction.doc,
-        range.newRange,
-        isNodeBlock,
-      );
-    })
-    .map(({ node }) => nodeToBlock(node, pmSchema));
-
-  const nextBlocks = new Map(
-    nextAffectedBlocks.map((block) => {
-      return [block.id, block];
-    }),
+  const prevBlocks = collectAllBlocks<BSchema, ISchema, SSchema>(
+    combinedTransaction.before,
   );
-  const prevBlocks = new Map(
-    prevAffectedBlocks.map((block) => {
-      return [block.id, block];
-    }),
+  const nextBlocks = collectAllBlocks<BSchema, ISchema, SSchema>(
+    combinedTransaction.doc,
   );
 
   const changes: BlocksChanged<BSchema, ISchema, SSchema> = [];
 
-  // Inserted blocks are blocks that were not in the previous state and are in the next state
-  for (const [id, block] of nextBlocks) {
-    if (!prevBlocks.has(id)) {
+  // Handle inserted blocks
+  Object.keys(nextBlocks)
+    .filter((id) => !(id in prevBlocks))
+    .forEach((id) => {
       changes.push({
         type: "insert",
-        block,
+        block: nextBlocks[id].block,
         source,
         prevBlock: undefined,
       });
-    }
-  }
+    });
 
-  // Deleted blocks are blocks that were in the previous state but not in the next state
-  for (const [id, block] of prevBlocks) {
-    if (!nextBlocks.has(id)) {
+  // Handle deleted blocks
+  Object.keys(prevBlocks)
+    .filter((id) => !(id in nextBlocks))
+    .forEach((id) => {
       changes.push({
         type: "delete",
-        block,
+        block: prevBlocks[id].block,
         source,
         prevBlock: undefined,
       });
-    }
-  }
+    });
 
-  // Updated blocks are blocks that were in the previous state and are in the next state
-  for (const [id, block] of nextBlocks) {
-    if (prevBlocks.has(id)) {
-      const prevBlock = prevBlocks.get(id)!;
+  // Handle updated, moved, indented, outdented blocks
+  Object.keys(nextBlocks)
+    .filter((id) => id in prevBlocks)
+    .forEach((id) => {
+      const prev = prevBlocks[id];
+      const next = nextBlocks[id];
+      const isParentDifferent = prev.parentId !== next.parentId;
+      const isDepthDifferent = prev.depth !== next.depth;
 
-      // Only include the update if the block itself changed (excluding children)
-      if (areBlocksDifferentExcludingChildren(prevBlock, block)) {
+      if (isParentDifferent || isDepthDifferent) {
+        const isDepthIncrease = next.depth > prev.depth;
+        const isDepthDecrease = next.depth < prev.depth;
+
+        if (isDepthIncrease) {
+          changes.push({
+            type: "indent",
+            block: next.block,
+            prevBlock: prev.block,
+            source,
+            prevParent: prev.parentId
+              ? prevBlocks[prev.parentId]?.block
+              : undefined,
+            currentParent: next.parentId
+              ? nextBlocks[next.parentId]?.block
+              : undefined,
+          });
+        } else if (isDepthDecrease) {
+          changes.push({
+            type: "outdent",
+            block: next.block,
+            prevBlock: prev.block,
+            source,
+            prevParent: prev.parentId
+              ? prevBlocks[prev.parentId]?.block
+              : undefined,
+            currentParent: next.parentId
+              ? nextBlocks[next.parentId]?.block
+              : undefined,
+          });
+        } else {
+          changes.push({
+            type: "move",
+            block: next.block,
+            prevBlock: prev.block,
+            source,
+          });
+        }
+      } else if (areBlocksDifferentExcludingChildren(prev.block, next.block)) {
         changes.push({
           type: "update",
-          block,
-          prevBlock,
+          block: next.block,
+          prevBlock: prev.block,
           source,
         });
       }
-    }
-  }
+    });
 
   return changes;
 }


### PR DESCRIPTION
This implements detecting moves (including indents and outdents) as changes when using the `getBlocksChangedByTransaction` utility.

To implement this, it now has to scan the whole document to know where the parents are, so this may potentially incur a slight reduction in perf
