### PR TITLE
fix: `bn-inline-content` class name getting duplicated

### DIFF
--- a/packages/react/src/schema/ReactBlockSpec.tsx
+++ b/packages/react/src/schema/ReactBlockSpec.tsx
@@ -189,7 +189,10 @@ export function createReactBlockSpec<
                   editor={editor as any}
                   contentRef={(element) => {
                     ref(element);
-                    if (element) {
+                    if (
+                      element &&
+                      !element.classList.contains("bn-inline-content")
+                    ) {
                       element.className = mergeCSSClasses(
                         "bn-inline-content",
                         element.className,
@@ -268,7 +271,10 @@ export function createReactBlockSpec<
               editor={editor as any}
               contentRef={(element) => {
                 refCB(element);
-                if (element) {
+                if (
+                  element &&
+                  !element.classList.contains("bn-inline-content")
+                ) {
                   element.className = mergeCSSClasses(
                     "bn-inline-content",
                     element.className,


### PR DESCRIPTION
This PR fixes the `bn-inline-content` class name being added to React custom block's inline content element whenever its content changes.

Closes #1727