### PR TITLE
Fix documentation formatting for `foundations/document-structure` page

### DIFF
--- a/docs/content/docs/foundations/document-structure.mdx
+++ b/docs/content/docs/foundations/document-structure.mdx
@@ -72,7 +72,6 @@ type CustomInlineContent = {
   content: StyledText[] | undefined;
   props: Record<string, boolean | number | string>;
 };
-```
 
 type InlineContent = Link | StyledText | CustomInlineContent;
 


### PR DESCRIPTION
Remove extra code block ticks that prevent proper doc page rendering (see screenshot below)

<img width="1511" height="856" alt="Screenshot 2025-08-29 at 9 01 37 PM" src="https://github.com/user-attachments/assets/62dfa989-2a7e-4db9-80c3-5b00c038b380" />
