### PR TITLE
fix: Minor drag & drop changes

### DIFF
--- a/packages/core/src/extensions/SideMenu/SideMenuPlugin.ts
+++ b/packages/core/src/extensions/SideMenu/SideMenuPlugin.ts
@@ -242,21 +242,11 @@ export class SideMenuView<
 
     this.hoveredBlock = block.node;
 
-    // Gets the block's content node, which lets to ignore child blocks when determining the block menu's position.
-    // TODO: needed?
-    const blockContent = block.node.firstChild as HTMLElement;
-
-    if (!blockContent) {
-      return;
-    }
-
-    // TODO: needed?
-
     // Shows or updates elements.
     if (this.editor.isEditable) {
-      const blockContentBoundingBox = blockContent.getBoundingClientRect();
+      const blockContentBoundingBox = block.node.getBoundingClientRect();
       const column = block.node.closest("[data-node-type=column]");
-      this.updateState({
+      this.state = {
         show: true,
         referencePos: new DOMRect(
           column
@@ -275,7 +265,8 @@ export class SideMenuView<
         block: this.editor.getBlock(
           this.hoveredBlock!.getAttribute("data-id")!,
         )!,
-      });
+      };
+      this.updateState(this.state);
     }
   };
 
@@ -435,9 +426,9 @@ export class SideMenuView<
     // We need to check if there is text content that is being dragged (select some text & just drag it)
     const textContentIsBeingDragged =
       !event.dataTransfer?.types.includes("blocknote/html") &&
-      Boolean(this.pmView.dragging);
+      !!this.pmView.dragging;
     // This is the side menu drag from this plugin
-    const sideMenuIsBeingDragged = Boolean(this.isDragOrigin);
+    const sideMenuIsBeingDragged = !!this.isDragOrigin;
     // Tells us that the current editor instance has a drag ongoing (either text or side menu)
     const isDragOrigin = textContentIsBeingDragged || sideMenuIsBeingDragged;
 


### PR DESCRIPTION
In case anyone is interested, the TODOs I cleared up were indeed no longer needed. We previously placed the side menu in the vertical center of the block content, and so we needed to use the bounding box of the block content.

We then changed this so the side menu is equal to the height of the block's first line. For blocks without inline content, we use either the overall height of the block, or default to the height of the first line of a paragraph block.

In addition, we also positioned the side menu at the vertical top of the block to match Notion's UX, but kept the side menu code the same since nothing broke. However, it made using the block content bounding box instead of the block bounding box redundant, since the top edge of both is the same height.