### PR TITLE
fix: preserve leading whitespace in PDF output using nbsp

### DIFF
--- a/packages/xl-pdf-exporter/src/pdf/__snapshots__/example.jsx
+++ b/packages/xl-pdf-exporter/src/pdf/__snapshots__/example.jsx
@@ -869,7 +869,7 @@
             Styled Text
           </TEXT>
           <TEXT style={{}}>
-            {' '}
+             
           </TEXT>
           <LINK href="https://www.blocknotejs.org">
             <TEXT style={{}}>

--- a/packages/xl-pdf-exporter/src/pdf/__snapshots__/exampleWithHeaderAndFooter.jsx
+++ b/packages/xl-pdf-exporter/src/pdf/__snapshots__/exampleWithHeaderAndFooter.jsx
@@ -877,7 +877,7 @@
             Styled Text
           </TEXT>
           <TEXT style={{}}>
-            {' '}
+             
           </TEXT>
           <LINK href="https://www.blocknotejs.org">
             <TEXT style={{}}>

--- a/packages/xl-pdf-exporter/src/pdf/pdfExporter.tsx
+++ b/packages/xl-pdf-exporter/src/pdf/pdfExporter.tsx
@@ -118,9 +118,13 @@ export class PDFExporter<
   public transformStyledText(styledText: StyledText<S>) {
     const stylesArray = this.mapStyles(styledText.styles);
     const styles = Object.assign({}, ...stylesArray);
+    const textWithLeadingNbsp = styledText.text.replace(
+      /(^|\n) +/g,
+      (leadingWhiteSpaces) => leadingWhiteSpaces.replace(/ /g, "\u00A0"),
+    );
     return (
       <Text style={styles} key={styledText.text}>
-        {styledText.text}
+        {textWithLeadingNbsp}
       </Text>
     );
   }


### PR DESCRIPTION
Small fix to make leading whitespaces in pdf to render correctly. 