### PR TITLE
[Fix] block dragging errors between editors with multiple column extension

### DIFF
--- a/packages/xl-multi-column/src/extensions/DropCursor/MultiColumnDropCursorPlugin.ts
+++ b/packages/xl-multi-column/src/extensions/DropCursor/MultiColumnDropCursorPlugin.ts
@@ -145,7 +145,9 @@ export function multiColumnDropCursor(
               id: UniqueID.options.generateID(),
             });
 
-          editor.removeBlocks([draggedBlock]);
+          if (editor.getBlock(draggedBlock.id)) {
+            editor.removeBlocks([draggedBlock]);
+          }
 
           editor.updateBlock(columnList, {
             children: newChildren,
@@ -162,7 +164,11 @@ export function multiColumnDropCursor(
 
           const blocks =
             position === "left" ? [draggedBlock, block] : [block, draggedBlock];
-          editor.removeBlocks([draggedBlock]);
+
+          if (editor.getBlock(draggedBlock.id)) {
+            editor.removeBlocks([draggedBlock]);
+          }
+
           editor.replaceBlocks(
             [block],
             [


### PR DESCRIPTION
This PR fixes an error that occurs when dragging a block from one editor to another while using the multiple column extension.

## How Has This Been Tested?
- Dragging blocks within editor configured with multiple column extension
- Dragging blocks from one editor to another

## Video

https://github.com/user-attachments/assets/d008bdd7-bebf-4e91-ba59-5db23e0885b7


## Root Cause

When a block is dragged from an editor, its ID is regenerated. After the block is dropped, the target editor attempts to delete a block with the same ID. However, since that ID does not exist in the target editor, this leads to an error.

<img width="471" height="259" alt="image" src="https://github.com/user-attachments/assets/c4f2f600-053d-46a9-89de-670dab589e50" />

<img width="849" height="673" alt="image" src="https://github.com/user-attachments/assets/fd1cf69e-1493-4678-abbf-291cb8c00236" />


## FIx
The fix ensures that the target editor checks whether the block exists before attempting to delete it.