### PR TITLE
fix: `setSelection` not using `MultipleNodeSelection`

### DIFF
--- a/packages/core/src/extensions-shared/MultipleNodeSelection.ts
+++ b/packages/core/src/extensions-shared/MultipleNodeSelection.ts
@@ -7,7 +7,7 @@ import { Mappable } from "prosemirror-transform";
  * to drag multiple blocks at the same time. Expects the selection anchor and head to be between nodes, i.e. just before
  * the first target node and just after the last, and that anchor and head are at the same nesting level.
  *
- * Partially based on ProseMirror's NodeSelection implementation:
+ * Based on ProseMirror's NodeSelection implementation:
  * (https://github.com/ProseMirror/prosemirror-state/blob/master/src/selection.ts)
  * MultipleNodeSelection differs from NodeSelection in the following ways:
  * 1. Stores which nodes are included in the selection instead of just a single node.
@@ -83,6 +83,17 @@ export class MultipleNodeSelection extends Selection {
 
   toJSON(): any {
     return { type: "multiple-node", anchor: this.anchor, head: this.head };
+  }
+
+  static fromJSON(doc: Node, json: any) {
+    if (typeof json.anchor != "number" || json.head !== "number") {
+      throw new RangeError("Invalid input for NodeSelection.fromJSON");
+    }
+
+    return new MultipleNodeSelection(
+      doc.resolve(json.anchor),
+      doc.resolve(json.head),
+    );
   }
 }
 

--- a/packages/core/src/extensions/KeyboardShortcuts/KeyboardShortcutsExtension.ts
+++ b/packages/core/src/extensions/KeyboardShortcuts/KeyboardShortcutsExtension.ts
@@ -621,6 +621,17 @@ export const KeyboardShortcutsExtension = Extension.create<{
       "Mod-z": () => this.options.editor.undo(),
       "Mod-y": () => this.options.editor.redo(),
       "Shift-Mod-z": () => this.options.editor.redo(),
+      // By default, ProseMirror tries to find a `TextSelection` that spans the 
+      // whole editor. This can cause issues if the first/last block is a table
+      // or node without content. So we use `editor.setSelection` instead
+      "Mod-a": () => {
+        this.options.editor.setSelection(
+          this.options.editor.document[0],
+          this.options.editor.document[this.options.editor.document.length - 1],
+        );
+
+        return true;
+      },
     };
   },
 });

--- a/packages/core/src/extensions/SideMenu/dragging.ts
+++ b/packages/core/src/extensions/SideMenu/dragging.ts
@@ -14,7 +14,7 @@ import {
   InlineContentSchema,
   StyleSchema,
 } from "../../schema/index.js";
-import { MultipleNodeSelection } from "./MultipleNodeSelection.js";
+import { MultipleNodeSelection } from "../../extensions-shared/MultipleNodeSelection.js";
 
 let dragImageElement: Element | undefined;
 


### PR DESCRIPTION
# Summary

<!-- Briefly describe the feature being introduced. -->

This PR rewrites `setSelection` to use `MultipleNodeSelection` when spanning multiple blocks. When the start and end blocks are the same, the entire block content is selected, i.e.:

- When a block has inline content, a `TextSelection` spanning it is used.
- When a block has table content, a `CellSelection` spanning all cells is used.
- When a block has no content, a `NodeSelection` spanning the `blockContent` node is used.

## Rationale

<!-- Explain the reasoning behind this feature and its benefits to the project. -->

Currently, `setSelection` uses a `TextSelection` when spanning multiple nodes. This can cause issues when the start/end blocks do not have content, as it's not possible to find a `TextSelection` that spans them.

## Changes

<!-- List the major changes made in this pull request. -->

- Rewrote `setSelection`
- Updated `getSelection`
- Added `fromJSON` to `MultipleNodeSelection`
- Updated `moveBlocks` to work with a `MultipleNodeSelection`.
- Added `"Mod-a"` keyboard handler which calls `setSelection` on the whole document. The default `"Mod-a"` shortcut attempts to create a `TextSelection`, which has the aforementioned issues.

## Impact

<!-- Discuss any potential impacts this feature may have on existing functionalities. -->

Should not be a breaking change as the BlockNote API is unchanged.

## Testing

<!-- Describe how the feature has been tested, including both automated and manual testing strategies. -->

We already have tests for `getSelection`/`setSelection`. When implementing the changes, I ran them against the tests to ensure they were correct.

## Screenshots/Video

<!-- Include screenshots or video demonstrating the new feature, if applicable. -->

N/A

## Checklist

- [X] Code follows the project's coding standards.
- [X] Unit tests covering the new feature have been added.
- [X] All existing tests pass.
- [X] The documentation has been updated to reflect the new feature

## Additional Notes

<!-- Any additional information or context relevant to this PR. -->
