### PR TITLE
fix(nodeUtil): moved blocks now included in the editor changes

### DIFF
--- a/packages/core/src/api/nodeUtil.ts
+++ b/packages/core/src/api/nodeUtil.ts
@@ -260,6 +260,8 @@ export function getBlocksChangedByTransaction<
       });
     });
 
+  const draggedBlockId = transaction.getMeta("draggedBlockId");
+
   // Handle updated, moved, indented, outdented blocks
   Object.keys(nextBlocks)
     .filter((id) => id in prevBlocks)
@@ -267,9 +269,9 @@ export function getBlocksChangedByTransaction<
       const prev = prevBlocks[id];
       const next = nextBlocks[id];
       const isParentDifferent = prev.parentId !== next.parentId;
-      const isIndexDifferent = prev.index !== next.index;
+      const isDraggedBlock = prev.index !== next.index && draggedBlockId === id;
 
-      if (isParentDifferent || isIndexDifferent) {
+      if (isParentDifferent || isDraggedBlock) {
         changes.push({
           type: "move",
           block: next.block,

--- a/packages/core/src/api/nodeUtil.ts
+++ b/packages/core/src/api/nodeUtil.ts
@@ -184,6 +184,7 @@ function collectAllBlocks<
   {
     block: Block<BSchema, ISchema, SSchema>;
     parentId: string | undefined;
+    index: number;
   }
 > {
   const blocks: Record<
@@ -191,15 +192,17 @@ function collectAllBlocks<
     {
       block: Block<BSchema, ISchema, SSchema>;
       parentId: string | undefined;
+      index: number;
     }
   > = {};
   const pmSchema = getPmSchema(doc);
-  doc.descendants((node, pos) => {
+  doc.descendants((node, pos, _, index) => {
     if (isNodeBlock(node)) {
       const parentId = getParentBlockId(doc, pos);
       blocks[node.attrs.id] = {
         block: nodeToBlock(node, pmSchema),
         parentId,
+        index,
       };
     }
     return true;
@@ -264,8 +267,9 @@ export function getBlocksChangedByTransaction<
       const prev = prevBlocks[id];
       const next = nextBlocks[id];
       const isParentDifferent = prev.parentId !== next.parentId;
+      const isIndexDifferent = prev.index !== next.index;
 
-      if (isParentDifferent) {
+      if (isParentDifferent || isIndexDifferent) {
         changes.push({
           type: "move",
           block: next.block,


### PR DESCRIPTION
# Context

#1924

## Summary

Previously, only parent changes emitted a "move" (e.g, indentations). Reordering blocks within the same parent was missed. Now, we capture each block’s sibling index and emit a "move" when either parent or index changes.

## Changes

- `nodeUtils.ts`: On top of the parent IDs, we're now keeping track of each block’s index and emitting a "move" when either parent or index changes.
- `nodeUtils.test.ts`: TODO
