### PR TITLE
feat: FloatingUI options prop for `BlockPositioner`

### DIFF
--- a/packages/xl-ai/src/components/AIMenu/BlockPositioner.tsx
+++ b/packages/xl-ai/src/components/AIMenu/BlockPositioner.tsx
@@ -18,7 +18,7 @@ export const BlockPositioner = (props: {
     reason: OpenChangeReason,
   ) => void;
   canDismissViaOutsidePress?: boolean;
-  options?: Partial<
+  floatingOptions?: Partial<
     UseFloatingOptions & { canDismiss: boolean | UseDismissProps }
   >;
 }) => {
@@ -65,7 +65,7 @@ export const BlockPositioner = (props: {
         });
         return cleanup;
       },
-      ...props.options,
+      ...props.floatingOptions,
     });
 
   if (!isMounted) {


### PR DESCRIPTION
This PR adds an `options` prop to `BlockPositioner`, which lets you pass in FloatingUI options that get passed on to `useUIElementPositioning`.

This was requested by a client, but also the `BlockPositioner` is generally useful for custom UI elements and this gives it more flexibility.