### PR TITLE
fix: correctly index blocks that have children fixes #2115

### DIFF
--- a/packages/core/src/blocks/ListItem/NumberedListItem/IndexingPlugin.ts
+++ b/packages/core/src/blocks/ListItem/NumberedListItem/IndexingPlugin.ts
@@ -112,10 +112,11 @@ function getDecorations(
       );
 
       if (existingDecorations.length === 0) {
+        const blockNode = tr.doc.nodeAt(pos + 1);
         // Create a widget decoration to display the index
         decorationsToAdd.push(
           // move in by 1 to account for the block container
-          Decoration.node(pos + 1, pos + node.nodeSize - 1, {
+          Decoration.node(pos + 1, pos + 1 + blockNode!.nodeSize, {
             "data-index": index.toString(),
           }),
         );


### PR DESCRIPTION
# Summary

There was a bug where the `Decoration.node` was using the incorrect end position in cases where the block actually contains children.
<!-- Briefly describe the feature being introduced. -->

## Rationale

<!-- Explain the reasoning behind this feature and its benefits to the project. -->

## Changes

This moves the end position to be at the end of the node which the position is pointing to
<!-- List the major changes made in this pull request. -->

## Impact

<!-- Discuss any potential impacts this feature may have on existing functionalities. -->

## Testing
Manually tested, since these are decorations, it would be difficult to set up a test for them
<!-- Describe how the feature has been tested, including both automated and manual testing strategies. -->

## Screenshots/Video

<!-- Include screenshots or video demonstrating the new feature, if applicable. -->

## Checklist

- [x] Code follows the project's coding standards.
- [ ] Unit tests covering the new feature have been added.
- [x] All existing tests pass.
- [ ] The documentation has been updated to reflect the new feature

## Additional Notes

<!-- Any additional information or context relevant to this PR. -->
