### PR TITLE
feat: AI menu UX

### DIFF
--- a/packages/mantine/src/components.tsx
+++ b/packages/mantine/src/components.tsx
@@ -82,7 +82,7 @@ export const components: Components = {
       Group: BadgeGroup,
     },
     Form: {
-      Root: (props) => <div>{props.children}</div>,
+      Root: (props) => <>{props.children}</>,
       TextInput: TextInput,
     },
     Menu: {

--- a/packages/mantine/src/form/TextInput.tsx
+++ b/packages/mantine/src/form/TextInput.tsx
@@ -33,7 +33,7 @@ export const TextInput = forwardRef<
       size={"xs"}
       className={mergeCSSClasses(
         className || "",
-        variant === "large" ? "bn-mt-input-large" : ""
+        variant === "large" ? "bn-mt-input-large" : "",
       )}
       ref={ref}
       name={name}

--- a/packages/mantine/src/style.css
+++ b/packages/mantine/src/style.css
@@ -766,26 +766,73 @@
 }
 
 /* Combobox styling */
-.bn-mantine .bn-combobox-input,
+.bn-mantine .bn-combobox-input-wrapper,
 .bn-mantine .bn-combobox-items:not(:empty) {
   background-color: var(--bn-colors-menu-background);
   border: var(--bn-border);
   border-radius: var(--bn-border-radius-medium);
   box-shadow: var(--bn-shadow-medium);
   color: var(--bn-colors-menu-text);
-  gap: 4px;
   min-width: 145px;
   padding: 2px;
 }
 
-.bn-mantine .bn-combobox-input .bn-combobox-icon,
-.bn-mantine .bn-combobox-input .bn-combobox-right-section {
+.bn-mantine .bn-combobox-input-wrapper,
+.bn-mantine .bn-combobox-input,
+.bn-mantine .bn-combobox-loader,
+.bn-mantine .bn-combobox-left-section,
+.bn-mantine .bn-combobox-right-section {
   align-items: center;
   display: flex;
   justify-content: center;
 }
 
-.bn-mantine .bn-combobox-input .bn-combobox-error {
+.bn-mantine .bn-combobox-input,
+.bn-mantine .bn-combobox-loader {
+  flex: 1;
+  justify-content: flex-start;
+  width: 0;
+}
+
+.bn-mantine .bn-combobox-input > div {
+  width: 100%;
+}
+
+.bn-mantine .bn-combobox-input input {
+  padding: 0;
+}
+
+.bn-mantine .bn-ai-loader {
+  align-items: center;
+  color: var(--bn-colors-side-menu);
+  display: flex;
+  font-family: var(--bn-font-family);
+  font-size: 14px;
+  gap: 4px;
+  height: 52px;
+  justify-content: flex-start;
+  width: 100%;
+}
+
+.bn-mantine .bn-ai-loader-icon {
+  width: fit-content;
+}
+
+.bn-mantine .bn-ai-icon,
+.bn-mantine .bn-ai-stop,
+.bn-mantine .bn-ai-error {
+  align-items: center;
+  color: var(--bn-colors-menu-text);
+  display: flex;
+  justify-content: center;
+  width: 28px;
+}
+
+.bn-mantine .bn-ai-stop {
+  cursor: pointer;
+}
+
+.bn-mantine .bn-ai-error {
   color: var(--bn-colors-highlights-red-background);
 }
 

--- a/packages/react/src/editor/ComponentsContext.tsx
+++ b/packages/react/src/editor/ComponentsContext.tsx
@@ -262,7 +262,7 @@ export type ComponentProps = {
         name: string;
         label?: string;
         variant?: "default" | "large";
-        icon: ReactNode;
+        icon?: ReactNode;
         rightSection?: ReactNode;
         autoFocus?: boolean;
         placeholder?: string;

--- a/packages/xl-ai/src/components/AIMenu/AIMenu.tsx
+++ b/packages/xl-ai/src/components/AIMenu/AIMenu.tsx
@@ -1,7 +1,11 @@
 import { BlockNoteEditor } from "@blocknote/core";
 import { useBlockNoteEditor, useComponentsContext } from "@blocknote/react";
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { RiSparkling2Fill } from "react-icons/ri";
+import {
+  RiErrorWarningFill,
+  RiSparkling2Fill,
+  RiStopCircleFill,
+} from "react-icons/ri";
 import { useStore } from "zustand";
 
 import { getAIExtension } from "../../AIExtension.js";
@@ -80,66 +84,55 @@ export const AIMenu = (props: AIMenuProps) => {
   }, [aiResponseStatus]);
 
   const placeholder = useMemo(() => {
-    if (aiResponseStatus === "thinking") {
-      return dict.ai_menu.status.thinking;
-    } else if (aiResponseStatus === "ai-writing") {
-      return dict.ai_menu.status.editing;
-    } else if (aiResponseStatus === "error") {
+    if (aiResponseStatus === "error") {
       return dict.ai_menu.status.error;
     }
 
     return dict.ai_menu.input_placeholder;
   }, [aiResponseStatus, dict]);
 
-  const rightSection = useMemo(() => {
-    if (aiResponseStatus === "thinking" || aiResponseStatus === "ai-writing") {
-      return (
-        // TODO
-        <div onClick={() => ai.abort()}>
-          <Components.SuggestionMenu.Loader
-            className={"bn-suggestion-menu-loader bn-combobox-right-section"}
-          />
-        </div>
-      );
-    } else if (aiResponseStatus === "error") {
-      return (
-        <div className={"bn-combobox-right-section bn-combobox-error"}>
-          {/* Taken from Google Material Icons */}
-          {/* https://fonts.google.com/icons?selected=Material+Symbols+Rounded:error:FILL@0;wght@400;GRAD@0;opsz@24&icon.query=error&icon.size=24&icon.color=%23e8eaed&icon.set=Material+Symbols&icon.style=Rounded&icon.platform=web */}
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            height="1em"
-            viewBox="0 -960 960 960"
-            width="1em"
-            fill="currentColor"
-          >
-            <path d="M480-280q17 0 28.5-11.5T520-320q0-17-11.5-28.5T480-360q-17 0-28.5 11.5T440-320q0 17 11.5 28.5T480-280Zm0-160q17 0 28.5-11.5T520-480v-160q0-17-11.5-28.5T480-680q-17 0-28.5 11.5T440-640v160q0 17 11.5 28.5T480-440Zm0 360q-83 0-156-31.5T197-197q-54-54-85.5-127T80-480q0-83 31.5-156T197-763q54-54 127-85.5T480-880q83 0 156 31.5T763-763q54 54 85.5 127T880-480q0 83-31.5 156T763-197q-54 54-127 85.5T480-80Zm0-80q134 0 227-93t93-227q0-134-93-227t-227-93q-134 0-227 93t-93 227q0 134 93 227t227 93Zm0-320Z" />
-          </svg>
-        </div>
-      );
-    }
-
-    return undefined;
-  }, [Components, aiResponseStatus, ai]);
-
   return (
     <PromptSuggestionMenu
-      onManualPromptSubmit={
-        props.onManualPromptSubmit || onManualPromptSubmitDefault
-      }
       items={items}
-      promptText={prompt}
-      onPromptTextChange={setPrompt}
-      placeholder={placeholder}
-      disabled={
+      inputProps={{
+        value: prompt,
+        onChange: (e) => setPrompt(e.target.value),
+        onSubmit: () =>
+          props.onManualPromptSubmit?.(prompt) ||
+          onManualPromptSubmitDefault(prompt),
+        placeholder,
+      }}
+      loader={
+        <div className={"bn-ai-loader"}>
+          <span className={"bn-ai-loader-text"}>
+            {aiResponseStatus === "ai-writing"
+              ? dict.ai_menu.status.editing
+              : dict.ai_menu.status.thinking}
+          </span>
+          <Components.SuggestionMenu.Loader
+            className={"bn-ai-loader-icon bn-suggestion-menu-loader"}
+          />
+        </div>
+      }
+      isLoading={
         aiResponseStatus === "thinking" || aiResponseStatus === "ai-writing"
       }
-      icon={
-        <div className="bn-combobox-icon">
+      leftSection={
+        <div className={"bn-ai-icon"}>
           <RiSparkling2Fill />
         </div>
       }
-      rightSection={rightSection}
+      rightSection={
+        aiResponseStatus === "thinking" || aiResponseStatus === "ai-writing" ? (
+          <div className={"bn-ai-stop"}>
+            <RiStopCircleFill />
+          </div>
+        ) : aiResponseStatus === "error" ? (
+          <div className={"bn-ai-error"} onClick={() => ai.abort()}>
+            <RiErrorWarningFill />
+          </div>
+        ) : undefined
+      }
     />
   );
 };


### PR DESCRIPTION
This PR adds a proper stop button to the AI menu and also updates the UX.

I ended up having to refactor the `PromptSuggestionMenu` component quite a bit, since I wasn't able to copy how Notion displays the loading indicator right after the "Thinking" text due to an annoying quirk of text inputs (see comment in `PromptSuggestionMenu.tsx` for more info).

To get around this, I made it so the `PromptSuggestionMenu` now has its own `leftSection` and `rightSection` which are used for the AI icon on the left and pause button/error icon on the right. These have been moved out of the text input, as we now render a `loader` element instead while the `isLoading` prop is true.

For the AI menu, the `loader` element consists of the same placeholder text and loading indicator that was previously in the text input. However, since the placeholder text is now in a regular `div`, we can place the indicator right after it.

This is quite a big workaround for the fact that text input width can't scale to the length of their content/placeholder, but unfortunately the CSS/JS workarounds I've found are all super hacky, whereas this refactor is imo at least somewhat sensible.

TODO:

- Fix styling for Ariakit
- Fix styling for ShadCN
- Update e2e snapshots?