### PR TITLE
convert to figure/figcaption if caption exists

### DIFF
--- a/packages/core/src/blocks/FileBlockContent/helpers/render/createFileBlockWrapper.ts
+++ b/packages/core/src/blocks/FileBlockContent/helpers/render/createFileBlockWrapper.ts
@@ -52,6 +52,31 @@ export const createFileBlockWrapper = (
     };
   }
 
+  // Special accessible structure for images with captions: use figure/figcaption
+  const shouldUseFigure =
+    element &&
+    block.type === "image" &&
+    block.props.caption &&
+    block.props.showPreview !== false;
+  if (shouldUseFigure) {
+    const figure = document.createElement("figure");
+    figure.className = wrapper.className;
+
+    // Move preview element inside the figure
+    figure.appendChild(element.dom);
+
+    // Create figcaption instead of a paragraph
+    const figcaption = document.createElement("figcaption");
+    figcaption.className = "bn-file-caption";
+    figcaption.textContent = block.props.caption;
+    figure.appendChild(figcaption);
+
+    // ARIA enhancements for screen readers
+    figure.setAttribute("role", "img");
+    figure.setAttribute("aria-label", `Image: ${block.props.caption}`);
+
+    return { dom: figure, destroy: element.destroy };
+  }
   const ret: { dom: HTMLElement; destroy?: () => void } = { dom: wrapper };
 
   // Show the file preview, or the file name and icon.

--- a/packages/core/src/blocks/ImageBlockContent/ImageBlockContent.ts
+++ b/packages/core/src/blocks/ImageBlockContent/ImageBlockContent.ts
@@ -70,22 +70,15 @@ export const imageRender = (
     image.src = block.props.url;
   }
 
-  // Accessibility: set alt/aria based on presence of caption per RGAA
-  const accessibleImageWithCaption = () => {
-    image.alt = block.props.caption;
+  const altText = block.props.name || block.props.caption || "";
+  image.alt = altText;
+  if (altText) {
     image.removeAttribute("aria-hidden");
     image.removeAttribute("role");
-    image.setAttribute("tabindex", "0");
-  };
-
-  const accessibleImage = () => {
-    image.alt = "";
+  } else {
     image.setAttribute("role", "presentation");
     image.setAttribute("aria-hidden", "true");
-    image.setAttribute("tabindex", "-1");
-  };
-
-  block.props.caption ? accessibleImageWithCaption() : accessibleImage();
+  }
 
   image.contentEditable = "false";
   image.draggable = false;
@@ -146,11 +139,10 @@ export const imageToExternalHTML = (
   if (block.props.showPreview) {
     image = document.createElement("img");
     image.src = block.props.url;
-    // Accessibility for exported HTML: prefer caption as alt when present
-    if (block.props.caption) {
-      image.alt = block.props.caption;
-    } else {
-      image.alt = "";
+
+    const altText = block.props.name || block.props.caption || "";
+    image.alt = altText;
+    if (!altText) {
       image.setAttribute("role", "presentation");
       image.setAttribute("aria-hidden", "true");
     }
@@ -166,9 +158,6 @@ export const imageToExternalHTML = (
   if (block.props.caption) {
     if (block.props.showPreview) {
       const { dom } = createFigureWithCaption(image, block.props.caption);
-      // Enhance figure with explicit role and aria-label
-      dom.setAttribute("role", "img");
-      dom.setAttribute("aria-label", `Image: ${block.props.caption}`);
       return { dom };
     } else {
       return createLinkWithCaption(image, block.props.caption);


### PR DESCRIPTION
**Purpose**
Improve accessibility and semantic HTML by applying the appropriate structure when captions are present, to comply with WCAG requirement.

issue : [2055](https://github.com/TypeCellOS/BlockNote/issues/2055)

![figcap](https://github.com/user-attachments/assets/90bd224a-41f7-4ae0-9217-de4142122ea7)


**Proposal**

-  Detect if a caption exists in the component/template
-  Place the caption inside a `figcaption `tag
-  Wrap media elements in a `figure `tag
-  Place the caption inside a `figcaption `tag