### PR TITLE
fix: re-evaluate side-menu on scroll

### DIFF
--- a/packages/core/src/extensions/SideMenu/SideMenuPlugin.ts
+++ b/packages/core/src/extensions/SideMenu/SideMenuPlugin.ts
@@ -192,6 +192,12 @@ export class SideMenuView<
       true,
     );
 
+    // Update state when the editor scrolls
+    this.pmView.root.addEventListener(
+      "scroll",
+      this.updateStateFromMousePos as EventListener,
+    );
+
     // Hides and unfreezes the menu whenever the user presses a key.
     this.pmView.root.addEventListener(
       "keydown",
@@ -574,6 +580,10 @@ export class SideMenuView<
       "mousemove",
       this.onMouseMove as EventListener,
       true,
+    );
+    this.pmView.root.removeEventListener(
+      "scroll",
+      this.updateStateFromMousePos as EventListener,
     );
     this.pmView.root.removeEventListener(
       "dragstart",


### PR DESCRIPTION
This attempts to resolve a bug where scrolling with a mouse over an element will keep the block side menu attached to the previous block rather than re-evaluating to the new hovered block.

This makes it more inline with normal hover behavior
