### PR TITLE
refactor: serialize clipboard to json instead of html

### DIFF
--- a/packages/core/src/api/clipboard/fromClipboard/acceptedMIMETypes.ts
+++ b/packages/core/src/api/clipboard/fromClipboard/acceptedMIMETypes.ts
@@ -1,6 +1,6 @@
 export const acceptedMIMETypes = [
   "vscode-editor-data",
-  "blocknote/html",
+  "blocknote/json",
   "text/markdown",
   "text/html",
   "text/plain",

--- a/packages/core/src/api/clipboard/fromClipboard/pasteExtension.ts
+++ b/packages/core/src/api/clipboard/fromClipboard/pasteExtension.ts
@@ -14,6 +14,8 @@ import {
 import { acceptedMIMETypes } from "./acceptedMIMETypes.js";
 import { handleFileInsertion } from "./handleFileInsertion.js";
 import { handleVSCodePaste } from "./handleVSCodePaste.js";
+import { Slice } from "prosemirror-model";
+import { getPmSchema } from "../../pmUtil.js";
 
 function defaultPasteHandler({
   event,
@@ -68,9 +70,13 @@ function defaultPasteHandler({
 
   const data = event.clipboardData!.getData(format);
 
-  if (format === "blocknote/html") {
-    // Is blocknote/html, so no need to convert it
-    editor.pasteHTML(data, true);
+  if (format === "blocknote/json") {
+    editor.transact((tr) => {
+      const schema = getPmSchema(tr);
+      const slice = Slice.fromJSON(schema, JSON.parse(data));
+      // Probably need to expand the selection to the block that is being pasted into?
+      tr.replaceSelection(slice);
+    });
     return true;
   }
 

--- a/packages/core/src/extensions/SideMenu/SideMenuPlugin.ts
+++ b/packages/core/src/extensions/SideMenu/SideMenuPlugin.ts
@@ -1,4 +1,4 @@
-import { DOMParser, Slice } from "@tiptap/pm/model";
+import { Slice } from "@tiptap/pm/model";
 import {
   EditorState,
   Plugin,
@@ -338,7 +338,7 @@ export class SideMenuView<
     if (
       this.sideMenuDetection === "editor" ||
       (event as any).synthetic ||
-      !event.dataTransfer?.types.includes("blocknote/html")
+      !event.dataTransfer?.types.includes("blocknote/json")
     ) {
       return;
     }
@@ -387,8 +387,8 @@ export class SideMenuView<
    * access `dataTransfer` contents on `dragstart` and `drop` events.
    */
   onDragStart = (event: DragEvent) => {
-    const html = event.dataTransfer?.getData("blocknote/html");
-    if (!html) {
+    const json = event.dataTransfer?.getData("blocknote/json");
+    if (!json) {
       return;
     }
 
@@ -396,16 +396,8 @@ export class SideMenuView<
       throw new Error("New drag was started while an existing drag is ongoing");
     }
 
-    const element = document.createElement("div");
-    element.innerHTML = html;
-
-    const parser = DOMParser.fromSchema(this.pmView.state.schema);
-    const node = parser.parse(element, {
-      topNode: this.pmView.state.schema.nodes["blockGroup"].create(),
-    });
-
     this.pmView.dragging = {
-      slice: new Slice(node.content, 0, 0),
+      slice: Slice.fromJSON(this.pmView.state.schema, JSON.parse(json)),
       move: true,
     };
   };
@@ -419,7 +411,7 @@ export class SideMenuView<
     if (
       this.sideMenuDetection === "editor" ||
       (event as any).synthetic ||
-      !event.dataTransfer?.types.includes("blocknote/html")
+      !event.dataTransfer?.types.includes("blocknote/json")
     ) {
       return;
     }

--- a/packages/core/src/extensions/SideMenu/dragging.ts
+++ b/packages/core/src/extensions/SideMenu/dragging.ts
@@ -196,9 +196,6 @@ export function dragStart<
     const selectedSlice = view.state.selection.content();
     const schema = editor.pmSchema;
 
-    const clipboardHTML =
-      view.serializeForClipboard(selectedSlice).dom.innerHTML;
-
     const externalHTMLExporter = createExternalHTMLExporter(schema, editor);
 
     const blocks = fragmentToBlocks(selectedSlice.content);
@@ -207,7 +204,10 @@ export function dragStart<
     const plainText = cleanHTMLToMarkdown(externalHTML);
 
     e.dataTransfer.clearData();
-    e.dataTransfer.setData("blocknote/html", clipboardHTML);
+    e.dataTransfer.setData(
+      "blocknote/json",
+      JSON.stringify(selectedSlice.toJSON()),
+    );
     e.dataTransfer.setData("text/html", externalHTML);
     e.dataTransfer.setData("text/plain", plainText);
     e.dataTransfer.effectAllowed = "move";


### PR DESCRIPTION
Instead of trying to serialize everything into `blocknote/html`, we can instead serialize into `blocknote/json` whatever slice of data we want to be on the clipboard or drag & drop.

This should resolve a number of issues related to drag & drop, and simplifies things significantly.

HTML cannot encode the same sort of information that json can, for example, that a slice has different depths is not representable by html & has to be inferred, whereas just representing it as a slice, just works.
 
 Does not resolve:
 - https://github.com/TypeCellOS/BlockNote/issues/1205
 - https://github.com/TypeCellOS/BlockNote/issues/1610 need to handle a drag like that as a sort of cut & paste
 - Likely the same https://github.com/TypeCellOS/BlockNote/issues/1653
   - this likely needs to be re-worked: https://github.com/TypeCellOS/BlockNote/blob/0eb3bceae6a52cd9612c7d52a1715d2f24400949/packages/core/src/extensions/SideMenu/SideMenuPlugin.ts#L301-L335
 - Needs more info: https://github.com/TypeCellOS/BlockNote/issues/1452
 - Did not check, but unlikely to resolve: https://github.com/TypeCellOS/BlockNote/issues/1693
 - Did not check, but unlikely to resolve: https://github.com/TypeCellOS/BlockNote/issues/1694
 -  Don't know what is happening here: https://github.com/TypeCellOS/BlockNote/issues/1788
 
 ### What is left?

 - [ ] We should add some tests around this to make sure that copy & paste results in the correct document (rather than just testing clipboard serialization)
 - [ ] There is some work to do when it comes to drag & drop behavior (i.e. when to cut & paste)