### PR TITLE
[CRITICAL] Fix: Infinite render loop when selecting all content (Ctrl+A / Cmd+A)

### DIFF
--- a/packages/core/src/extensions/FormattingToolbar/FormattingToolbarPlugin.ts
+++ b/packages/core/src/extensions/FormattingToolbar/FormattingToolbarPlugin.ts
@@ -206,15 +206,14 @@ export class FormattingToolbarView implements PluginView {
       // individually in each button.
       const newReferencePos = this.getSelectionBoundingBox();
 
-      // Workaround to ensure the correct reference position when rendering 
+      // Workaround to ensure the correct reference position when rendering
       // React components. Without this, e.g. updating styles on React inline
-      // content causes the formatting toolbar to be in the wrong place. We 
-      // know the component has not yet rendered if the reference position has 
+      // content causes the formatting toolbar to be in the wrong place. We
+      // know the component has not yet rendered if the reference position has
       // zero dimensions.
       if (
         newReferencePos.x === 0 ||
         newReferencePos.y === 0 ||
-        newReferencePos.width === 0 ||
         newReferencePos.height === 0
       ) {
         // Updates the reference position again following the render.


### PR DESCRIPTION
## Reproduction Steps

Select all content manually, or use the shortcut Ctrl+A / Cmd+A.

The editor enters an infinite render loop and eventually crashes the page.

## Root Cause

In the `FormattingToolbarView` update event handler, the logic attempts to check the selection boundary to determine whether the formatting toolbar is rendered.
If the toolbar isn’t rendered, it forces the view to update.

When all content is selected, posToDOMRect (from Tiptap) reports a selection width of 0.
This results in the handler continuously scheduling forced updates, creating an infinite render loop.

```
// Why width = 0?
| <- Start (left = 0, right = 0)
Content Content Content Content
| <- End (left = 0, right = 0)

const width = right - left; // width = 0
```

<img width="925" height="694" alt="image" src="https://github.com/user-attachments/assets/0e3a6696-ac57-4c27-a9c5-97ddd06bcca4" />

#965 
#1908 