### PR TITLE
fix: doLLMRequest fails when deleting a non-existent block

### DIFF
--- a/packages/xl-ai/src/api/LLMRequest.ts
+++ b/packages/xl-ai/src/api/LLMRequest.ts
@@ -231,7 +231,7 @@ export async function doLLMRequest(
         ...rest,
       },
       () => {
-        if (deleteCursorBlock) {
+        if (deleteCursorBlock && editor.getBlock(deleteCursorBlock)) {
           editor.removeBlocks([deleteCursorBlock]);
         }
         onStart?.();
@@ -242,7 +242,7 @@ export async function doLLMRequest(
       messages,
       ...rest,
     });
-    if (deleteCursorBlock) {
+    if (deleteCursorBlock && editor.getBlock(deleteCursorBlock)) {
       editor.removeBlocks([deleteCursorBlock]);
     }
     onStart?.();


### PR DESCRIPTION
In some cases, which are hard to reproduce, `doLLMRequest` attempts to delete a non-existent block. This could be caused by a retry.