### PR TITLE
fix: Vanilla blocks return `true` for `editor.isEditable` on initial render

### DIFF
--- a/packages/react/src/editor/BlockNoteView.tsx
+++ b/packages/react/src/editor/BlockNoteView.tsx
@@ -202,6 +202,7 @@ function BlockNoteViewComponent<
         <BlockNoteViewContainer
           className={className}
           renderEditor={renderEditor}
+          editable={editable}
           editorColorScheme={editorColorScheme}
           ref={ref}
           {...rest}
@@ -221,26 +222,34 @@ const BlockNoteViewContainer = React.forwardRef<
   HTMLDivElement,
   {
     renderEditor: boolean;
+    editable?: boolean;
     editorColorScheme: "light" | "dark";
     children: ReactNode;
   } & Omit<
     HTMLAttributes<HTMLDivElement>,
     "onChange" | "onSelectionChange" | "children"
   >
->(({ className, renderEditor, editorColorScheme, children, ...rest }, ref) => (
-  <div
-    className={mergeCSSClasses("bn-container", editorColorScheme, className)}
-    data-color-scheme={editorColorScheme}
-    {...rest}
-    ref={ref}
-  >
-    {renderEditor ? (
-      <BlockNoteViewEditor>{children}</BlockNoteViewEditor>
-    ) : (
-      children
-    )}
-  </div>
-));
+>(
+  (
+    { className, renderEditor, editable, editorColorScheme, children, ...rest },
+    ref,
+  ) => (
+    <div
+      className={mergeCSSClasses("bn-container", editorColorScheme, className)}
+      data-color-scheme={editorColorScheme}
+      {...rest}
+      ref={ref}
+    >
+      {renderEditor ? (
+        <BlockNoteViewEditor editable={editable}>
+          {children}
+        </BlockNoteViewEditor>
+      ) : (
+        children
+      )}
+    </div>
+  ),
+);
 
 // https://fettblog.eu/typescript-react-generic-forward-refs/
 export const BlockNoteViewRaw = React.forwardRef(BlockNoteViewComponent) as <
@@ -260,7 +269,10 @@ export const BlockNoteViewRaw = React.forwardRef(BlockNoteViewComponent) as <
  * Renders the contentEditable editor itself (.bn-editor element) and the
  * default UI elements.
  */
-export const BlockNoteViewEditor = (props: { children?: ReactNode }) => {
+export const BlockNoteViewEditor = (props: {
+  editable?: boolean;
+  children?: ReactNode;
+}) => {
   const ctx = useBlockNoteViewContext()!;
   const editor = useBlockNoteEditor();
 
@@ -270,9 +282,15 @@ export const BlockNoteViewEditor = (props: { children?: ReactNode }) => {
 
   const mount = useCallback(
     (element: HTMLElement | null) => {
+      if (
+        props.editable !== undefined &&
+        props.editable !== editor.isEditable
+      ) {
+        editor.isEditable = props.editable;
+      }
       editor.mount(element, portalManager);
     },
-    [editor, portalManager],
+    [editor, portalManager, props.editable],
   );
 
   return (


### PR DESCRIPTION
This PR fixes an issue where getting `editor.isEditable` in the `render` function of a vanilla JS block would return `true`, regardless of if the editor is actually editable.

This is because `editor.isEditable` is set in a `useEffect` hook in `BlockNoteViewComponent`, which updates the value async, and so it can happen after the block has already rendered.

I've changed it so `editor.isEditable` is also set in `BlockNoteViewEditor`, before the editor is mounted, ensuring the value is correct before any vanilla blocks are rendered.

Closes #1477