### PR TITLE
fix(core): input rules can handle when a new block is empty now

### DIFF
--- a/packages/core/src/editor/BlockNoteEditor.ts
+++ b/packages/core/src/editor/BlockNoteEditor.ts
@@ -794,29 +794,31 @@ export class BlockNoteEditor<
                               editor: this,
                             });
                             if (replaceWith) {
+                              const cursorPosition =
+                                this.getTextCursorPosition();
+
+                              if (
+                                this.schema.blockSchema[
+                                  cursorPosition.block.type
+                                ].content !== "inline"
+                              ) {
+                                return undefined;
+                              }
+
                               const blockInfo = getBlockInfoFromTransaction(
                                 state.tr,
                               );
+                              const tr = state.tr.deleteRange(
+                                range.from,
+                                range.to,
+                              );
 
-                              // TODO this is weird, why do we need it?
-                              if (
-                                blockInfo.isBlockContainer &&
-                                blockInfo.blockContent.node.type.spec
-                                  .content === "inline*"
-                              ) {
-                                const tr = state.tr.deleteRange(
-                                  range.from,
-                                  range.to,
-                                );
-                                updateBlockTr(
-                                  tr,
-                                  blockInfo.bnBlock.beforePos,
-                                  replaceWith,
-                                  range.from,
-                                  range.to,
-                                );
-                                return undefined;
-                              }
+                              updateBlockTr(
+                                tr,
+                                blockInfo.bnBlock.beforePos,
+                                replaceWith,
+                              );
+                              return undefined;
                             }
                             return null;
                           },


### PR DESCRIPTION
This is a minor fix to address an issue I found with inputRules
