### PR TITLE
fix: Table column widths not being set in exported HTML

### DIFF
--- a/packages/core/src/blocks/TableBlockContent/TableBlockContent.ts
+++ b/packages/core/src/blocks/TableBlockContent/TableBlockContent.ts
@@ -34,16 +34,45 @@ export const TableBlockContent = createStronglyTypedTiptapNode({
     ];
   },
 
-  renderHTML({ HTMLAttributes }) {
-    return createDefaultBlockDOMOutputSpec(
+  renderHTML({ node, HTMLAttributes }) {
+    const domOutputSpec = createDefaultBlockDOMOutputSpec(
       this.name,
       "table",
       {
-        ...(this.options.domAttributes?.blockContent || {}),
+        ...(this.options.domAttributes?.blockContent || { fesfes: "fesfes" }),
         ...HTMLAttributes,
       },
       this.options.domAttributes?.inlineContent || {},
     );
+
+    // Need to manually add column widths.
+    const cols: HTMLTableColElement[] = [];
+    for (const tableCell of node.children[0].children) {
+      const colWidths: null | (number | undefined)[] =
+        tableCell.attrs["colwidth"];
+
+      if (colWidths) {
+        for (const colWidth of tableCell.attrs["colwidth"]) {
+          const col = document.createElement("col");
+          if (colWidth) {
+            col.style = `width: ${colWidth}px`;
+          }
+
+          cols.push(col);
+        }
+      } else {
+        cols.push(document.createElement("col"));
+      }
+    }
+
+    const colGroup = document.createElement("colgroup");
+    for (const col of cols) {
+      colGroup.appendChild(col);
+    }
+
+    domOutputSpec.dom.firstChild?.appendChild(colGroup);
+
+    return domOutputSpec;
   },
 
   // This node view is needed for the `columnResizing` plugin. By default, the


### PR DESCRIPTION
Closes #1574

TODO: Empty paragraphs should also include a line break for correct row height.