### PR TITLE
fix: allow listening to `onChange` and other events before the underlying editor is initialized

### DIFF
--- a/docs/content/docs/reference/editor/events.mdx
+++ b/docs/content/docs/reference/editor/events.mdx
@@ -12,7 +12,7 @@ BlockNote provides several event callbacks that allow you to respond to changes 
 
 The editor emits events for:
 
-- **Editor lifecycle** - When the editor is mounted, unmounted, etc.
+- **Editor lifecycle** - When the editor is created, mounted, unmounted, etc.
 - **Content changes** - When blocks are inserted, updated, or deleted
 - **Selection changes** - When the cursor position or selection changes
 

--- a/docs/content/docs/reference/editor/events.mdx
+++ b/docs/content/docs/reference/editor/events.mdx
@@ -12,7 +12,7 @@ BlockNote provides several event callbacks that allow you to respond to changes 
 
 The editor emits events for:
 
-- **Editor initialization** - When the editor is ready for use
+- **Editor lifecycle** - When the editor is mounted, unmounted, etc.
 - **Content changes** - When blocks are inserted, updated, or deleted
 - **Selection changes** - When the cursor position or selection changes
 
@@ -24,6 +24,26 @@ The `onCreate` callback is called when the editor has been initialized and is re
 editor.onCreate(() => {
   console.log("Editor is ready for use");
   // Initialize plugins, set up event listeners, etc.
+});
+```
+
+## `onMount`
+
+The `onMount` callback is called when the editor has been mounted.
+
+```typescript
+editor.onMount(() => {
+  console.log("Editor is mounted");
+});
+```
+
+## `onUnmount`
+
+The `onUnmount` callback is called when the editor has been unmounted.
+
+```typescript
+editor.onUnmount(() => {
+  console.log("Editor is unmounted");
 });
 ```
 

--- a/packages/core/src/editor/BlockNoteEditor.test.ts
+++ b/packages/core/src/editor/BlockNoteEditor.test.ts
@@ -4,6 +4,7 @@ import {
   getNearestBlockPos,
 } from "../api/getBlockInfoFromPos.js";
 import { BlockNoteEditor } from "./BlockNoteEditor.js";
+import { BlockNoteExtension } from "./BlockNoteExtension.js";
 
 /**
  * @vitest-environment jsdom
@@ -101,4 +102,43 @@ it("block prop types", () => {
     // eslint-disable-next-line
     expect(level).toBe(1);
   }
+});
+
+it("onMount and onUnmount", () => {
+  const editor = BlockNoteEditor.create();
+  let mounted = false;
+  let unmounted = false;
+  editor.onMount(() => {
+    mounted = true;
+  });
+  editor.onUnmount(() => {
+    unmounted = true;
+  });
+  editor.mount(document.createElement("div"));
+  expect(mounted).toBe(true);
+  expect(unmounted).toBe(false);
+  editor.unmount();
+  expect(mounted).toBe(true);
+  expect(unmounted).toBe(true);
+});
+
+it("onCreate event", () => {
+  let created = false;
+  BlockNoteEditor.create({
+    extensions: [
+      (e) =>
+        new (class extends BlockNoteExtension {
+          public static key() {
+            return "test";
+          }
+          constructor(editor: BlockNoteEditor) {
+            super(editor);
+            editor.onCreate(() => {
+              created = true;
+            });
+          }
+        })(e),
+    ],
+  });
+  expect(created).toBe(true);
 });

--- a/packages/core/src/editor/BlockNoteEditor.ts
+++ b/packages/core/src/editor/BlockNoteEditor.ts
@@ -1577,9 +1577,11 @@ export class BlockNoteEditor<
    * A callback function that runs when the editor has been initialized.
    *
    * This can be useful for plugins to initialize themselves after the editor has been initialized.
+   *
+   * @param callback The callback to execute.
+   * @returns A function to remove the callback.
    */
   public onCreate(callback: () => void) {
-    // TODO I think this create handler is wrong actually...
     this.on("create", callback);
 
     return () => {
@@ -1587,6 +1589,42 @@ export class BlockNoteEditor<
     };
   }
 
+  /**
+   * A callback function that runs when the editor has been mounted.
+   *
+   * This can be useful for plugins to initialize themselves after the editor has been mounted.
+   *
+   * @param callback The callback to execute.
+   * @returns A function to remove the callback.
+   */
+  public onMount(
+    callback: (ctx: {
+      editor: BlockNoteEditor<BSchema, ISchema, SSchema>;
+    }) => void,
+  ) {
+    this._eventManager.onMount(callback);
+  }
+
+  /**
+   * A callback function that runs when the editor has been unmounted.
+   *
+   * This can be useful for plugins to clean up themselves after the editor has been unmounted.
+   *
+   * @param callback The callback to execute.
+   * @returns A function to remove the callback.
+   */
+  public onUnmount(
+    callback: (ctx: {
+      editor: BlockNoteEditor<BSchema, ISchema, SSchema>;
+    }) => void,
+  ) {
+    this._eventManager.onUnmount(callback);
+  }
+
+  /**
+   * Gets the bounding box of the current selection.
+   * @returns The bounding box of the current selection.
+   */
   public getSelectionBoundingBox() {
     return this._selectionManager.getSelectionBoundingBox();
   }


### PR DESCRIPTION
# Summary
This change allows for using `editor.onChange` before the `editor.tiptapEditor` is actually assigned. This allows us to not have to wrap every event we register in extensions (the only time you'd have access to the editor instance without the tiptapEditor being initialized), be forced to be wrapped in `editor.onCreate`.
<!-- Briefly describe the feature being introduced. -->

## Rationale

This simplifies extension code to be the same as what you'd use with a fully constructed editor instance.
<!-- Explain the reasoning behind this feature and its benefits to the project. -->

## Changes

De-coupled the event handling to be done on the EventManager instance by making it into an EventEmitter
<!-- List the major changes made in this pull request. -->

## Impact
Should be no change
<!-- Discuss any potential impacts this feature may have on existing functionalities. -->

## Testing
Added tests to prove that this works, also added tests for the new onMount & onUnMount events that I exposed as part of this
<!-- Describe how the feature has been tested, including both automated and manual testing strategies. -->

## Screenshots/Video

<!-- Include screenshots or video demonstrating the new feature, if applicable. -->

## Checklist

- [ ] Code follows the project's coding standards.
- [ ] Unit tests covering the new feature have been added.
- [ ] All existing tests pass.
- [ ] The documentation has been updated to reflect the new feature

## Additional Notes

<!-- Any additional information or context relevant to this PR. -->
