### PR TITLE
fix: Firefox invisible text cursor after dropping blocks

### DIFF
--- a/packages/core/src/editor/BlockNoteEditor.ts
+++ b/packages/core/src/editor/BlockNoteEditor.ts
@@ -1107,6 +1107,13 @@ export class BlockNoteEditor<
     this.prosemirrorView.focus();
   }
 
+  public blur() {
+    if (this.headless) {
+      return;
+    }
+    this.prosemirrorView.dom.blur();
+  }
+
   public onUploadStart(callback: (blockId?: string) => void) {
     this.onUploadStartCallbacks.push(callback);
 

--- a/packages/core/src/extensions/SideMenu/SideMenuPlugin.ts
+++ b/packages/core/src/extensions/SideMenu/SideMenuPlugin.ts
@@ -739,7 +739,7 @@ export class SideMenuProsemirrorPlugin<
       this.view.isDragOrigin = false;
     }
 
-    this.editor.domElement?.blur();
+    this.editor.blur();
   };
   /**
    * Freezes the side menu. When frozen, the side menu will stay


### PR DESCRIPTION
# Summary

<!-- Briefly describe the feature being introduced. -->

This PR blurs the editor after blocks are dragged and dropped. This is mainly to fix an issue in Firefox that causes the text cursor to become invisible after drag & drop. However, it's also generally better for UX, as having the editor keep focus makes the formatting toolbar show up. Notion also doesn't show the toolbar after blocks are dropped.

R.e. the Firefox invisible cursor issue, this was a bit of a rabbithole.

First off, this also happens with TipTap's drag handle implementions (vanilla JS, React, and Vue):

[Vanilla JS Drag Handle](https://tiptap.dev/docs/editor/extensions/functionality/drag-handle)

[React Drag Handle](https://tiptap.dev/docs/editor/extensions/functionality/drag-handle-react)

[Vue Drag Handle](https://tiptap.dev/docs/editor/extensions/functionality/drag-handle-vue)

Then I found that TinyMCE also had this issue ages ago, but was since fixed:

[TinyMCE #2823](https://github.com/tinymce/tinymce/issues/2823)

[TinyMCE #1497](https://github.com/tinymce/tinymce/issues/1497)

Unfortunately, despite searching for it, I couldn't find the PR with the fix for these issues.

There's also a ProseMirror bug report that's been open for years regarding what seems to be the same issue:

[ProseMirror #593](https://github.com/ProseMirror/prosemirror/issues/583)

So overall, looks like this is just a bug with Firefox, and the best we can do is work around it. Blurring the editor and refocusing it works. This PR just blurs it (as this more closely matches Notion's UX), but could be changed to refocus it after too.

Closes #2036

## Rationale

<!-- Explain the reasoning behind this feature and its benefits to the project. -->

The caret disappearing in Firefox is a major annoyance, and users have to click somewhere outside the editor, then back on it, to make it reappear.

## Changes

<!-- List the major changes made in this pull request. -->

Made editor DOM element get blurred at the end of `blockDragEnd`.

## Impact

<!-- Discuss any potential impacts this feature may have on existing functionalities. -->

N/A

## Testing

<!-- Describe how the feature has been tested, including both automated and manual testing strategies. -->

Is there even a way to test for this? Even with e2e test screenshots, the text cursor blinks so they seem like they'd be flaky at best.

## Screenshots/Video

<!-- Include screenshots or video demonstrating the new feature, if applicable. -->

N/A

## Checklist

- [x] Code follows the project's coding standards.
- [x] Unit tests covering the new feature have been added.
- [x] All existing tests pass.
- [x] The documentation has been updated to reflect the new feature

## Additional Notes

<!-- Any additional information or context relevant to this PR. -->
