### PR TITLE
docs: Updated formatting toolbar buttons example

### DIFF
--- a/examples/03-ui-components/02-formatting-toolbar-buttons/src/App.tsx
+++ b/examples/03-ui-components/02-formatting-toolbar-buttons/src/App.tsx
@@ -62,6 +62,11 @@ export default function App() {
       },
       {
         type: "paragraph",
+        content:
+          "Notice that the button doesn't appear when the image block above is selected, as it has no inline content.",
+      },
+      {
+        type: "paragraph",
       },
     ],
   });

--- a/examples/03-ui-components/02-formatting-toolbar-buttons/src/BlueButton.tsx
+++ b/examples/03-ui-components/02-formatting-toolbar-buttons/src/BlueButton.tsx
@@ -3,6 +3,7 @@ import {
   useBlockNoteEditor,
   useComponentsContext,
   useEditorContentOrSelectionChange,
+  useSelectedBlocks,
 } from "@blocknote/react";
 import { useState } from "react";
 
@@ -25,6 +26,14 @@ export function BlueButton() {
         editor.getActiveStyles().backgroundColor === "blue",
     );
   }, editor);
+
+  // Doesn't render unless a at least one block with inline content is 
+  // selected. You can use a similar pattern of returning `null` to 
+  // conditionally render buttons based on the editor state.
+  const blocks = useSelectedBlocks();
+  if (blocks.filter((block) => block.content !== undefined)) {
+    return null;
+  }
 
   return (
     <Components.FormattingToolbar.Button


### PR DESCRIPTION
This PR updates the example for adding formatting toolbar buttons. A common use case is to show/hide a button based on the selected block, so the custom button in the example is now hidden for blocks without inline content, as it has no funciton there anyway.