### PR TITLE
fix(comments): update the styles for the cursor to be the default cursor

### DIFF
--- a/examples/07-collaboration/06-comments-with-sidebar/package.json
+++ b/examples/07-collaboration/06-comments-with-sidebar/package.json
@@ -21,7 +21,8 @@
     "@mantine/utils": "^6.0.22",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
-    "@y-sweet/react": "^0.6.3"
+    "y-partykit": "^0.0.25",
+    "yjs": "^13.6.27"
   },
   "devDependencies": {
     "@types/react": "^19.2.2",

--- a/examples/07-collaboration/06-comments-with-sidebar/src/App.tsx
+++ b/examples/07-collaboration/06-comments-with-sidebar/src/App.tsx
@@ -12,8 +12,9 @@ import {
   ThreadsSidebar,
   useCreateBlockNote,
 } from "@blocknote/react";
-import { YDocProvider, useYDoc, useYjsProvider } from "@y-sweet/react";
 import { useMemo, useState } from "react";
+import YPartyKitProvider from "y-partykit/provider";
+import * as Y from "yjs";
 
 import { SettingsSelect } from "./SettingsSelect";
 import { HARDCODED_USERS, MyUserType, getRandomColor } from "./userdata";
@@ -31,23 +32,19 @@ async function resolveUsers(userIds: string[]) {
   return HARDCODED_USERS.filter((user) => userIds.includes(user.id));
 }
 
+// Sets up Yjs document and PartyKit Yjs provider.
+const doc = new Y.Doc();
+const provider = new YPartyKitProvider(
+  "blocknote-dev.yousefed.partykit.dev",
+  // Use a unique name as a "room" for your application.
+  "comments-with-sidebar",
+  doc,
+);
+
 // This follows the Y-Sweet example to setup a collabotive editor
 // (but of course, you also use other collaboration providers
 // see the docs for more information)
 export default function App() {
-  const docId = "my-blocknote-document-with-comments-2";
-
-  return (
-    <YDocProvider
-      docId={docId}
-      authEndpoint="https://demos.y-sweet.dev/api/auth"
-    >
-      <Document />
-    </YDocProvider>
-  );
-}
-
-function Document() {
   const [activeUser, setActiveUser] = useState<MyUserType>(HARDCODED_USERS[0]);
   const [commentFilter, setCommentFilter] = useState<
     "open" | "resolved" | "all"
@@ -55,11 +52,6 @@ function Document() {
   const [commentSort, setCommentSort] = useState<
     "position" | "recent-activity" | "oldest"
   >("position");
-
-  const provider = useYjsProvider();
-
-  // take the Y.Doc collaborative document from Y-Sweet
-  const doc = useYDoc();
 
   // setup the thread store which stores / and syncs thread / comment data
   const threadStore = useMemo(() => {

--- a/packages/core/src/comments/threadstore/yjs/YjsThreadStoreBase.ts
+++ b/packages/core/src/comments/threadstore/yjs/YjsThreadStoreBase.ts
@@ -29,7 +29,9 @@ export abstract class YjsThreadStoreBase extends ThreadStore {
   public getThreads(): Map<string, ThreadData> {
     const threadMap = new Map<string, ThreadData>();
     this.threadsYMap.forEach((yThread, id) => {
-      threadMap.set(id, yMapToThread(yThread));
+      if (yThread instanceof Y.Map) {
+        threadMap.set(id, yMapToThread(yThread));
+      }
     });
     return threadMap;
   }

--- a/packages/mantine/src/blocknoteStyles.css
+++ b/packages/mantine/src/blocknoteStyles.css
@@ -635,10 +635,6 @@
   box-shadow: none;
 }
 
-.bn-mantine .bn-thread:not(.selected) {
-  cursor: pointer;
-}
-
 .bn-mantine .bn-thread-comments,
 .bn-mantine .bn-thread-composer {
   display: flex;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3635,15 +3635,18 @@ importers:
       '@mantine/utils':
         specifier: ^6.0.22
         version: 6.0.22(react@19.2.0)
-      '@y-sweet/react':
-        specifier: ^0.6.3
-        version: 0.6.4(react@19.2.0)(yjs@13.6.27)
       react:
         specifier: ^19.2.0
         version: 19.2.0
       react-dom:
         specifier: ^19.2.0
         version: 19.2.0(react@19.2.0)
+      y-partykit:
+        specifier: ^0.0.25
+        version: 0.0.25
+      yjs:
+        specifier: ^13.6.27
+        version: 13.6.27
     devDependencies:
       '@types/react':
         specifier: ^19.2.2


### PR DESCRIPTION
# Summary

Addresses: https://linear.app/blocknote/issue/BLO-333/comments-cursor
Introduced by: https://github.com/TypeCellOS/BlockNote/pull/2033

This removes some styles which were changing the cursor to be a pointer, when it was not actually needed.

I noticed that the sidebar demo was not working, I think that someone must've edited the document to produce an invalid thread map (which is why I did the instance of check).
When I changed the document it pointed to, it seems like y-sweet is not accepting new document ids, so I've just switched it to use partykit instead.\
This should also wipe the document (the y-sweet document got very large & was hard to render in the editor)

<!-- Briefly describe the feature being introduced. -->

## Rationale

<!-- Explain the reasoning behind this feature and its benefits to the project. -->

## Changes

<!-- List the major changes made in this pull request. -->

## Impact

<!-- Discuss any potential impacts this feature may have on existing functionalities. -->

## Testing

<!-- Describe how the feature has been tested, including both automated and manual testing strategies. -->

## Screenshots/Video

<!-- Include screenshots or video demonstrating the new feature, if applicable. -->

## Checklist

- [ ] Code follows the project's coding standards.
- [ ] Unit tests covering the new feature have been added.
- [ ] All existing tests pass.
- [ ] The documentation has been updated to reflect the new feature

## Additional Notes

<!-- Any additional information or context relevant to this PR. -->
