### PR TITLE
Use image alt text for image block name

### DIFF
--- a/packages/core/src/blocks/ImageBlockContent/parseImageElement.ts
+++ b/packages/core/src/blocks/ImageBlockContent/parseImageElement.ts
@@ -1,6 +1,7 @@
 export const parseImageElement = (imageElement: HTMLImageElement) => {
   const url = imageElement.src || undefined;
   const previewWidth = imageElement.width || undefined;
+  const name = imageElement.alt || undefined;
 
-  return { url, previewWidth };
+  return { url, previewWidth, name };
 };

--- a/packages/server-util/src/context/__snapshots__/ServerBlockNoteEditor.test.ts.snap
+++ b/packages/server-util/src/context/__snapshots__/ServerBlockNoteEditor.test.ts.snap
@@ -217,7 +217,7 @@ exports[`Test ServerBlockNoteEditor > converts to and from markdown (blocksToMar
     "props": {
       "backgroundColor": "default",
       "caption": "",
-      "name": "",
+      "name": "Example",
       "showPreview": true,
       "textAlignment": "left",
       "url": "exampleURL",


### PR DESCRIPTION
This fixes the issue (#1882) where Markdown images that are converted to blocks and back again lose their alt text, having it replaced with the default alt text ("BlockNote image").

An alternative fix would be to use the alt text as the caption, but given that the caption is rendered as a separate element, that seemed less appropriate.