### PR TITLE
feat(core,docs): add AccessibleImageBlock (alt=) and wire into homepa…

### DIFF
--- a/docs/app/(home)/hero/DemoEditor.tsx
+++ b/docs/app/(home)/hero/DemoEditor.tsx
@@ -1,8 +1,10 @@
 import {
   BlockNoteSchema,
   combineByGroup,
+  defaultBlockSpecs,
   filterSuggestionItems,
   uploadToTmpFilesDotOrg_DEV_ONLY,
+  AccessibleImageBlock,
 } from "@blocknote/core";
 import * as locales from "@blocknote/core/locales";
 import "@blocknote/core/fonts/inter.css";
@@ -90,7 +92,14 @@ export default function DemoEditor() {
         ...locales.en,
         multi_column: multiColumnLocales.en,
       },
-      schema: withMultiColumn(BlockNoteSchema.create()),
+      schema: withMultiColumn(
+        BlockNoteSchema.create({
+          blockSpecs: {
+            ...defaultBlockSpecs,
+            image: AccessibleImageBlock,
+          },
+        }),
+      ),
       dropCursor: multiColumnDropCursor,
       collaboration: {
         provider,

--- a/packages/core/src/blocks/ImageBlockContent/AccessibleImageBlock.ts
+++ b/packages/core/src/blocks/ImageBlockContent/AccessibleImageBlock.ts
@@ -1,0 +1,45 @@
+import type { BlockNoteEditor } from "../../editor/BlockNoteEditor.js";
+import type {
+  BlockFromConfig,
+  BlockSchemaWithBlock,
+} from "../../schema/blocks/types.js";
+import type { InlineContentSchema } from "../../schema/inlineContent/types.js";
+import type { StyleSchema } from "../../schema/styles/types.js";
+import { createBlockSpec } from "../../schema/blocks/createSpec.js";
+import {
+  imageBlockConfig,
+  imageParse,
+  imageRender,
+  imageToExternalHTML,
+} from "./ImageBlockContent.js";
+
+type ImageBlockConfig = typeof imageBlockConfig;
+
+export const accessibleImageRender = (
+  block: BlockFromConfig<ImageBlockConfig, InlineContentSchema, StyleSchema>,
+  editor: BlockNoteEditor<
+    BlockSchemaWithBlock<ImageBlockConfig["type"], ImageBlockConfig>,
+    InlineContentSchema,
+    StyleSchema
+  >,
+) => {
+  const imageRenderComputed = imageRender(block, editor);
+  const dom = imageRenderComputed.dom;
+  const imgSelector = dom.querySelector("img");
+
+  imgSelector?.setAttribute("alt", "");
+  imgSelector?.setAttribute("role", "presentation");
+  imgSelector?.setAttribute("aria-hidden", "true");
+  imgSelector?.setAttribute("tabindex", "-1");
+
+  return {
+    ...imageRenderComputed,
+    dom,
+  };
+};
+
+export const AccessibleImageBlock = createBlockSpec(imageBlockConfig, {
+  render: accessibleImageRender,
+  parse: imageParse,
+  toExternalHTML: imageToExternalHTML,
+});

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -23,6 +23,7 @@ export * from "./blocks/FileBlockContent/helpers/toExternalHTML/createFigureWith
 export * from "./blocks/FileBlockContent/helpers/toExternalHTML/createLinkWithCaption.js";
 export * from "./blocks/FileBlockContent/uploadToTmpFilesDotOrg_DEV_ONLY.js";
 export * from "./blocks/ImageBlockContent/ImageBlockContent.js";
+export * from "./blocks/ImageBlockContent/AccessibleImageBlock.js";
 export * from "./blocks/PageBreakBlockContent/getPageBreakSlashMenuItems.js";
 export * from "./blocks/PageBreakBlockContent/PageBreakBlockContent.js";
 export * from "./blocks/PageBreakBlockContent/schema.js";


### PR DESCRIPTION
**Title**

Add AccessibleImageBlock for decorative images (alt="", role="presentation", aria-hidden, tabindex)

**Why**
Avoiding screen reader to read `alt`,
[RGAA 1.2 criterion](https://accessibilite.numerique.gouv.fr/methode/criteres-et-tests/)

**Description**

This PR introduces a reusable opt‑in image block, AccessibleImageBlock, exported from @blocknote/core. It renders images as decorative by default (alt="") and sets role="presentation", aria-hidden="true", and tabindex="-1". The homepage demo is updated to use this block via a schema override.

**Details**

- Added AccessibleImageBlock to core:
- File: packages/core/src/blocks/ImageBlockContent/AccessibleImageBlock.ts
- Exported via packages/core/src/index.ts
- Implementation wraps imageBlockConfig with a custom render that:
- Sets alt="" (decorative image per WCAG 1.1.1)
- Sets role="presentation" and aria-hidden="true" so assistive tech ignores the image
- Sets tabindex="-1" so the image isn’t focusable
- Reuses existing imageParse and imageToExternalHTML

Demo integration:
docs/app/(home)/hero/DemoEditor.tsx overrides the schema to use AccessibleImageBlock for the image block type

Usage : 

Override the image block in your schema:
```
import { BlockNoteSchema, defaultBlockSpecs, AccessibleImageBlock } from '@blocknote/core';

const schema = BlockNoteSchema.create({
  blockSpecs: {
    ...defaultBlockSpecs,
    image: AccessibleImageBlock, // alt="" by default
  },
});
```
React:
```
import { useCreateBlockNote } from '@blocknote/react';
const editor = useCreateBlockNote({ schema });
```
Vanilla:
React:
```
import { useCreateBlockNote } from '@blocknote/core';
const editor = useCreateBlockNote({ schema });
```