### PR TITLE
feat: add configurable event handling for SideMenu

### DIFF
--- a/packages/react/src/components/SideMenu/SideMenuController.tsx
+++ b/packages/react/src/components/SideMenu/SideMenuController.tsx
@@ -6,7 +6,7 @@ import {
   InlineContentSchema,
   StyleSchema,
 } from "@blocknote/core";
-import { FC } from "react";
+import { FC, useEffect } from "react";
 
 import { UseFloatingOptions } from "@floating-ui/react";
 import { useBlockNoteEditor } from "../../hooks/useBlockNoteEditor.js";
@@ -22,6 +22,7 @@ export const SideMenuController = <
 >(props: {
   sideMenu?: FC<SideMenuProps<BSchema, I, S>>;
   floatingOptions?: Partial<UseFloatingOptions>;
+  useHandleDOMEvents?: boolean;
 }) => {
   const editor = useBlockNoteEditor<BSchema, I, S>();
 
@@ -31,6 +32,12 @@ export const SideMenuController = <
     freezeMenu: editor.sideMenu.freezeMenu,
     unfreezeMenu: editor.sideMenu.unfreezeMenu,
   };
+
+  useEffect(() => {
+    if (props.useHandleDOMEvents) {
+      editor.sideMenu.setUseHandleDOMEvents(props.useHandleDOMEvents);
+    }
+  }, [editor.sideMenu, props.useHandleDOMEvents]);
 
   const state = useUIPluginState(
     editor.sideMenu.onUpdate.bind(editor.sideMenu),


### PR DESCRIPTION
This PR demonstrates how to scope the mouse tracking inside the editor by providing an opt-in mechanism to use ProseMirror's `handleDOMEvents` instead of root-level event listeners.

# Summary

Adds a configurable `useHandleDOMEvents` option to the SideMenu plugin, allowing users to choose between two event handling strategies for mouse tracking.

## Rationale

Issue here https://github.com/TypeCellOS/BlockNote/issues/1016

## Changes

<!-- List the major changes made in this pull request. -->

## Impact

<!-- Discuss any potential impacts this feature may have on existing functionalities. -->

## Testing

<!-- Describe how the feature has been tested, including both automated and manual testing strategies. -->

## Screenshots/Video

<!-- Include screenshots or video demonstrating the new feature, if applicable. -->

## Checklist

- [ ] Code follows the project's coding standards.
- [ ] Unit tests covering the new feature have been added.
- [ ] All existing tests pass.
- [ ] The documentation has been updated to reflect the new feature

## Additional Notes

<!-- Any additional information or context relevant to this PR. -->
