### PR TITLE
fix: Improve setting text for custom file blocks

### DIFF
--- a/examples/06-custom-schema/04-pdf-file-block/src/App.tsx
+++ b/examples/06-custom-schema/04-pdf-file-block/src/App.tsx
@@ -4,6 +4,7 @@ import {
   filterSuggestionItems,
   insertOrUpdateBlock,
 } from "@blocknote/core";
+import { en } from "@blocknote/core/locales";
 import "@blocknote/core/fonts/inter.css";
 import { BlockNoteView } from "@blocknote/mantine";
 import "@blocknote/mantine/style.css";
@@ -16,6 +17,12 @@ import {
 import { RiFilePdfFill } from "react-icons/ri";
 
 import { PDF } from "./PDF";
+
+// Updated English dictionary with entries for PDF blocks.
+const dictionary = en;
+en.file_blocks.add_button_text["pdf"] = "Add PDF";
+en.file_panel.embed.embed_button["pdf"] = "Embed PDF";
+en.file_panel.upload.file_placeholder["pdf"] = "Upload PDF";
 
 // Our schema with block specs, which contain the configs and implementations for blocks
 // that we want our editor to use.
@@ -44,6 +51,7 @@ const insertPDF = (editor: typeof schema.BlockNoteEditor) => ({
 export default function App() {
   // Creates a new editor instance.
   const editor = useCreateBlockNote({
+    dictionary,
     schema,
     initialContent: [
       {

--- a/examples/06-custom-schema/04-pdf-file-block/src/PDF.tsx
+++ b/examples/06-custom-schema/04-pdf-file-block/src/PDF.tsx
@@ -54,7 +54,6 @@ export const PDF = createReactBlockSpec(
     render: (props) => (
       <ResizableFileBlockWrapper
         {...(props as any)}
-        bbuttonText={"Add PDF"}
         buttonIcon={<RiFilePdfFill size={24} />}
       >
         <PDFPreview {...(props as any)} />

--- a/packages/core/src/blocks/AudioBlockContent/AudioBlockContent.ts
+++ b/packages/core/src/blocks/AudioBlockContent/AudioBlockContent.ts
@@ -69,7 +69,6 @@ export const audioRender = (
     block,
     editor,
     { dom: audio },
-    editor.dictionary.file_blocks.audio.add_button_text,
     icon.firstElementChild as HTMLElement,
   );
 };

--- a/packages/core/src/blocks/FileBlockContent/helpers/render/createAddFileButton.ts
+++ b/packages/core/src/blocks/FileBlockContent/helpers/render/createAddFileButton.ts
@@ -4,7 +4,6 @@ import { BlockFromConfig, FileBlockConfig } from "../../../../schema/index.js";
 export const createAddFileButton = (
   block: BlockFromConfig<FileBlockConfig, any, any>,
   editor: BlockNoteEditor<any, any, any>,
-  buttonText?: string,
   buttonIcon?: HTMLElement,
 ) => {
   const addFileButton = document.createElement("div");
@@ -23,7 +22,9 @@ export const createAddFileButton = (
   const addFileButtonText = document.createElement("p");
   addFileButtonText.className = "bn-add-file-button-text";
   addFileButtonText.innerHTML =
-    buttonText || editor.dictionary.file_blocks.file.add_button_text;
+    block.type in editor.dictionary.file_blocks.add_button_text
+      ? editor.dictionary.file_blocks.add_button_text[block.type]
+      : editor.dictionary.file_blocks.add_button_text["file"];
   addFileButton.appendChild(addFileButtonText);
 
   // Prevents focus from moving to the button.

--- a/packages/core/src/blocks/FileBlockContent/helpers/render/createFileBlockWrapper.ts
+++ b/packages/core/src/blocks/FileBlockContent/helpers/render/createFileBlockWrapper.ts
@@ -15,7 +15,6 @@ export const createFileBlockWrapper = (
     any
   >,
   element?: { dom: HTMLElement; destroy?: () => void },
-  buttonText?: string,
   buttonIcon?: HTMLElement,
 ) => {
   const wrapper = document.createElement("div");
@@ -24,12 +23,7 @@ export const createFileBlockWrapper = (
   // Show the add file button if the file has not been uploaded yet. Change to
   // show a loader if a file upload for the block begins.
   if (block.props.url === "") {
-    const addFileButton = createAddFileButton(
-      block,
-      editor,
-      buttonText,
-      buttonIcon,
-    );
+    const addFileButton = createAddFileButton(block, editor, buttonIcon);
     wrapper.appendChild(addFileButton.dom);
 
     const destroyUploadStartHandler = editor.onUploadStart((blockId) => {

--- a/packages/core/src/blocks/FileBlockContent/helpers/render/createResizableFileBlockWrapper.ts
+++ b/packages/core/src/blocks/FileBlockContent/helpers/render/createResizableFileBlockWrapper.ts
@@ -7,14 +7,12 @@ export const createResizableFileBlockWrapper = (
   editor: BlockNoteEditor<any, any, any>,
   element: { dom: HTMLElement; destroy?: () => void },
   resizeHandlesContainerElement: HTMLElement,
-  buttonText: string,
-  buttonIcon: HTMLElement,
+  buttonIcon?: HTMLElement,
 ): { dom: HTMLElement; destroy: () => void } => {
   const { dom, destroy } = createFileBlockWrapper(
     block,
     editor,
     element,
-    buttonText,
     buttonIcon,
   );
   const wrapper = dom;

--- a/packages/core/src/blocks/ImageBlockContent/ImageBlockContent.ts
+++ b/packages/core/src/blocks/ImageBlockContent/ImageBlockContent.ts
@@ -80,7 +80,6 @@ export const imageRender = (
     editor,
     { dom: imageWrapper },
     imageWrapper,
-    editor.dictionary.file_blocks.image.add_button_text,
     icon.firstElementChild as HTMLElement,
   );
 };

--- a/packages/core/src/blocks/VideoBlockContent/VideoBlockContent.ts
+++ b/packages/core/src/blocks/VideoBlockContent/VideoBlockContent.ts
@@ -80,7 +80,6 @@ export const videoRender = (
     editor,
     { dom: videoWrapper },
     videoWrapper,
-    editor.dictionary.file_blocks.video.add_button_text,
     icon.firstElementChild as HTMLElement,
   );
 };

--- a/packages/core/src/i18n/locales/ar.ts
+++ b/packages/core/src/i18n/locales/ar.ts
@@ -169,18 +169,12 @@ export const ar: Dictionary = {
     comment_reply: "أضف تعليقًا...",
   },
   file_blocks: {
-    image: {
-      add_button_text: "إضافة صورة",
-    },
-    video: {
-      add_button_text: "إضافة فيديو",
-    },
-    audio: {
-      add_button_text: "إضافة صوت",
-    },
-    file: {
-      add_button_text: "إضافة ملف",
-    },
+    add_button_text: {
+      image: "إضافة صورة",
+      video: "إضافة فيديو",
+      audio: "إضافة صوت",
+      file: "إضافة ملف",
+    } as Record<string, string>,
   },
   toggle_blocks: {
     add_block_button: "تبديل فارغ. انقر لإضافة كتلة.",

--- a/packages/core/src/i18n/locales/de.ts
+++ b/packages/core/src/i18n/locales/de.ts
@@ -204,18 +204,12 @@ export const de: Dictionary = {
     comment_reply: "Kommentar hinzufügen …",
   },
   file_blocks: {
-    image: {
-      add_button_text: "Bild hinzufügen",
-    },
-    video: {
-      add_button_text: "Video hinzufügen",
-    },
-    audio: {
-      add_button_text: "Audio hinzufügen",
-    },
-    file: {
-      add_button_text: "Datei hinzufügen",
-    },
+    add_button_text: {
+      image: "Bild hinzufügen",
+      video: "Video hinzufügen",
+      audio: "Audio hinzufügen",
+      file: "Datei hinzufügen",
+    } as Record<string, string>,
   },
   toggle_blocks: {
     add_block_button:

--- a/packages/core/src/i18n/locales/en.ts
+++ b/packages/core/src/i18n/locales/en.ts
@@ -184,18 +184,12 @@ export const en = {
     comment_reply: "Add comment...",
   } as Record<string | "default" | "emptyDocument", string | undefined>,
   file_blocks: {
-    image: {
-      add_button_text: "Add image",
-    },
-    video: {
-      add_button_text: "Add video",
-    },
-    audio: {
-      add_button_text: "Add audio",
-    },
-    file: {
-      add_button_text: "Add file",
-    },
+    add_button_text: {
+      image: "Add image",
+      video: "Add video",
+      audio: "Add audio",
+      file: "Add file",
+    } as Record<string, string>,
   },
   toggle_blocks: {
     add_block_button: "Empty toggle. Click to add a block.",

--- a/packages/core/src/i18n/locales/es.ts
+++ b/packages/core/src/i18n/locales/es.ts
@@ -184,18 +184,12 @@ export const es: Dictionary = {
     comment_reply: "Agregar comentario...",
   },
   file_blocks: {
-    image: {
-      add_button_text: "Agregar imagen",
-    },
-    video: {
-      add_button_text: "Agregar vídeo",
-    },
-    audio: {
-      add_button_text: "Agregar audio",
-    },
-    file: {
-      add_button_text: "Agregar archivo",
-    },
+    add_button_text: {
+      image: "Agregar imagen",
+      video: "Agregar vídeo",
+      audio: "Agregar audio",
+      file: "Agregar archivo",
+    } as Record<string, string>,
   },
   toggle_blocks: {
     add_block_button: "Toggle vacío. Haz clic para añadir un bloque.",

--- a/packages/core/src/i18n/locales/fr.ts
+++ b/packages/core/src/i18n/locales/fr.ts
@@ -230,18 +230,12 @@ export const fr: Dictionary = {
     comment_reply: "Ajouter un commentaire...",
   },
   file_blocks: {
-    image: {
-      add_button_text: "Ajouter une image",
-    },
-    video: {
-      add_button_text: "Ajouter une vidéo",
-    },
-    audio: {
-      add_button_text: "Ajouter un audio",
-    },
-    file: {
-      add_button_text: "Ajouter un fichier",
-    },
+    add_button_text: {
+      image: "Ajouter une image",
+      video: "Ajouter une vidéo",
+      audio: "Ajouter un audio",
+      file: "Ajouter un fichier",
+    } as Record<string, string>,
   },
   toggle_blocks: {
     add_block_button: "Toggle vide. Cliquez pour ajouter un bloc.",

--- a/packages/core/src/i18n/locales/he.ts
+++ b/packages/core/src/i18n/locales/he.ts
@@ -186,18 +186,12 @@ export const he: Dictionary = {
     comment_reply: "הוסף תגובה...",
   } as Record<string | "default" | "emptyDocument", string | undefined>,
   file_blocks: {
-    image: {
-      add_button_text: "הוסף תמונה",
-    },
-    video: {
-      add_button_text: "הוסף וידאו",
-    },
-    audio: {
-      add_button_text: "הוסף אודיו",
-    },
-    file: {
-      add_button_text: "הוסף קובץ",
-    },
+    add_button_text: {
+      image: "הוסף תמונה",
+      video: "הוסף וידאו",
+      audio: "הוסף אודיו",
+      file: "הוסף קובץ",
+    } as Record<string, string>,
   },
   toggle_blocks: {
     add_block_button: "מתג ריק. לחץ כדי להוסיף בלוק.",

--- a/packages/core/src/i18n/locales/hr.ts
+++ b/packages/core/src/i18n/locales/hr.ts
@@ -197,18 +197,12 @@ export const hr: Dictionary = {
     comment_reply: "Dodaj komentar...",
   },
   file_blocks: {
-    image: {
-      add_button_text: "Dodaj sliku",
-    },
-    video: {
-      add_button_text: "Dodaj video",
-    },
-    audio: {
-      add_button_text: "Dodaj audio",
-    },
-    file: {
-      add_button_text: "Dodaj datoteku",
-    },
+    add_button_text: {
+      image: "Dodaj sliku",
+      video: "Dodaj video",
+      audio: "Dodaj audio",
+      file: "Dodaj datoteku",
+    } as Record<string, string>,
   },
   toggle_blocks: {
     add_block_button: "Prazan sklopivi blok. Klikni da dodaš sadržaj.",

--- a/packages/core/src/i18n/locales/is.ts
+++ b/packages/core/src/i18n/locales/is.ts
@@ -198,18 +198,12 @@ export const is: Dictionary = {
     comment_reply: "Bæta við athugasemd...",
   },
   file_blocks: {
-    image: {
-      add_button_text: "Bæta við mynd",
-    },
-    video: {
-      add_button_text: "Bæta við myndbandi",
-    },
-    audio: {
-      add_button_text: "Bæta við hljóði",
-    },
-    file: {
-      add_button_text: "Bæta við skrá",
-    },
+    add_button_text: {
+      image: "Bæta við mynd",
+      video: "Bæta við myndbandi",
+      audio: "Bæta við hljóði",
+      file: "Bæta við skrá",
+    } as Record<string, string>,
   },
   toggle_blocks: {
     add_block_button: "Tóm fellilína. Smelltu til að bæta við blokk.",

--- a/packages/core/src/i18n/locales/it.ts
+++ b/packages/core/src/i18n/locales/it.ts
@@ -206,18 +206,12 @@ export const it: Dictionary = {
     comment_reply: "Aggiungi commento...",
   },
   file_blocks: {
-    image: {
-      add_button_text: "Aggiungi immagine",
-    },
-    video: {
-      add_button_text: "Aggiungi video",
-    },
-    audio: {
-      add_button_text: "Aggiungi audio",
-    },
-    file: {
-      add_button_text: "Aggiungi file",
-    },
+    add_button_text: {
+      image: "Aggiungi immagine",
+      video: "Aggiungi video",
+      audio: "Aggiungi audio",
+      file: "Aggiungi file",
+    } as Record<string, string>,
   },
   toggle_blocks: {
     add_block_button: "Toggle vuoto. Clicca per aggiungere un blocco.",

--- a/packages/core/src/i18n/locales/ja.ts
+++ b/packages/core/src/i18n/locales/ja.ts
@@ -224,18 +224,12 @@ export const ja: Dictionary = {
     comment_reply: "コメントを追加...",
   },
   file_blocks: {
-    image: {
-      add_button_text: "画像を追加",
-    },
-    video: {
-      add_button_text: "ビデオを追加",
-    },
-    audio: {
-      add_button_text: "オーディオを追加",
-    },
-    file: {
-      add_button_text: "ファイルを追加",
-    },
+    add_button_text: {
+      image: "画像を追加",
+      video: "ビデオを追加",
+      audio: "オーディオを追加",
+      file: "ファイルを追加",
+    } as Record<string, string>,
   },
   toggle_blocks: {
     add_block_button: "空のトグルです。クリックしてブロックを追加。",

--- a/packages/core/src/i18n/locales/ko.ts
+++ b/packages/core/src/i18n/locales/ko.ts
@@ -197,18 +197,12 @@ export const ko: Dictionary = {
     comment_reply: "댓글 추가...",
   },
   file_blocks: {
-    image: {
-      add_button_text: "이미지 추가",
-    },
-    video: {
-      add_button_text: "비디오 추가",
-    },
-    audio: {
-      add_button_text: "오디오 추가",
-    },
-    file: {
-      add_button_text: "파일 추가",
-    },
+    add_button_text: {
+      image: "이미지 추가",
+      video: "비디오 추가",
+      audio: "오디오 추가",
+      file: "파일 추가",
+    } as Record<string, string>,
   },
   toggle_blocks: {
     add_block_button: "비어 있는 토글입니다. 클릭하여 블록을 추가하세요.",

--- a/packages/core/src/i18n/locales/nl.ts
+++ b/packages/core/src/i18n/locales/nl.ts
@@ -185,18 +185,12 @@ export const nl: Dictionary = {
     comment_reply: "Reactie toevoegen...",
   },
   file_blocks: {
-    image: {
-      add_button_text: "Afbeelding toevoegen",
-    },
-    video: {
-      add_button_text: "Video toevoegen",
-    },
-    audio: {
-      add_button_text: "Audio toevoegen",
-    },
-    file: {
-      add_button_text: "Bestand toevoegen",
-    },
+    add_button_text: {
+      image: "Afbeelding toevoegen",
+      video: "Video toevoegen",
+      audio: "Audio toevoegen",
+      file: "Bestand toevoegen",
+    } as Record<string, string>,
   },
   toggle_blocks: {
     add_block_button: "Lege uitklapper. Klik om een blok toe te voegen.",

--- a/packages/core/src/i18n/locales/no.ts
+++ b/packages/core/src/i18n/locales/no.ts
@@ -203,18 +203,12 @@ export const no: Dictionary = {
     comment_reply: "Legg til kommentar...",
   },
   file_blocks: {
-    image: {
-      add_button_text: "Legg til bilde",
-    },
-    video: {
-      add_button_text: "Legg til video",
-    },
-    audio: {
-      add_button_text: "Legg til lyd",
-    },
-    file: {
-      add_button_text: "Legg til fil",
-    },
+    add_button_text: {
+      image: "Legg til bilde",
+      video: "Legg til video",
+      audio: "Legg til lyd",
+      file: "Legg til fil",
+    } as Record<string, string>,
   },
   toggle_blocks: {
     add_block_button: "Tomt toggle. Klikk for å legge til en blokk.",

--- a/packages/core/src/i18n/locales/pl.ts
+++ b/packages/core/src/i18n/locales/pl.ts
@@ -175,18 +175,12 @@ export const pl: Dictionary = {
     comment_reply: "Dodaj komentarz...",
   },
   file_blocks: {
-    image: {
-      add_button_text: "Dodaj zdjęcie",
-    },
-    video: {
-      add_button_text: "Dodaj wideo",
-    },
-    audio: {
-      add_button_text: "Dodaj audio",
-    },
-    file: {
-      add_button_text: "Dodaj plik",
-    },
+    add_button_text: {
+      image: "Dodaj zdjęcie",
+      video: "Dodaj wideo",
+      audio: "Dodaj audio",
+      file: "Dodaj plik",
+    } as Record<string, string>,
   },
   toggle_blocks: {
     add_block_button:

--- a/packages/core/src/i18n/locales/pt.ts
+++ b/packages/core/src/i18n/locales/pt.ts
@@ -176,18 +176,12 @@ export const pt: Dictionary = {
     comment_reply: "Adicionar comentário...",
   },
   file_blocks: {
-    image: {
-      add_button_text: "Adicionar imagem",
-    },
-    video: {
-      add_button_text: "Adicionar vídeo",
-    },
-    audio: {
-      add_button_text: "Adicionar áudio",
-    },
-    file: {
-      add_button_text: "Adicionar arquivo",
-    },
+    add_button_text: {
+      image: "Adicionar imagem",
+      video: "Adicionar vídeo",
+      audio: "Adicionar áudio",
+      file: "Adicionar arquivo",
+    } as Record<string, string>,
   },
   toggle_blocks: {
     add_block_button: "Toggle vazio. Clique para adicionar um bloco.",

--- a/packages/core/src/i18n/locales/ru.ts
+++ b/packages/core/src/i18n/locales/ru.ts
@@ -227,18 +227,12 @@ export const ru: Dictionary = {
     comment_reply: "Добавить комментарий...",
   },
   file_blocks: {
-    image: {
-      add_button_text: "Добавить изображение",
-    },
-    video: {
-      add_button_text: "Добавить видео",
-    },
-    audio: {
-      add_button_text: "Добавить аудио",
-    },
-    file: {
-      add_button_text: "Добавить файл",
-    },
+    add_button_text: {
+      image: "Добавить изображение",
+      video: "Добавить видео",
+      audio: "Добавить аудио",
+      file: "Добавить файл",
+    } as Record<string, string>,
   },
   toggle_blocks: {
     add_block_button: "Пустой переключатель. Нажмите, чтобы добавить блок.",

--- a/packages/core/src/i18n/locales/sk.ts
+++ b/packages/core/src/i18n/locales/sk.ts
@@ -184,18 +184,12 @@ export const sk = {
     comment_reply: "Pridať komentár...",
   } as Record<string | "default" | "emptyDocument", string | undefined>,
   file_blocks: {
-    image: {
-      add_button_text: "Pridať obrázok",
-    },
-    video: {
-      add_button_text: "Pridať video",
-    },
-    audio: {
-      add_button_text: "Pridať audio",
-    },
-    file: {
-      add_button_text: "Pridať súbor",
-    },
+    add_button_text: {
+      image: "Pridať obrázok",
+      video: "Pridať video",
+      audio: "Pridať audio",
+      file: "Pridať súbor",
+    } as Record<string, string>,
   },
   toggle_blocks: {
     add_block_button: "Prázdne prepínanie. Kliknite pre pridanie bloku.",

--- a/packages/core/src/i18n/locales/uk.ts
+++ b/packages/core/src/i18n/locales/uk.ts
@@ -209,18 +209,12 @@ export const uk: Dictionary = {
     comment_reply: "Додати коментар...",
   },
   file_blocks: {
-    image: {
-      add_button_text: "Додати зображення",
-    },
-    video: {
-      add_button_text: "Додати відео",
-    },
-    audio: {
-      add_button_text: "Додати аудіо",
-    },
-    file: {
-      add_button_text: "Додати файл",
-    },
+    add_button_text: {
+      image: "Додати зображення",
+      video: "Додати відео",
+      audio: "Додати аудіо",
+      file: "Додати файл",
+    } as Record<string, string>,
   },
   toggle_blocks: {
     add_block_button: "Порожній перемикач. Натисніть, щоб додати блок.",

--- a/packages/core/src/i18n/locales/vi.ts
+++ b/packages/core/src/i18n/locales/vi.ts
@@ -183,18 +183,12 @@ export const vi: Dictionary = {
     comment_reply: "Thêm bình luận...",
   },
   file_blocks: {
-    image: {
-      add_button_text: "Thêm ảnh",
-    },
-    video: {
-      add_button_text: "Thêm video",
-    },
-    audio: {
-      add_button_text: "Thêm âm thanh",
-    },
-    file: {
-      add_button_text: "Thêm tệp",
-    },
+    add_button_text: {
+      image: "Thêm ảnh",
+      video: "Thêm video",
+      audio: "Thêm âm thanh",
+      file: "Thêm tệp",
+    } as Record<string, string>,
   },
   toggle_blocks: {
     add_block_button: "Toggle trống. Nhấp để thêm khối.",

--- a/packages/core/src/i18n/locales/zh-tw.ts
+++ b/packages/core/src/i18n/locales/zh-tw.ts
@@ -225,18 +225,12 @@ export const zhTW: Dictionary = {
     comment_reply: "新增評論...",
   },
   file_blocks: {
-    image: {
-      add_button_text: "新增圖片",
-    },
-    video: {
-      add_button_text: "新增影片",
-    },
-    audio: {
-      add_button_text: "新增音訊",
-    },
-    file: {
-      add_button_text: "新增檔案",
-    },
+    add_button_text: {
+      image: "新增圖片",
+      video: "新增影片",
+      audio: "新增音訊",
+      file: "新增檔案",
+    } as Record<string, string>,
   },
   toggle_blocks: {
     add_block_button: "空的切換區。點擊新增區塊。",

--- a/packages/core/src/i18n/locales/zh.ts
+++ b/packages/core/src/i18n/locales/zh.ts
@@ -225,18 +225,12 @@ export const zh: Dictionary = {
     comment_reply: "添加评论...",
   },
   file_blocks: {
-    image: {
-      add_button_text: "添加图片",
-    },
-    video: {
-      add_button_text: "添加视频",
-    },
-    audio: {
-      add_button_text: "添加音频",
-    },
-    file: {
-      add_button_text: "添加文件",
-    },
+    add_button_text: {
+      image: "添加图片",
+      video: "添加视频",
+      audio: "添加音频",
+      file: "添加文件",
+    } as Record<string, string>,
   },
   toggle_blocks: {
     add_block_button: "空的切换区。点击添加区块。",

--- a/packages/react/src/blocks/AudioBlockContent/AudioBlockContent.tsx
+++ b/packages/react/src/blocks/AudioBlockContent/AudioBlockContent.tsx
@@ -73,7 +73,6 @@ export const AudioBlock = (
   return (
     <FileBlockWrapper
       {...(props as any)}
-      buttonText={props.editor.dictionary.file_blocks.audio.add_button_text}
       buttonIcon={<RiVolumeUpFill size={24} />}
     >
       <AudioPreview {...(props as any)} />

--- a/packages/react/src/blocks/FileBlockContent/helpers/render/AddFileButton.tsx
+++ b/packages/react/src/blocks/FileBlockContent/helpers/render/AddFileButton.tsx
@@ -10,7 +10,6 @@ export const AddFileButton = (
     ReactCustomBlockRenderProps<FileBlockConfig, any, any>,
     "contentRef"
   > & {
-    buttonText?: string;
     buttonIcon?: ReactNode;
   },
 ) => {
@@ -42,7 +41,9 @@ export const AddFileButton = (
         {props.buttonIcon || <RiFile2Line size={24} />}
       </div>
       <div className={"bn-add-file-button-text"}>
-        {props.buttonText || dict.file_blocks.file.add_button_text}
+        {props.block.type in dict.file_blocks.add_button_text
+          ? dict.file_blocks.add_button_text[props.block.type]
+          : dict.file_blocks.add_button_text["file"]}
       </div>
     </div>
   );

--- a/packages/react/src/blocks/FileBlockContent/helpers/render/FileBlockWrapper.tsx
+++ b/packages/react/src/blocks/FileBlockContent/helpers/render/FileBlockWrapper.tsx
@@ -11,7 +11,6 @@ export const FileBlockWrapper = (
     ReactCustomBlockRenderProps<FileBlockConfig, any, any>,
     "contentRef"
   > & {
-    buttonText?: string;
     buttonIcon?: ReactNode;
     children?: ReactNode;
   } & {

--- a/packages/react/src/blocks/FileBlockContent/helpers/render/ResizableFileBlockWrapper.tsx
+++ b/packages/react/src/blocks/FileBlockContent/helpers/render/ResizableFileBlockWrapper.tsx
@@ -10,9 +10,8 @@ export const ResizableFileBlockWrapper = (
     ReactCustomBlockRenderProps<FileBlockConfig, any, any>,
     "contentRef"
   > & {
-    buttonText: string;
-    buttonIcon: ReactNode;
-    children: ReactNode;
+    buttonIcon?: ReactNode;
+    children?: ReactNode;
   },
 ) => {
   // Temporary parameters set when the user begins resizing the element, used to

--- a/packages/react/src/blocks/ImageBlockContent/ImageBlockContent.tsx
+++ b/packages/react/src/blocks/ImageBlockContent/ImageBlockContent.tsx
@@ -78,7 +78,6 @@ export const ImageBlock = (
   return (
     <ResizableFileBlockWrapper
       {...(props as any)}
-      buttonText={props.editor.dictionary.file_blocks.image.add_button_text}
       buttonIcon={<RiImage2Fill size={24} />}
     >
       <ImagePreview {...(props as any)} />

--- a/packages/react/src/blocks/VideoBlockContent/VideoBlockContent.tsx
+++ b/packages/react/src/blocks/VideoBlockContent/VideoBlockContent.tsx
@@ -72,7 +72,6 @@ export const VideoBlock = (
   return (
     <ResizableFileBlockWrapper
       {...(props as any)}
-      buttonText={props.editor.dictionary.file_blocks.video.add_button_text}
       buttonIcon={<RiVideoFill size={24} />}
     >
       <VideoPreview {...(props as any)} />


### PR DESCRIPTION
This PR makes some small but useful changes for how text in the add block button & file panel is changed for file blocks. It's now done entirely through the dictionary, whereas it was previously split. The file panel text was set throught the dictionary, but the add block button text was set using a `buttonText` prop. The PDF block example has also been updated with this change.