### PR TITLE
fix: set default previewWidth to 512 to prevent RangeError

### DIFF
--- a/packages/core/src/blocks/Image/block.ts
+++ b/packages/core/src/blocks/Image/block.ts
@@ -45,7 +45,7 @@ export const createImageBlockConfig = createBlockConfig(
         },
         // File preview width in px.
         previewWidth: {
-          default: undefined,
+          default: 512 as const,
           type: "number" as const,
         },
       },


### PR DESCRIPTION
#2170 There was an issue similar to this one.

While it is possible for users to override it manually, I believe it would be more appropriate to update the type definition to match the official documentation.