### PR TITLE
build: externalize deps from server-util #1966

### DIFF
--- a/packages/server-util/vite.config.ts
+++ b/packages/server-util/vite.config.ts
@@ -41,25 +41,22 @@ export default defineConfig((conf) => ({
     rollupOptions: {
       // make sure to externalize deps that shouldn't be bundled
       // into your library
-      external: (source: string) => {
-        if (deps.includes(source)) {
-          return true;
-        }
-
-        if (source === "react/jsx-runtime") {
-          return true;
-        }
-
-        if (source.startsWith("prosemirror-")) {
-          return true;
-        }
-
-        return false;
-      },
+      external: [
+        ...Object.keys({
+          ...pkg.dependencies,
+          ...pkg.peerDependencies,
+          ...pkg.devDependencies,
+        }),
+        "react-dom/client",
+        "react/jsx-runtime",
+      ],
       output: {
         // Provide global variables to use in the UMD build
         // for externalized deps
-        globals: {},
+        globals: {
+          react: "React",
+          "react-dom": "ReactDOM",
+        },
         interop: "compat", // https://rollupjs.org/migration/#changed-defaults
       },
     },


### PR DESCRIPTION
This properly externalizes react, react-dom, react-dom/client from the server-util bundle, allowing users to use whatever version of React their application requires
