### PR TITLE
fix: ShadCN example Tailwind setup

### DIFF
--- a/docs/components/Example.tsx
+++ b/docs/components/Example.tsx
@@ -42,11 +42,13 @@ function ExampleDemoBar(props: { exampleData: ExampleData }) {
         icon={<AiFillGithub size={16} />}
         url={`https://github.com/TypeCellOS/BlockNote/tree/main/${props.exampleData.pathFromRoot}`}
       />
-      <ExampleDemoBarSourceCodeLink
-        name="StackBlitz"
-        icon={<SiStackblitz size={16} />}
-        url={`https://www.stackblitz.com/github/TypeCellOS/BlockNote/tree/main/${props.exampleData.pathFromRoot}`}
-      />
+      {props.exampleData.showStackBlitzLink && (
+        <ExampleDemoBarSourceCodeLink
+          name="StackBlitz"
+          icon={<SiStackblitz size={16} />}
+          url={`https://www.stackblitz.com/github/TypeCellOS/BlockNote/tree/main/${props.exampleData.pathFromRoot}`}
+        />
+      )}
     </div>
   );
 }

--- a/examples/01-basic/01-minimal/package.json
+++ b/examples/01-basic/01-minimal/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@blocknote/example-basic-minimal",
   "description": "AUTO-GENERATED FILE, DO NOT EDIT DIRECTLY",
+  "type": "module",
   "private": true,
   "version": "0.12.4",
   "scripts": {

--- a/examples/01-basic/02-block-objects/package.json
+++ b/examples/01-basic/02-block-objects/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@blocknote/example-basic-block-objects",
   "description": "AUTO-GENERATED FILE, DO NOT EDIT DIRECTLY",
+  "type": "module",
   "private": true,
   "version": "0.12.4",
   "scripts": {

--- a/examples/01-basic/03-multi-column/package.json
+++ b/examples/01-basic/03-multi-column/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@blocknote/example-basic-multi-column",
   "description": "AUTO-GENERATED FILE, DO NOT EDIT DIRECTLY",
+  "type": "module",
   "private": true,
   "version": "0.12.4",
   "scripts": {

--- a/examples/01-basic/04-default-blocks/package.json
+++ b/examples/01-basic/04-default-blocks/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@blocknote/example-basic-default-blocks",
   "description": "AUTO-GENERATED FILE, DO NOT EDIT DIRECTLY",
+  "type": "module",
   "private": true,
   "version": "0.12.4",
   "scripts": {

--- a/examples/01-basic/05-removing-default-blocks/package.json
+++ b/examples/01-basic/05-removing-default-blocks/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@blocknote/example-basic-removing-default-blocks",
   "description": "AUTO-GENERATED FILE, DO NOT EDIT DIRECTLY",
+  "type": "module",
   "private": true,
   "version": "0.12.4",
   "scripts": {

--- a/examples/01-basic/06-block-manipulation/package.json
+++ b/examples/01-basic/06-block-manipulation/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@blocknote/example-basic-block-manipulation",
   "description": "AUTO-GENERATED FILE, DO NOT EDIT DIRECTLY",
+  "type": "module",
   "private": true,
   "version": "0.12.4",
   "scripts": {

--- a/examples/01-basic/07-selection-blocks/package.json
+++ b/examples/01-basic/07-selection-blocks/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@blocknote/example-basic-selection-blocks",
   "description": "AUTO-GENERATED FILE, DO NOT EDIT DIRECTLY",
+  "type": "module",
   "private": true,
   "version": "0.12.4",
   "scripts": {

--- a/examples/01-basic/08-ariakit/package.json
+++ b/examples/01-basic/08-ariakit/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@blocknote/example-basic-ariakit",
   "description": "AUTO-GENERATED FILE, DO NOT EDIT DIRECTLY",
+  "type": "module",
   "private": true,
   "version": "0.12.4",
   "scripts": {

--- a/examples/01-basic/09-shadcn/.bnexample.json
+++ b/examples/01-basic/09-shadcn/.bnexample.json
@@ -3,5 +3,6 @@
   "docs": true,
   "author": "matthewlipski",
   "tags": ["Basic"],
-  "tailwind": true
+  "tailwind": true,
+  "stackBlitz": false
 }

--- a/examples/01-basic/09-shadcn/.bnexample.json
+++ b/examples/01-basic/09-shadcn/.bnexample.json
@@ -2,5 +2,6 @@
   "playground": true,
   "docs": true,
   "author": "matthewlipski",
-  "tags": ["Basic"]
+  "tags": ["Basic"],
+  "tailwind": true
 }

--- a/examples/01-basic/09-shadcn/README.md
+++ b/examples/01-basic/09-shadcn/README.md
@@ -2,11 +2,6 @@
 
 This example shows how you can use BlockNote with ShadCN (instead of Mantine).
 
-<Callout type={"warning"}>
-Because the ShadCN version of BlockNote requires being in a Tailwind app,
-viewing the demo below on StackBlitz will have missing styles.
-</Callout>
-
 **Relevant Docs:**
 
 - [Getting Started with ShadCN](/docs/getting-started/shadcn)

--- a/examples/01-basic/09-shadcn/main.tsx
+++ b/examples/01-basic/09-shadcn/main.tsx
@@ -2,6 +2,7 @@
 import React from "react";
 import { createRoot } from "react-dom/client";
 import App from "./src/App.jsx";
+import "./tailwind.css";
 
 const root = createRoot(document.getElementById("root")!);
 root.render(

--- a/examples/01-basic/09-shadcn/package.json
+++ b/examples/01-basic/09-shadcn/package.json
@@ -16,9 +16,12 @@
     "@blocknote/mantine": "latest",
     "@blocknote/shadcn": "latest",
     "react": "^19.1.0",
-    "react-dom": "^19.1.0"
+    "react-dom": "^19.1.0",
+    "tailwindcss": "^4.1.12",
+    "tw-animate-css": "^1.3.7"
   },
   "devDependencies": {
+    "@tailwindcss/vite": "^4.1.12",
     "@types/react": "^19.1.0",
     "@types/react-dom": "^19.1.0",
     "@vitejs/plugin-react": "^4.3.1",

--- a/examples/01-basic/09-shadcn/package.json
+++ b/examples/01-basic/09-shadcn/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@blocknote/example-basic-shadcn",
   "description": "AUTO-GENERATED FILE, DO NOT EDIT DIRECTLY",
+  "type": "module",
   "private": true,
   "version": "0.12.4",
   "scripts": {

--- a/examples/01-basic/09-shadcn/tailwind.css
+++ b/examples/01-basic/09-shadcn/tailwind.css
@@ -1,51 +1,11 @@
----
-title: With ShadCN
-description: ShadCN rich text editor using BlockNote
-imageTitle: ShadCN rich text editor using BlockNote
----
-
-# Getting Started With ShadCN
-
-[shadcn/ui](https://ui.shadcn.com/) is an open-source collection of React components based on [Radix](https://radix-ui.com/) and [TailwindCSS](https://tailwindcss.com/).
-
-```console tab="npm"
-npm install @blocknote/core @blocknote/react @blocknote/shadcn
-```
-
-```console tab="pnpm"
-pnpm add @blocknote/core @blocknote/react @blocknote/shadcn
-```
-
-```console tab="bun"
-bun add @blocknote/core @blocknote/react @blocknote/shadcn
-```
-
-To use BlockNote with ShadCN, you can import `BlockNoteView` from `@blocknote/shadcn` and the stylesheet from `@blocknote/shadcn/style.css`. This version of `BlockNoteView` is expected to be used in apps that are already using ShadCN/TailwindCSS, so it does not import any of those styles itself.
-
-To ensure Tailwind generates the necessary CSS for all utility classes used by BlockNote components, make sure to add the `@source` directive to your stylesheet that imports Tailwind:
-
-```css
 @import "tailwindcss";
-...
-/* Path to your installed `@blocknote/shadcn` package. */
-@source "../node_modules/@blocknote/shadcn";
-```
+@import "tw-animate-css";
 
-<Example name="basic/shadcn" />
+/* Code below needed for ShadCN examples, check docs for more info. */
+@source "./node_modules/@blocknote/shadcn";
 
-## Usage with Tailwind Only
-
-If your app doesn't use ShadCN components and only uses TailwindCSS, you just need to extend your Tailwind theme with ShadCN utility classes to get everything working. You can do this by simply copying the styles below into your stylesheet that imports Tailwind.
-
-```css
-@import "tailwindcss";
-...
-/* Path to your installed `@blocknote/shadcn` package. */
-@source "../node_modules/@blocknote/shadcn";
-...
 @custom-variant dark (&:is(.dark *));
 
-/* Light theme ShadCN CSS variables. */
 :root {
   --radius: 0.625rem;
   --background: oklch(1 0 0);
@@ -81,7 +41,6 @@ If your app doesn't use ShadCN components and only uses TailwindCSS, you just ne
   --sidebar-ring: oklch(0.708 0 0);
 }
 
-/* Dark theme ShadCN CSS variables. */
 .dark {
   --background: oklch(0.145 0 0);
   --foreground: oklch(0.985 0 0);
@@ -116,7 +75,6 @@ If your app doesn't use ShadCN components and only uses TailwindCSS, you just ne
   --sidebar-ring: oklch(0.556 0 0);
 }
 
-/* Extending Tailwind theme with ShadCN utility classes. */
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
@@ -156,52 +114,8 @@ If your app doesn't use ShadCN components and only uses TailwindCSS, you just ne
   --color-sidebar-ring: var(--sidebar-ring);
 }
 
-/* Applies some additional necessary border styles within the editor. */
 @layer base {
   .bn-shadcn * {
     @apply border-border outline-ring/50;
   }
 }
-```
-
-The values used are for the Neutral ShadCN color theme (used in demo above), but you can customize them however you'd like.
-
-This website uses the exact same setup as the one described above, which you can see in [this file](https://github.com/TypeCellOS/BlockNote/blob/main/docs/app/global.css).
-
-## ShadCN Customization
-
-BlockNote comes with default shadcn components. However, it's likely that you have copied and possibly customized your own shadcn components in your project.
-To make BlockNote use the ShadCN components from your project instead of the default ones, you can pass them using the `shadCNComponents` prop of `BlockNoteView`:
-
-```tsx
-import * as Button from "@/components/ui/button"
-import * as Select from "@/components/ui/select"
-
-return (
-  <BlockNoteView editor={editor} shadCNComponents={{
-    Select,
-    Button,
-    ...
-  }} />
-);
-```
-
-You can pass components from the following ShadCN modules:
-
-- Badge
-- Button
-- Card
-- DropdownMenu
-- Form
-- Input
-- Label
-- Popover
-- Select
-- Tabs
-- Toggle
-- Tooltip
-
-<Callout type="warning" emoji="⚠️">
-  To ensure compatibility, your ShadCN components should not use Portals
-  (comment these out from your DropdownMenu, Popover and Select components).
-</Callout>

--- a/examples/01-basic/09-shadcn/vite.config.ts
+++ b/examples/01-basic/09-shadcn/vite.config.ts
@@ -3,10 +3,11 @@ import react from "@vitejs/plugin-react";
 import * as fs from "fs";
 import * as path from "path";
 import { defineConfig } from "vite";
+import tailwindcss from "@tailwindcss/vite";
 // import eslintPlugin from "vite-plugin-eslint";
 // https://vitejs.dev/config/
 export default defineConfig((conf) => ({
-  plugins: [react()],
+  plugins: [react(), tailwindcss()],
   optimizeDeps: {},
   build: {
     sourcemap: true,

--- a/examples/01-basic/10-localization/package.json
+++ b/examples/01-basic/10-localization/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@blocknote/example-basic-localization",
   "description": "AUTO-GENERATED FILE, DO NOT EDIT DIRECTLY",
+  "type": "module",
   "private": true,
   "version": "0.12.4",
   "scripts": {

--- a/examples/01-basic/11-custom-placeholder/package.json
+++ b/examples/01-basic/11-custom-placeholder/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@blocknote/example-basic-custom-placeholder",
   "description": "AUTO-GENERATED FILE, DO NOT EDIT DIRECTLY",
+  "type": "module",
   "private": true,
   "version": "0.12.4",
   "scripts": {

--- a/examples/01-basic/12-multi-editor/package.json
+++ b/examples/01-basic/12-multi-editor/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@blocknote/example-basic-multi-editor",
   "description": "AUTO-GENERATED FILE, DO NOT EDIT DIRECTLY",
+  "type": "module",
   "private": true,
   "version": "0.12.4",
   "scripts": {

--- a/examples/01-basic/13-custom-paste-handler/package.json
+++ b/examples/01-basic/13-custom-paste-handler/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@blocknote/example-basic-custom-paste-handler",
   "description": "AUTO-GENERATED FILE, DO NOT EDIT DIRECTLY",
+  "type": "module",
   "private": true,
   "version": "0.12.4",
   "scripts": {

--- a/examples/01-basic/testing/package.json
+++ b/examples/01-basic/testing/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@blocknote/example-basic-testing",
   "description": "AUTO-GENERATED FILE, DO NOT EDIT DIRECTLY",
+  "type": "module",
   "private": true,
   "version": "0.12.4",
   "scripts": {

--- a/examples/02-backend/01-file-uploading/package.json
+++ b/examples/02-backend/01-file-uploading/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@blocknote/example-backend-file-uploading",
   "description": "AUTO-GENERATED FILE, DO NOT EDIT DIRECTLY",
+  "type": "module",
   "private": true,
   "version": "0.12.4",
   "scripts": {

--- a/examples/02-backend/02-saving-loading/package.json
+++ b/examples/02-backend/02-saving-loading/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@blocknote/example-backend-saving-loading",
   "description": "AUTO-GENERATED FILE, DO NOT EDIT DIRECTLY",
+  "type": "module",
   "private": true,
   "version": "0.12.4",
   "scripts": {

--- a/examples/02-backend/03-s3/package.json
+++ b/examples/02-backend/03-s3/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@blocknote/example-backend-s3",
   "description": "AUTO-GENERATED FILE, DO NOT EDIT DIRECTLY",
+  "type": "module",
   "private": true,
   "version": "0.12.4",
   "scripts": {

--- a/examples/02-backend/04-rendering-static-documents/package.json
+++ b/examples/02-backend/04-rendering-static-documents/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@blocknote/example-backend-rendering-static-documents",
   "description": "AUTO-GENERATED FILE, DO NOT EDIT DIRECTLY",
+  "type": "module",
   "private": true,
   "version": "0.12.4",
   "scripts": {

--- a/examples/03-ui-components/01-ui-elements-remove/package.json
+++ b/examples/03-ui-components/01-ui-elements-remove/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@blocknote/example-ui-components-ui-elements-remove",
   "description": "AUTO-GENERATED FILE, DO NOT EDIT DIRECTLY",
+  "type": "module",
   "private": true,
   "version": "0.12.4",
   "scripts": {

--- a/examples/03-ui-components/02-formatting-toolbar-buttons/package.json
+++ b/examples/03-ui-components/02-formatting-toolbar-buttons/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@blocknote/example-ui-components-formatting-toolbar-buttons",
   "description": "AUTO-GENERATED FILE, DO NOT EDIT DIRECTLY",
+  "type": "module",
   "private": true,
   "version": "0.12.4",
   "scripts": {

--- a/examples/03-ui-components/03-formatting-toolbar-block-type-items/package.json
+++ b/examples/03-ui-components/03-formatting-toolbar-block-type-items/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@blocknote/example-ui-components-formatting-toolbar-block-type-items",
   "description": "AUTO-GENERATED FILE, DO NOT EDIT DIRECTLY",
+  "type": "module",
   "private": true,
   "version": "0.12.4",
   "scripts": {

--- a/examples/03-ui-components/04-side-menu-buttons/package.json
+++ b/examples/03-ui-components/04-side-menu-buttons/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@blocknote/example-ui-components-side-menu-buttons",
   "description": "AUTO-GENERATED FILE, DO NOT EDIT DIRECTLY",
+  "type": "module",
   "private": true,
   "version": "0.12.4",
   "scripts": {

--- a/examples/03-ui-components/05-side-menu-drag-handle-items/package.json
+++ b/examples/03-ui-components/05-side-menu-drag-handle-items/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@blocknote/example-ui-components-side-menu-drag-handle-items",
   "description": "AUTO-GENERATED FILE, DO NOT EDIT DIRECTLY",
+  "type": "module",
   "private": true,
   "version": "0.12.4",
   "scripts": {

--- a/examples/03-ui-components/06-suggestion-menus-slash-menu-items/package.json
+++ b/examples/03-ui-components/06-suggestion-menus-slash-menu-items/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@blocknote/example-ui-components-suggestion-menus-slash-menu-items",
   "description": "AUTO-GENERATED FILE, DO NOT EDIT DIRECTLY",
+  "type": "module",
   "private": true,
   "version": "0.12.4",
   "scripts": {

--- a/examples/03-ui-components/07-suggestion-menus-slash-menu-component/package.json
+++ b/examples/03-ui-components/07-suggestion-menus-slash-menu-component/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@blocknote/example-ui-components-suggestion-menus-slash-menu-component",
   "description": "AUTO-GENERATED FILE, DO NOT EDIT DIRECTLY",
+  "type": "module",
   "private": true,
   "version": "0.12.4",
   "scripts": {

--- a/examples/03-ui-components/08-suggestion-menus-emoji-picker-columns/package.json
+++ b/examples/03-ui-components/08-suggestion-menus-emoji-picker-columns/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@blocknote/example-ui-components-suggestion-menus-emoji-picker-columns",
   "description": "AUTO-GENERATED FILE, DO NOT EDIT DIRECTLY",
+  "type": "module",
   "private": true,
   "version": "0.12.4",
   "scripts": {

--- a/examples/03-ui-components/09-suggestion-menus-emoji-picker-component/package.json
+++ b/examples/03-ui-components/09-suggestion-menus-emoji-picker-component/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@blocknote/example-ui-components-suggestion-menus-emoji-picker-component",
   "description": "AUTO-GENERATED FILE, DO NOT EDIT DIRECTLY",
+  "type": "module",
   "private": true,
   "version": "0.12.4",
   "scripts": {

--- a/examples/03-ui-components/10-suggestion-menus-grid-mentions/package.json
+++ b/examples/03-ui-components/10-suggestion-menus-grid-mentions/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@blocknote/example-ui-components-suggestion-menus-grid-mentions",
   "description": "AUTO-GENERATED FILE, DO NOT EDIT DIRECTLY",
+  "type": "module",
   "private": true,
   "version": "0.12.4",
   "scripts": {

--- a/examples/03-ui-components/11-uppy-file-panel/package.json
+++ b/examples/03-ui-components/11-uppy-file-panel/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@blocknote/example-ui-components-uppy-file-panel",
   "description": "AUTO-GENERATED FILE, DO NOT EDIT DIRECTLY",
+  "type": "module",
   "private": true,
   "version": "0.12.4",
   "scripts": {

--- a/examples/03-ui-components/12-static-formatting-toolbar/package.json
+++ b/examples/03-ui-components/12-static-formatting-toolbar/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@blocknote/example-ui-components-static-formatting-toolbar",
   "description": "AUTO-GENERATED FILE, DO NOT EDIT DIRECTLY",
+  "type": "module",
   "private": true,
   "version": "0.12.4",
   "scripts": {

--- a/examples/03-ui-components/13-custom-ui/package.json
+++ b/examples/03-ui-components/13-custom-ui/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@blocknote/example-ui-components-custom-ui",
   "description": "AUTO-GENERATED FILE, DO NOT EDIT DIRECTLY",
+  "type": "module",
   "private": true,
   "version": "0.12.4",
   "scripts": {

--- a/examples/03-ui-components/14-experimental-mobile-formatting-toolbar/package.json
+++ b/examples/03-ui-components/14-experimental-mobile-formatting-toolbar/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@blocknote/example-ui-components-experimental-mobile-formatting-toolbar",
   "description": "AUTO-GENERATED FILE, DO NOT EDIT DIRECTLY",
+  "type": "module",
   "private": true,
   "version": "0.12.4",
   "scripts": {

--- a/examples/03-ui-components/15-advanced-tables/package.json
+++ b/examples/03-ui-components/15-advanced-tables/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@blocknote/example-ui-components-advanced-tables",
   "description": "AUTO-GENERATED FILE, DO NOT EDIT DIRECTLY",
+  "type": "module",
   "private": true,
   "version": "0.12.4",
   "scripts": {

--- a/examples/03-ui-components/16-link-toolbar-buttons/package.json
+++ b/examples/03-ui-components/16-link-toolbar-buttons/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@blocknote/example-ui-components-link-toolbar-buttons",
   "description": "AUTO-GENERATED FILE, DO NOT EDIT DIRECTLY",
+  "type": "module",
   "private": true,
   "version": "0.12.4",
   "scripts": {

--- a/examples/03-ui-components/17-advanced-tables-2/package.json
+++ b/examples/03-ui-components/17-advanced-tables-2/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@blocknote/example-ui-components-advanced-tables-2",
   "description": "AUTO-GENERATED FILE, DO NOT EDIT DIRECTLY",
+  "type": "module",
   "private": true,
   "version": "0.12.4",
   "scripts": {

--- a/examples/04-theming/01-theming-dom-attributes/package.json
+++ b/examples/04-theming/01-theming-dom-attributes/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@blocknote/example-theming-theming-dom-attributes",
   "description": "AUTO-GENERATED FILE, DO NOT EDIT DIRECTLY",
+  "type": "module",
   "private": true,
   "version": "0.12.4",
   "scripts": {

--- a/examples/04-theming/02-changing-font/package.json
+++ b/examples/04-theming/02-changing-font/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@blocknote/example-theming-changing-font",
   "description": "AUTO-GENERATED FILE, DO NOT EDIT DIRECTLY",
+  "type": "module",
   "private": true,
   "version": "0.12.4",
   "scripts": {

--- a/examples/04-theming/03-theming-css/package.json
+++ b/examples/04-theming/03-theming-css/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@blocknote/example-theming-theming-css",
   "description": "AUTO-GENERATED FILE, DO NOT EDIT DIRECTLY",
+  "type": "module",
   "private": true,
   "version": "0.12.4",
   "scripts": {

--- a/examples/04-theming/04-theming-css-variables/package.json
+++ b/examples/04-theming/04-theming-css-variables/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@blocknote/example-theming-theming-css-variables",
   "description": "AUTO-GENERATED FILE, DO NOT EDIT DIRECTLY",
+  "type": "module",
   "private": true,
   "version": "0.12.4",
   "scripts": {

--- a/examples/04-theming/05-theming-css-variables-code/package.json
+++ b/examples/04-theming/05-theming-css-variables-code/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@blocknote/example-theming-theming-css-variables-code",
   "description": "AUTO-GENERATED FILE, DO NOT EDIT DIRECTLY",
+  "type": "module",
   "private": true,
   "version": "0.12.4",
   "scripts": {

--- a/examples/04-theming/06-code-block/package.json
+++ b/examples/04-theming/06-code-block/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@blocknote/example-theming-code-block",
   "description": "AUTO-GENERATED FILE, DO NOT EDIT DIRECTLY",
+  "type": "module",
   "private": true,
   "version": "0.12.4",
   "scripts": {

--- a/examples/04-theming/07-custom-code-block/package.json
+++ b/examples/04-theming/07-custom-code-block/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@blocknote/example-theming-custom-code-block",
   "description": "AUTO-GENERATED FILE, DO NOT EDIT DIRECTLY",
+  "type": "module",
   "private": true,
   "version": "0.12.4",
   "scripts": {

--- a/examples/05-interoperability/01-converting-blocks-to-html/package.json
+++ b/examples/05-interoperability/01-converting-blocks-to-html/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@blocknote/example-interoperability-converting-blocks-to-html",
   "description": "AUTO-GENERATED FILE, DO NOT EDIT DIRECTLY",
+  "type": "module",
   "private": true,
   "version": "0.12.4",
   "scripts": {

--- a/examples/05-interoperability/02-converting-blocks-from-html/package.json
+++ b/examples/05-interoperability/02-converting-blocks-from-html/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@blocknote/example-interoperability-converting-blocks-from-html",
   "description": "AUTO-GENERATED FILE, DO NOT EDIT DIRECTLY",
+  "type": "module",
   "private": true,
   "version": "0.12.4",
   "scripts": {

--- a/examples/05-interoperability/03-converting-blocks-to-md/package.json
+++ b/examples/05-interoperability/03-converting-blocks-to-md/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@blocknote/example-interoperability-converting-blocks-to-md",
   "description": "AUTO-GENERATED FILE, DO NOT EDIT DIRECTLY",
+  "type": "module",
   "private": true,
   "version": "0.12.4",
   "scripts": {

--- a/examples/05-interoperability/04-converting-blocks-from-md/package.json
+++ b/examples/05-interoperability/04-converting-blocks-from-md/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@blocknote/example-interoperability-converting-blocks-from-md",
   "description": "AUTO-GENERATED FILE, DO NOT EDIT DIRECTLY",
+  "type": "module",
   "private": true,
   "version": "0.12.4",
   "scripts": {

--- a/examples/05-interoperability/05-converting-blocks-to-pdf/package.json
+++ b/examples/05-interoperability/05-converting-blocks-to-pdf/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@blocknote/example-interoperability-converting-blocks-to-pdf",
   "description": "AUTO-GENERATED FILE, DO NOT EDIT DIRECTLY",
+  "type": "module",
   "private": true,
   "version": "0.12.4",
   "scripts": {

--- a/examples/05-interoperability/06-converting-blocks-to-docx/package.json
+++ b/examples/05-interoperability/06-converting-blocks-to-docx/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@blocknote/example-interoperability-converting-blocks-to-docx",
   "description": "AUTO-GENERATED FILE, DO NOT EDIT DIRECTLY",
+  "type": "module",
   "private": true,
   "version": "0.12.4",
   "scripts": {

--- a/examples/05-interoperability/07-converting-blocks-to-odt/package.json
+++ b/examples/05-interoperability/07-converting-blocks-to-odt/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@blocknote/example-interoperability-converting-blocks-to-odt",
   "description": "AUTO-GENERATED FILE, DO NOT EDIT DIRECTLY",
+  "type": "module",
   "private": true,
   "version": "0.12.4",
   "scripts": {

--- a/examples/05-interoperability/08-converting-blocks-to-react-email/package.json
+++ b/examples/05-interoperability/08-converting-blocks-to-react-email/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@blocknote/example-interoperability-converting-blocks-to-react-email",
   "description": "AUTO-GENERATED FILE, DO NOT EDIT DIRECTLY",
+  "type": "module",
   "private": true,
   "version": "0.12.4",
   "scripts": {

--- a/examples/06-custom-schema/01-alert-block/package.json
+++ b/examples/06-custom-schema/01-alert-block/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@blocknote/example-custom-schema-alert-block",
   "description": "AUTO-GENERATED FILE, DO NOT EDIT DIRECTLY",
+  "type": "module",
   "private": true,
   "version": "0.12.4",
   "scripts": {

--- a/examples/06-custom-schema/02-suggestion-menus-mentions/package.json
+++ b/examples/06-custom-schema/02-suggestion-menus-mentions/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@blocknote/example-custom-schema-suggestion-menus-mentions",
   "description": "AUTO-GENERATED FILE, DO NOT EDIT DIRECTLY",
+  "type": "module",
   "private": true,
   "version": "0.12.4",
   "scripts": {

--- a/examples/06-custom-schema/03-font-style/package.json
+++ b/examples/06-custom-schema/03-font-style/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@blocknote/example-custom-schema-font-style",
   "description": "AUTO-GENERATED FILE, DO NOT EDIT DIRECTLY",
+  "type": "module",
   "private": true,
   "version": "0.12.4",
   "scripts": {

--- a/examples/06-custom-schema/04-pdf-file-block/package.json
+++ b/examples/06-custom-schema/04-pdf-file-block/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@blocknote/example-custom-schema-pdf-file-block",
   "description": "AUTO-GENERATED FILE, DO NOT EDIT DIRECTLY",
+  "type": "module",
   "private": true,
   "version": "0.12.4",
   "scripts": {

--- a/examples/06-custom-schema/05-alert-block-full-ux/package.json
+++ b/examples/06-custom-schema/05-alert-block-full-ux/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@blocknote/example-custom-schema-alert-block-full-ux",
   "description": "AUTO-GENERATED FILE, DO NOT EDIT DIRECTLY",
+  "type": "module",
   "private": true,
   "version": "0.12.4",
   "scripts": {

--- a/examples/06-custom-schema/06-toggleable-blocks/package.json
+++ b/examples/06-custom-schema/06-toggleable-blocks/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@blocknote/example-custom-schema-toggleable-blocks",
   "description": "AUTO-GENERATED FILE, DO NOT EDIT DIRECTLY",
+  "type": "module",
   "private": true,
   "version": "0.12.4",
   "scripts": {

--- a/examples/06-custom-schema/draggable-inline-content/package.json
+++ b/examples/06-custom-schema/draggable-inline-content/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@blocknote/example-custom-schema-draggable-inline-content",
   "description": "AUTO-GENERATED FILE, DO NOT EDIT DIRECTLY",
+  "type": "module",
   "private": true,
   "version": "0.12.4",
   "scripts": {

--- a/examples/06-custom-schema/react-custom-blocks/package.json
+++ b/examples/06-custom-schema/react-custom-blocks/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@blocknote/example-custom-schema-react-custom-blocks",
   "description": "AUTO-GENERATED FILE, DO NOT EDIT DIRECTLY",
+  "type": "module",
   "private": true,
   "version": "0.12.4",
   "scripts": {

--- a/examples/06-custom-schema/react-custom-inline-content/package.json
+++ b/examples/06-custom-schema/react-custom-inline-content/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@blocknote/example-custom-schema-react-custom-inline-content",
   "description": "AUTO-GENERATED FILE, DO NOT EDIT DIRECTLY",
+  "type": "module",
   "private": true,
   "version": "0.12.4",
   "scripts": {

--- a/examples/06-custom-schema/react-custom-styles/package.json
+++ b/examples/06-custom-schema/react-custom-styles/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@blocknote/example-custom-schema-react-custom-styles",
   "description": "AUTO-GENERATED FILE, DO NOT EDIT DIRECTLY",
+  "type": "module",
   "private": true,
   "version": "0.12.4",
   "scripts": {

--- a/examples/07-collaboration/01-partykit/package.json
+++ b/examples/07-collaboration/01-partykit/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@blocknote/example-collaboration-partykit",
   "description": "AUTO-GENERATED FILE, DO NOT EDIT DIRECTLY",
+  "type": "module",
   "private": true,
   "version": "0.12.4",
   "scripts": {

--- a/examples/07-collaboration/02-liveblocks/package.json
+++ b/examples/07-collaboration/02-liveblocks/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@blocknote/example-collaboration-liveblocks",
   "description": "AUTO-GENERATED FILE, DO NOT EDIT DIRECTLY",
+  "type": "module",
   "private": true,
   "version": "0.12.4",
   "scripts": {

--- a/examples/07-collaboration/03-y-sweet/package.json
+++ b/examples/07-collaboration/03-y-sweet/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@blocknote/example-collaboration-y-sweet",
   "description": "AUTO-GENERATED FILE, DO NOT EDIT DIRECTLY",
+  "type": "module",
   "private": true,
   "version": "0.12.4",
   "scripts": {

--- a/examples/07-collaboration/04-electric-sql/package.json
+++ b/examples/07-collaboration/04-electric-sql/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@blocknote/example-collaboration-electric-sql",
   "description": "AUTO-GENERATED FILE, DO NOT EDIT DIRECTLY",
+  "type": "module",
   "private": true,
   "version": "0.12.4",
   "scripts": {

--- a/examples/07-collaboration/05-comments/package.json
+++ b/examples/07-collaboration/05-comments/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@blocknote/example-collaboration-comments",
   "description": "AUTO-GENERATED FILE, DO NOT EDIT DIRECTLY",
+  "type": "module",
   "private": true,
   "version": "0.12.4",
   "scripts": {

--- a/examples/07-collaboration/06-comments-with-sidebar/package.json
+++ b/examples/07-collaboration/06-comments-with-sidebar/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@blocknote/example-collaboration-comments-with-sidebar",
   "description": "AUTO-GENERATED FILE, DO NOT EDIT DIRECTLY",
+  "type": "module",
   "private": true,
   "version": "0.12.4",
   "scripts": {

--- a/examples/07-collaboration/07-ghost-writer/package.json
+++ b/examples/07-collaboration/07-ghost-writer/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@blocknote/example-collaboration-ghost-writer",
   "description": "AUTO-GENERATED FILE, DO NOT EDIT DIRECTLY",
+  "type": "module",
   "private": true,
   "version": "0.12.4",
   "scripts": {

--- a/examples/07-collaboration/08-forking/package.json
+++ b/examples/07-collaboration/08-forking/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@blocknote/example-collaboration-forking",
   "description": "AUTO-GENERATED FILE, DO NOT EDIT DIRECTLY",
+  "type": "module",
   "private": true,
   "version": "0.12.4",
   "scripts": {

--- a/examples/08-extensions/01-tiptap-arrow-conversion/package.json
+++ b/examples/08-extensions/01-tiptap-arrow-conversion/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@blocknote/example-extensions-tiptap-arrow-conversion",
   "description": "AUTO-GENERATED FILE, DO NOT EDIT DIRECTLY",
+  "type": "module",
   "private": true,
   "version": "0.12.4",
   "scripts": {

--- a/examples/09-ai/01-minimal/package.json
+++ b/examples/09-ai/01-minimal/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@blocknote/example-ai-minimal",
   "description": "AUTO-GENERATED FILE, DO NOT EDIT DIRECTLY",
+  "type": "module",
   "private": true,
   "version": "0.12.4",
   "scripts": {

--- a/examples/09-ai/02-playground/package.json
+++ b/examples/09-ai/02-playground/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@blocknote/example-ai-playground",
   "description": "AUTO-GENERATED FILE, DO NOT EDIT DIRECTLY",
+  "type": "module",
   "private": true,
   "version": "0.12.4",
   "scripts": {

--- a/examples/09-ai/03-custom-ai-menu-items/package.json
+++ b/examples/09-ai/03-custom-ai-menu-items/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@blocknote/example-ai-custom-ai-menu-items",
   "description": "AUTO-GENERATED FILE, DO NOT EDIT DIRECTLY",
+  "type": "module",
   "private": true,
   "version": "0.12.4",
   "scripts": {

--- a/examples/09-ai/04-with-collaboration/package.json
+++ b/examples/09-ai/04-with-collaboration/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@blocknote/example-ai-with-collaboration",
   "description": "AUTO-GENERATED FILE, DO NOT EDIT DIRECTLY",
+  "type": "module",
   "private": true,
   "version": "0.12.4",
   "scripts": {

--- a/examples/vanilla-js/react-vanilla-custom-blocks/package.json
+++ b/examples/vanilla-js/react-vanilla-custom-blocks/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@blocknote/example-vanilla-js-react-vanilla-custom-blocks",
   "description": "AUTO-GENERATED FILE, DO NOT EDIT DIRECTLY",
+  "type": "module",
   "private": true,
   "version": "0.12.4",
   "scripts": {

--- a/examples/vanilla-js/react-vanilla-custom-inline-content/package.json
+++ b/examples/vanilla-js/react-vanilla-custom-inline-content/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@blocknote/example-vanilla-js-react-vanilla-custom-inline-content",
   "description": "AUTO-GENERATED FILE, DO NOT EDIT DIRECTLY",
+  "type": "module",
   "private": true,
   "version": "0.12.4",
   "scripts": {

--- a/examples/vanilla-js/react-vanilla-custom-styles/package.json
+++ b/examples/vanilla-js/react-vanilla-custom-styles/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@blocknote/example-vanilla-js-react-vanilla-custom-styles",
   "description": "AUTO-GENERATED FILE, DO NOT EDIT DIRECTLY",
+  "type": "module",
   "private": true,
   "version": "0.12.4",
   "scripts": {

--- a/packages/dev-scripts/examples/gen.ts
+++ b/packages/dev-scripts/examples/gen.ts
@@ -28,6 +28,12 @@ const dir = path.parse(fileURLToPath(import.meta.url)).dir;
 
 async function writeTemplate(project: Project, templateFile: string) {
   const template = await import(pathToFileURL(templateFile).toString());
+  if (
+    project.config.tailwind !== true &&
+    templateFile.endsWith("tailwind.css.template.tsx")
+  ) {
+    return;
+  }
   const ret = await template.default(project);
 
   const targetFilePath = path.join(

--- a/packages/dev-scripts/examples/genDocs.ts
+++ b/packages/dev-scripts/examples/genDocs.ts
@@ -114,6 +114,7 @@ async function generateExampleGroupsData(projects: Project[]) {
       author: project.config.author,
       isPro: project.config.pro || false,
       inTailwindApp: project.config.tailwind || false,
+      showStackBlitzLink: project.config.stackBlitz ?? true,
       pathFromRoot: project.pathFromRoot,
       files: Object.fromEntries(
         getProjectFiles(project).map((file) => [
@@ -136,6 +137,7 @@ export type ExampleGroupsData = {
     author: string;
     isPro: boolean;
     inTailwindApp: boolean;
+    showStackBlitzLink: boolean;
     pathFromRoot: string;
     files: Record<string, string>;
   }[];

--- a/packages/dev-scripts/examples/genDocs.ts
+++ b/packages/dev-scripts/examples/genDocs.ts
@@ -113,6 +113,7 @@ async function generateExampleGroupsData(projects: Project[]) {
       title: project.title,
       author: project.config.author,
       isPro: project.config.pro || false,
+      inTailwindApp: project.config.tailwind || false,
       pathFromRoot: project.pathFromRoot,
       files: Object.fromEntries(
         getProjectFiles(project).map((file) => [
@@ -134,6 +135,7 @@ export type ExampleGroupsData = {
     title: string;
     author: string;
     isPro: boolean;
+    inTailwindApp: boolean;
     pathFromRoot: string;
     files: Record<string, string>;
   }[];

--- a/packages/dev-scripts/examples/template-react/main.tsx.template.tsx
+++ b/packages/dev-scripts/examples/template-react/main.tsx.template.tsx
@@ -6,7 +6,12 @@ const template = (
 import React from "react";
 import { createRoot } from "react-dom/client";
 import App from "./src/App.jsx";
-
+${
+  project.config.tailwind
+    ? `import "./tailwind.css";
+`
+    : ""
+}
 const root = createRoot(document.getElementById("root")!);
 root.render(
   <React.StrictMode>

--- a/packages/dev-scripts/examples/template-react/package.json.template.tsx
+++ b/packages/dev-scripts/examples/template-react/package.json.template.tsx
@@ -19,9 +19,20 @@ const template = (project: Project) => ({
     "@blocknote/shadcn": "latest",
     react: "^19.1.0",
     "react-dom": "^19.1.0",
+    ...(project.config.tailwind
+      ? {
+          tailwindcss: "^4.1.12",
+          "tw-animate-css": "^1.3.7",
+        }
+      : {}),
     ...(project.config?.dependencies || {}),
   },
   devDependencies: {
+    ...(project.config.tailwind
+      ? {
+          "@tailwindcss/vite": "^4.1.12",
+        }
+      : {}),
     "@types/react": "^19.1.0",
     "@types/react-dom": "^19.1.0",
     "@vitejs/plugin-react": "^4.3.1",

--- a/packages/dev-scripts/examples/template-react/package.json.template.tsx
+++ b/packages/dev-scripts/examples/template-react/package.json.template.tsx
@@ -3,6 +3,7 @@ import type { Project } from "../util";
 const template = (project: Project) => ({
   name: "@blocknote/example-" + project.fullSlug.replace("/", "-"),
   description: "AUTO-GENERATED FILE, DO NOT EDIT DIRECTLY",
+  type: "module",
   private: true,
   version: "0.12.4",
   scripts: {

--- a/packages/dev-scripts/examples/template-react/tailwind.css.template.tsx
+++ b/packages/dev-scripts/examples/template-react/tailwind.css.template.tsx
@@ -1,51 +1,13 @@
----
-title: With ShadCN
-description: ShadCN rich text editor using BlockNote
-imageTitle: ShadCN rich text editor using BlockNote
----
+import type { Project } from "../util";
 
-# Getting Started With ShadCN
+const template = (project: Project) => `@import "tailwindcss";
+@import "tw-animate-css";
 
-[shadcn/ui](https://ui.shadcn.com/) is an open-source collection of React components based on [Radix](https://radix-ui.com/) and [TailwindCSS](https://tailwindcss.com/).
+/* Code below needed for ShadCN examples, check docs for more info. */
+@source "./node_modules/@blocknote/shadcn";
 
-```console tab="npm"
-npm install @blocknote/core @blocknote/react @blocknote/shadcn
-```
-
-```console tab="pnpm"
-pnpm add @blocknote/core @blocknote/react @blocknote/shadcn
-```
-
-```console tab="bun"
-bun add @blocknote/core @blocknote/react @blocknote/shadcn
-```
-
-To use BlockNote with ShadCN, you can import `BlockNoteView` from `@blocknote/shadcn` and the stylesheet from `@blocknote/shadcn/style.css`. This version of `BlockNoteView` is expected to be used in apps that are already using ShadCN/TailwindCSS, so it does not import any of those styles itself.
-
-To ensure Tailwind generates the necessary CSS for all utility classes used by BlockNote components, make sure to add the `@source` directive to your stylesheet that imports Tailwind:
-
-```css
-@import "tailwindcss";
-...
-/* Path to your installed `@blocknote/shadcn` package. */
-@source "../node_modules/@blocknote/shadcn";
-```
-
-<Example name="basic/shadcn" />
-
-## Usage with Tailwind Only
-
-If your app doesn't use ShadCN components and only uses TailwindCSS, you just need to extend your Tailwind theme with ShadCN utility classes to get everything working. You can do this by simply copying the styles below into your stylesheet that imports Tailwind.
-
-```css
-@import "tailwindcss";
-...
-/* Path to your installed `@blocknote/shadcn` package. */
-@source "../node_modules/@blocknote/shadcn";
-...
 @custom-variant dark (&:is(.dark *));
 
-/* Light theme ShadCN CSS variables. */
 :root {
   --radius: 0.625rem;
   --background: oklch(1 0 0);
@@ -81,7 +43,6 @@ If your app doesn't use ShadCN components and only uses TailwindCSS, you just ne
   --sidebar-ring: oklch(0.708 0 0);
 }
 
-/* Dark theme ShadCN CSS variables. */
 .dark {
   --background: oklch(0.145 0 0);
   --foreground: oklch(0.985 0 0);
@@ -116,7 +77,6 @@ If your app doesn't use ShadCN components and only uses TailwindCSS, you just ne
   --sidebar-ring: oklch(0.556 0 0);
 }
 
-/* Extending Tailwind theme with ShadCN utility classes. */
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
@@ -156,52 +116,11 @@ If your app doesn't use ShadCN components and only uses TailwindCSS, you just ne
   --color-sidebar-ring: var(--sidebar-ring);
 }
 
-/* Applies some additional necessary border styles within the editor. */
 @layer base {
   .bn-shadcn * {
     @apply border-border outline-ring/50;
   }
 }
-```
+`;
 
-The values used are for the Neutral ShadCN color theme (used in demo above), but you can customize them however you'd like.
-
-This website uses the exact same setup as the one described above, which you can see in [this file](https://github.com/TypeCellOS/BlockNote/blob/main/docs/app/global.css).
-
-## ShadCN Customization
-
-BlockNote comes with default shadcn components. However, it's likely that you have copied and possibly customized your own shadcn components in your project.
-To make BlockNote use the ShadCN components from your project instead of the default ones, you can pass them using the `shadCNComponents` prop of `BlockNoteView`:
-
-```tsx
-import * as Button from "@/components/ui/button"
-import * as Select from "@/components/ui/select"
-
-return (
-  <BlockNoteView editor={editor} shadCNComponents={{
-    Select,
-    Button,
-    ...
-  }} />
-);
-```
-
-You can pass components from the following ShadCN modules:
-
-- Badge
-- Button
-- Card
-- DropdownMenu
-- Form
-- Input
-- Label
-- Popover
-- Select
-- Tabs
-- Toggle
-- Tooltip
-
-<Callout type="warning" emoji="⚠️">
-  To ensure compatibility, your ShadCN components should not use Portals
-  (comment these out from your DropdownMenu, Popover and Select components).
-</Callout>
+export default template;

--- a/packages/dev-scripts/examples/template-react/vite.config.ts.template.tsx
+++ b/packages/dev-scripts/examples/template-react/vite.config.ts.template.tsx
@@ -7,11 +7,16 @@ const template = (
 import react from "@vitejs/plugin-react";
 import * as fs from "fs";
 import * as path from "path";
-import { defineConfig } from "vite";
+import { defineConfig } from "vite";${
+  project.config.tailwind
+    ? `
+import tailwindcss from "@tailwindcss/vite";`
+    : ""
+}
 // import eslintPlugin from "vite-plugin-eslint";
 // https://vitejs.dev/config/
 export default defineConfig((conf) => ({
-  plugins: [react()],
+  plugins: [react()${project.config.tailwind ? ", tailwindcss()" : ""}],
   optimizeDeps: {},
   build: {
     sourcemap: true,

--- a/packages/dev-scripts/examples/util.ts
+++ b/packages/dev-scripts/examples/util.ts
@@ -43,6 +43,7 @@ export type Project = {
     shortTitle?: string;
     author: string;
     pro?: boolean;
+    tailwind?: boolean;
   };
   readme: string;
 };

--- a/packages/dev-scripts/examples/util.ts
+++ b/packages/dev-scripts/examples/util.ts
@@ -44,6 +44,7 @@ export type Project = {
     author: string;
     pro?: boolean;
     tailwind?: boolean;
+    stackBlitz?: boolean;
   };
   readme: string;
 };

--- a/playground/src/examples.gen.tsx
+++ b/playground/src/examples.gen.tsx
@@ -180,7 +180,8 @@
           "tags": [
             "Basic"
           ],
-          "tailwind": true
+          "tailwind": true,
+          "stackBlitz": false
         },
         "title": "Use with ShadCN",
         "group": {

--- a/playground/src/examples.gen.tsx
+++ b/playground/src/examples.gen.tsx
@@ -179,14 +179,15 @@
           "author": "matthewlipski",
           "tags": [
             "Basic"
-          ]
+          ],
+          "tailwind": true
         },
         "title": "Use with ShadCN",
         "group": {
           "pathFromRoot": "examples/01-basic",
           "slug": "basic"
         },
-        "readme": "This example shows how you can use BlockNote with ShadCN (instead of Mantine).\n\n<Callout type={\"warning\"}>\nBecause the ShadCN version of BlockNote requires being in a Tailwind app,\nviewing the demo below on StackBlitz will have missing styles.\n</Callout>\n\n**Relevant Docs:**\n\n- [Getting Started with ShadCN](/docs/getting-started/shadcn)"
+        "readme": "This example shows how you can use BlockNote with ShadCN (instead of Mantine).\n\n**Relevant Docs:**\n\n- [Getting Started with ShadCN](/docs/getting-started/shadcn)"
       },
       {
         "projectSlug": "localization",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -726,7 +726,16 @@ importers:
       react-dom:
         specifier: ^19.1.0
         version: 19.1.0(react@19.1.0)
+      tailwindcss:
+        specifier: ^4.1.12
+        version: 4.1.12
+      tw-animate-css:
+        specifier: ^1.3.7
+        version: 1.3.7
     devDependencies:
+      '@tailwindcss/vite':
+        specifier: ^4.1.12
+        version: 4.1.12(vite@5.4.15(@types/node@22.15.2)(lightningcss@1.30.1)(terser@5.44.0))
       '@types/react':
         specifier: ^19.1.0
         version: 19.1.8
@@ -20250,6 +20259,13 @@ snapshots:
       '@tailwindcss/oxide': 4.1.12
       postcss: 8.5.6
       tailwindcss: 4.1.12
+
+  '@tailwindcss/vite@4.1.12(vite@5.4.15(@types/node@22.15.2)(lightningcss@1.30.1)(terser@5.44.0))':
+    dependencies:
+      '@tailwindcss/node': 4.1.12
+      '@tailwindcss/oxide': 4.1.12
+      tailwindcss: 4.1.12
+      vite: 5.4.15(@types/node@22.15.2)(lightningcss@1.30.1)(terser@5.44.0)
 
   '@tailwindcss/vite@4.1.12(vite@6.3.5(@types/node@22.15.2)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.44.0)(tsx@4.19.3)(yaml@2.7.0))':
     dependencies:


### PR DESCRIPTION
This PR does 2 things:

- Adds `tailwind` field to `.bnexample.json` to add TailwindCSS to the example setup, when running it outside of the playground.
- Adds `stackBlitz` field to `.bnexample.json` to hide the StackBlitz link in the docs for the example.

The `tailwind` field allows the ShadCN example to have the correct styles when being run on its own. This should also fix the styles in StackBlitz, but there seems to be weird stuff going on with the setup there, as the `@source` Tailwind directive doesn't seem to work. As a workaround, the `stackBlitz` field is used to just hide the link.