### PR TITLE
fix: update docs editor.editable to editor.isEditable

### DIFF
--- a/docs/content/docs/reference/editor/overview.mdx
+++ b/docs/content/docs/reference/editor/overview.mdx
@@ -10,10 +10,10 @@ The BlockNote editor API is a comprehensive set of functions and methods that al
 
 ## Editable
 
-The editor is editable by default, but you can make it read-only by setting the `editable` property to `false`.
+The editor is editable by default, but you can make it read-only by setting the `isEditable` property to `false`.
 
 ```ts
-editor.editable = false;
+editor.isEditable = false;
 ```
 
 ## Focus


### PR DESCRIPTION
Title
Update docs to isEditable from editor.editable

Description
The key editable seems to be a holdover from the docs for the component prop. When setting it on the editor instance it should be editor.isEditable