### PR TITLE
fix(react): close link popover on submit in Static Formatting Toolbar…

### DIFF
--- a/packages/react/src/components/FormattingToolbar/DefaultButtons/CreateLinkButton.tsx
+++ b/packages/react/src/components/FormattingToolbar/DefaultButtons/CreateLinkButton.tsx
@@ -76,6 +76,7 @@ export const CreateLinkButton = () => {
   const update = useCallback(
     (url: string) => {
       editor.createLink(url);
+      setOpened(false);
       editor.focus();
     },
     [editor],
@@ -131,11 +132,7 @@ export const CreateLinkButton = () => {
         <EditLinkMenuItems
           url={url}
           text={text}
-          editLink={(url) => {
-            update(url);
-            setOpened(false);
-            editor.focus();
-          }}
+          editLink={update}
           showTextField={false}
         />
       </Components.Generic.Popover.Content>


### PR DESCRIPTION
Fixes [#1696](https://github.com/TypeCellOS/BlockNote/issues/1696)

**Before**

In the Static Formatting Toolbar, after inserting a link the popover remained open.

**After**
After submitting a URL and pressing Enter, the popover closes and focus returns to the editor.

**Change**
- `CreateLinkButton.tsx`: wrap `editLink` to call `setOpened(false)` and `editor.focus()` after applying the link.

**Manual QA**
- Highlight text -> Link -> paste URL -> Enter -> popover closes, link applied.
![Screen Recording 2025-09-10 at 1 29 59 PM](https://github.com/user-attachments/assets/3812adfb-4635-495b-842b-3bba8734076f)
**Note:** The demo recording is from my local docs environment (with some examples disabled for testing).  
The change itself is isolated to `CreateLinkButton.tsx`,  no toolbar layout or styling changes were made.