### PR TITLE
fix: mark react package as external in email exporter

### DIFF
--- a/packages/xl-email-exporter/vite.config.ts
+++ b/packages/xl-email-exporter/vite.config.ts
@@ -52,6 +52,9 @@ export default defineConfig((conf) => ({
         if (deps.includes(source)) {
           return true;
         }
+        if (source === "react/jsx-runtime") {
+          return true;
+        }
         return source.startsWith("prosemirror-");
       },
       output: {


### PR DESCRIPTION
closes https://github.com/TypeCellOS/BlockNote/issues/1803