### PR TITLE
fix: initialize esm deps before copy extension uses it

### DIFF
--- a/packages/core/src/api/clipboard/toClipboard/copyExtension.ts
+++ b/packages/core/src/api/clipboard/toClipboard/copyExtension.ts
@@ -17,6 +17,7 @@ import {
   contentNodeToInlineContent,
   contentNodeToTableContent,
 } from "../../nodeConversions/nodeToBlock.js";
+import { initializeESMDependencies } from "../../../util/esmDependencies.js";
 
 function fragmentToExternalHTML<
   BSchema extends BlockSchema,
@@ -208,6 +209,7 @@ export const createCopyToClipboardExtension = <
   Extension.create<{ editor: BlockNoteEditor<BSchema, I, S> }, undefined>({
     name: "copyToClipboard",
     addProseMirrorPlugins() {
+      initializeESMDependencies();
       return [
         new Plugin({
           props: {


### PR DESCRIPTION
Fixes #1940 by initializing the esm deps on extension initialization
