### PR TITLE
feat: adding ai menu shortcut (align with copilot)

### DIFF
--- a/packages/xl-ai/package.json
+++ b/packages/xl-ai/package.json
@@ -79,6 +79,7 @@
     "lodash.isequal": "^4.5.0",
     "lodash.merge": "^4.6.2",
     "prosemirror-changeset": "^2.4.1",
+    "prosemirror-keymap": "^1.2.3",
     "prosemirror-model": "^1.25.11",
     "prosemirror-state": "^1.4.4",
     "prosemirror-tables": "^1.8.5",

--- a/packages/xl-ai/src/AIExtension.ts
+++ b/packages/xl-ai/src/AIExtension.ts
@@ -19,6 +19,7 @@ import { Plugin, PluginKey } from "prosemirror-state";
 import { fixTablesKey } from "prosemirror-tables";
 import { buildAIRequest, sendMessageWithAIRequest } from "./api/index.js";
 import { createAgentCursorPlugin } from "./plugins/AgentCursorPlugin.js";
+import { createShortcutPlugin } from "./plugins/ShortcutPlugin.js";
 import { AIRequestHelpers, InvokeAIOptions } from "./types.js";
 import { AttributionMarksExtension } from "./prosemirror/AttributionMarks.js";
 
@@ -137,6 +138,7 @@ export const AIExtension = createExtension(
         createAgentCursorPlugin(
           editorOptions?.agentCursor || { name: "AI", color: "#8bc6ff" },
         ),
+        createShortcutPlugin(editor),
       ],
 
       /**

--- a/packages/xl-ai/src/plugins/ShortcutPlugin.ts
+++ b/packages/xl-ai/src/plugins/ShortcutPlugin.ts
@@ -1,0 +1,46 @@
+import { BlockNoteEditor } from "@blocknote/core";
+import { keymap } from "prosemirror-keymap";
+import { Command } from "prosemirror-state";
+
+type AIMenuExtension = {
+  store: { state: { aiMenuState: unknown } };
+  openAIMenuAtBlock: (blockId: string) => void;
+};
+
+// The command that will be executed when the shortcut is pressed.
+const openAIMenuCommand = (editor: BlockNoteEditor): Command => {
+  return () => {
+    const ai = editor.getExtension<AIMenuExtension>("ai");
+    if (!ai) {
+      return false;
+    }
+
+    // Check if the AI Menu is already open. If so, do nothing.
+    if (ai.store.state.aiMenuState !== "closed") {
+      return false; // Return false to indicate the command did nothing.
+    }
+
+    const cursor = editor.getTextCursorPosition();
+    if (
+      cursor.block.content &&
+      Array.isArray(cursor.block.content) && // isarray check not ideal
+      cursor.block.content.length === 0 &&
+      cursor.prevBlock
+    ) {
+      ai.openAIMenuAtBlock(cursor.prevBlock.id);
+    } else {
+      ai.openAIMenuAtBlock(cursor.block.id);
+    }
+
+    // Return true to indicate that the key event has been handled.
+    return true;
+  };
+};
+
+// A factory function to create the shortcut plugin.
+export const createShortcutPlugin = (editor: BlockNoteEditor) => {
+  return keymap({
+    // "Mod" maps to "Cmd" on Mac and "Ctrl" on Windows/Linux.
+    "Mod-i": openAIMenuCommand(editor),
+  });
+};


### PR DESCRIPTION
## Ctrl-I or Command-I to open AI-Menu

This pull request introduces enhancements to the `xl-ai` package, focusing on dependency updates and the addition of a new ProseMirror plugin to enable keyboard shortcuts for AI menu interactions. The most significant changes include adding the `ShortcutPlugin` for streamlined AI menu access and updating dependencies in `package.json` to support new functionality.

### Dependency Updates:
* [`packages/xl-ai/package.json`](diffhunk://#diff-1cee0e24879580ae426b6ee51ab3dbd46d473ef66c22339a7d77899abf3e7b08R76): Added `prosemirror-keymap` and its type definitions (`@types/prosemirror-keymap`) to enable keyboard shortcut functionality. 

### Plugin Addition:
* [`packages/xl-ai/src/plugins/ShortcutPlugin.ts`](diffhunk://#diff-cab3dd7e9cff426b72b9234c800b7d201457d689c6f29247fd44a6a8eb91dc35R1-R39): Implemented the `ShortcutPlugin`, which uses the `prosemirror-keymap` library to bind the "Mod-i" shortcut for opening the AI menu at the appropriate block.

### Integration of ShortcutPlugin:
* [`packages/xl-ai/src/AIExtension.ts`](diffhunk://#diff-065b153a79660b5d372d4771a61c8c71b954b2d916f395387b25e351cd6f5f01R20): Imported the `ShortcutPlugin` and integrated it into the `AIExtension` class, ensuring the plugin is added to the ProseMirror editor. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a keyboard shortcut to open the AI menu using Cmd/Ctrl+I.
  * The menu opens at the current text block, or the previous block when the current block is empty.
  * The shortcut is inactive when the AI menu is already open or unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->