### PR TITLE
add locale configuration for docx export

### DIFF
--- a/packages/xl-docx-exporter/src/docx/__snapshots__/basic/styles.xml
+++ b/packages/xl-docx-exporter/src/docx/__snapshots__/basic/styles.xml
@@ -7,7 +7,7 @@
                 <w:kern w:val="2"/>
                 <w:sz w:val="24"/>
                 <w:szCs w:val="24"/>
-                <w:lang w:val="en-NL" w:eastAsia="en-GB" w:bidi="ar-SA"/>
+                <w:lang w:val="en-US" w:eastAsia="en-GB" w:bidi="ar-SA"/>
                 <w14:ligatures w14:val="standardContextual"/>
             </w:rPr>
         </w:rPrDefault>

--- a/packages/xl-docx-exporter/src/docx/__snapshots__/withMultiColumn/styles.xml
+++ b/packages/xl-docx-exporter/src/docx/__snapshots__/withMultiColumn/styles.xml
@@ -7,7 +7,7 @@
                 <w:kern w:val="2"/>
                 <w:sz w:val="24"/>
                 <w:szCs w:val="24"/>
-                <w:lang w:val="en-NL" w:eastAsia="en-GB" w:bidi="ar-SA"/>
+                <w:lang w:val="en-US" w:eastAsia="en-GB" w:bidi="ar-SA"/>
                 <w14:ligatures w14:val="standardContextual"/>
             </w:rPr>
         </w:rPrDefault>

--- a/packages/xl-docx-exporter/src/docx/docxExporter.test.ts
+++ b/packages/xl-docx-exporter/src/docx/docxExporter.test.ts
@@ -28,7 +28,11 @@ describe("exporter", () => {
       }),
       docxDefaultSchemaMappings,
     );
-    const doc = await exporter.toDocxJsDocument(testDocument);
+    const doc = await exporter.toDocxJsDocument(testDocument, {
+      sectionOptions: {},
+      documentOptions: {},
+      locale: "en-US",
+    });
 
     const blob = await Packer.toBlob(doc);
     const zip = new ZipReader(new BlobReader(blob));
@@ -56,6 +60,7 @@ describe("exporter", () => {
       );
 
       const doc = await exporter.toDocxJsDocument(testDocument, {
+        locale: "en-US",
         documentOptions: {
           creator: "John Doe",
         },
@@ -181,6 +186,7 @@ describe("exporter", () => {
             ],
           },
         ]),
+        { sectionOptions: {}, documentOptions: {}, locale: "en-US" },
       );
 
       const blob = await Packer.toBlob(doc);

--- a/packages/xl-docx-exporter/src/docx/docxExporter.ts
+++ b/packages/xl-docx-exporter/src/docx/docxExporter.ts
@@ -196,8 +196,7 @@ export class DOCXExporter<
     // Replace the default language in styles.xml with the provided locale.
     // If not provided, default to en-US.
     const resolvedLocale = (locale && locale.trim()) || "en-US";
-    // Replace w:lang w:val="..." with the desired locale, leaving other attributes intact
-    // This targets the run default language defined in styles.xml
+
     externalStyles = externalStyles.replace(
       /(<w:lang\b[^>]*\bw:val=")([^"]+)("[^>]*\/>)/g,
       `$1${resolvedLocale}$3`,

--- a/shared/util/fileUtil.ts
+++ b/shared/util/fileUtil.ts
@@ -36,6 +36,12 @@ export async function loadFileBuffer(requireUrl: {
     if (url.startsWith("/@fs/")) {
       url = url.substring("/@fs".length);
     }
+    // On Windows, vite/vitest may yield paths like "/C:/..." after removing /@fs
+    // Node on Windows treats paths starting with "/" as relative to current drive,
+    // which would produce "C:\C:\...". Strip leading slash when followed by a drive letter.
+    if (/^\/[A-Za-z]:/.test(url)) {
+      url = url.slice(1);
+    }
     const buffer = fs.readFileSync(url);
     return buffer;
   } else {


### PR DESCRIPTION
**Title**
Add configurable locale for DOCX export (default: en-US)

**Description**
This PR introduces the ability to configure the default language of the generated .docx files via a new optional locale parameter in createDefaultDocumentOptions.

issue [1896](https://github.com/TypeCellOS/BlockNote/issues/1896)

**Details**

- Added locale?: string parameter to allow consumers of the library to set the document’s default language in the styles.xml metadata (<w:lang w:val="..."/>).
- If no locale is provided, the default is set to en-US.
- This change improves accessibility: screen readers rely on the document’s language metadata to pronounce words correctly.
- Implementation replaces the existing language in styles.xml while preserving other attributes.

**Example usage**

```
const exporter = new DOCXExporter(schema, mappings);
await exporter.toBlob(blocks, { locale: "fr-FR" });

```

