### PR TITLE
fix: hide table extend buttons when not editable #1848

### DIFF
--- a/packages/react/src/components/TableHandles/ExtendButton/ExtendButton.tsx
+++ b/packages/react/src/components/TableHandles/ExtendButton/ExtendButton.tsx
@@ -211,6 +211,10 @@ export const ExtendButton = <
     };
   }, [editingState, props.onMouseUp]);
 
+  if (!props.editor.isEditable) {
+    return null;
+  }
+
   return (
     <Components.TableHandle.ExtendButton
       className={mergeCSSClasses(


### PR DESCRIPTION
Closes #1848
