### PR TITLE
test: unit tests for block type guards

### DIFF
--- a/packages/core/src/blocks/defaultBlockTypeGuards.ts
+++ b/packages/core/src/blocks/defaultBlockTypeGuards.ts
@@ -50,7 +50,7 @@ export function editorHasBlockWithType<
     if (typeof propSpec === "string") {
       if (
         editor.schema.blockSpecs[blockType].config.propSchema[propName]
-          .default &&
+          .default !== undefined &&
         typeof editor.schema.blockSpecs[blockType].config.propSchema[propName]
           .default !== propSpec
       ) {
@@ -58,7 +58,8 @@ export function editorHasBlockWithType<
       }
 
       if (
-        editor.schema.blockSpecs[blockType].config.propSchema[propName].type &&
+        editor.schema.blockSpecs[blockType].config.propSchema[propName].type !==
+          undefined &&
         editor.schema.blockSpecs[blockType].config.propSchema[propName].type !==
           propSpec
       ) {

--- a/tests/src/unit/core/typeGuards/runTests.test.ts
+++ b/tests/src/unit/core/typeGuards/runTests.test.ts
@@ -83,4 +83,53 @@ describe("Editor block schema type guard tests", () => {
       }),
     ).toBeFalsy();
   });
+
+  it("customBlockType", () => {
+    expect(editorHasBlockWithType(getEditor(), "simpleImage")).toBeTruthy();
+  });
+
+  it("customBlockWithPropTypes", () => {
+    expect(
+      editorHasBlockWithType(getEditor(), "simpleImage", {
+        name: "string",
+        url: "string",
+      }),
+    ).toBeTruthy();
+  });
+
+  it("customBlockWithPropTypesInvalidType", () => {
+    expect(
+      editorHasBlockWithType(getEditor(), "simpleImage", {
+        name: "string",
+        url: "number",
+      }),
+    ).toBeFalsy();
+  });
+
+  it("customBlockWithPropSchema", () => {
+    expect(
+      editorHasBlockWithType(getEditor(), "simpleImage", {
+        name: { default: "" },
+        url: { default: "" },
+      }),
+    ).toBeTruthy();
+  });
+
+  it("customBlockWithPropSchemaInvalidType", () => {
+    expect(
+      editorHasBlockWithType(getEditor(), "simpleImage", {
+        name: { default: false },
+        url: { default: "" },
+      }),
+    ).toBeFalsy();
+  });
+
+  it("customBlockWithPropSchemaInvalidValues", () => {
+    expect(
+      editorHasBlockWithType(getEditor(), "simpleImage", {
+        name: { default: "", values: ["image", "photo"] },
+        url: { default: "" },
+      }),
+    ).toBeFalsy();
+  });
 });


### PR DESCRIPTION
# Summary

<!-- Briefly describe the feature being introduced. -->

This PR adds unit tests for `editorHasBlockWithType`.

The code for `editorHasBlockWithType` has also been changed slightly - when checking for a block with a given `propSchema` and `values`, the `values` can be an unordered subset of the ones in the schema. Previously, the 2 arrays had to be identical in order for the type guard to return `true`.

## Rationale

<!-- Explain the reasoning behind this feature and its benefits to the project. -->

Needed for #2096 and useful in general.

## Changes

<!-- List the major changes made in this pull request. -->

See above.

## Impact

<!-- Discuss any potential impacts this feature may have on existing functionalities. -->

N/A

## Testing

<!-- Describe how the feature has been tested, including both automated and manual testing strategies. -->

See above.

## Screenshots/Video

<!-- Include screenshots or video demonstrating the new feature, if applicable. -->

N/A

## Checklist

- [X] Code follows the project's coding standards.
- [X] Unit tests covering the new feature have been added.
- [X] All existing tests pass.
- [X] The documentation has been updated to reflect the new feature

## Additional Notes

<!-- Any additional information or context relevant to this PR. -->
