### PR TITLE
feat: export ShadCNComponentsContext

### DIFF
--- a/packages/shadcn/src/index.tsx
+++ b/packages/shadcn/src/index.tsx
@@ -2,3 +2,4 @@ import "./style.css";
 
 export { BlockNoteView } from "./BlockNoteView.js";
 export { components } from "./components.js";
+export * from "./ShadCNComponentsContext";


### PR DESCRIPTION
There might be cases where some components controlling the editor are outside of `BlockNoteView`. In that case, the context will be missing, and it needs to be exported to gain access to it.