### PR TITLE
fix: do not error on invalid backgroundColor or textColor #2176

### DIFF
--- a/packages/xl-docx-exporter/src/docx/defaultSchema/blocks.ts
+++ b/packages/xl-docx-exporter/src/docx/defaultSchema/blocks.ts
@@ -35,16 +35,25 @@ function blockPropsToStyles(
         ? undefined
         : {
             type: ShadingType.SOLID,
-            color:
-              colors[
-                props.backgroundColor as keyof typeof colors
-              ].background.slice(1),
+            color: (() => {
+              const color = colors[props.backgroundColor]?.background;
+              if (!color) {
+                return undefined;
+              }
+              return color.slice(1);
+            })(),
           },
     run:
       props.textColor === "default" || !props.textColor
         ? undefined
         : {
-            color: colors[props.textColor as keyof typeof colors].text.slice(1),
+            color: (() => {
+              const color = colors[props.textColor]?.text;
+              if (!color) {
+                return undefined;
+              }
+              return color.slice(1);
+            })(),
           },
     alignment:
       !props.textAlignment || props.textAlignment === "left"

--- a/packages/xl-docx-exporter/src/docx/defaultSchema/styles.ts
+++ b/packages/xl-docx-exporter/src/docx/defaultSchema/styles.ts
@@ -43,11 +43,13 @@ export const docxStyleMappingForDefaultSchema: StyleMapping<
     if (!val) {
       return {};
     }
+    const color = exporter.options.colors[val]?.background;
+    if (!color) {
+      return {};
+    }
     return {
       shading: {
-        fill: exporter.options.colors[
-          val as keyof typeof exporter.options.colors
-        ].background.slice(1),
+        fill: color.slice(1),
       },
     };
   },
@@ -55,11 +57,12 @@ export const docxStyleMappingForDefaultSchema: StyleMapping<
     if (!val) {
       return {};
     }
+    const color = exporter.options.colors[val]?.text;
+    if (!color) {
+      return {};
+    }
     return {
-      color:
-        exporter.options.colors[
-          val as keyof typeof exporter.options.colors
-        ].text.slice(1),
+      color: color.slice(1),
     };
   },
   code: (val) => {

--- a/packages/xl-docx-exporter/src/docx/util/Table.tsx
+++ b/packages/xl-docx-exporter/src/docx/util/Table.tsx
@@ -55,11 +55,15 @@ export const Table = (
                 ? undefined
                 : {
                     type: ShadingType.SOLID,
-                    color:
-                      t.options.colors[
-                        cell.props
-                          .backgroundColor as keyof typeof t.options.colors
-                      ].background.slice(1),
+                    color: (() => {
+                      const color =
+                        t.options.colors[cell.props.backgroundColor]
+                          ?.background;
+                      if (!color) {
+                        return undefined;
+                      }
+                      return color.slice(1);
+                    })(),
                   },
             children: [
               new Paragraph({
@@ -88,9 +92,14 @@ export const Table = (
                   color:
                     cell.props.textColor === "default" || !cell.props.textColor
                       ? undefined
-                      : t.options.colors[
-                          cell.props.textColor as keyof typeof t.options.colors
-                        ].text.slice(1),
+                      : (() => {
+                          const color =
+                            t.options.colors[cell.props.textColor]?.text;
+                          if (!color) {
+                            return undefined;
+                          }
+                          return color.slice(1);
+                        })(),
                 },
               }),
             ],

--- a/packages/xl-email-exporter/src/react-email/reactEmailExporter.tsx
+++ b/packages/xl-email-exporter/src/react-email/reactEmailExporter.tsx
@@ -333,15 +333,11 @@ export class ReactEmailExporter<
       backgroundColor:
         props.backgroundColor === "default" || !props.backgroundColor
           ? undefined
-          : this.options.colors[
-              props.backgroundColor as keyof typeof this.options.colors
-            ].background,
+          : this.options.colors[props.backgroundColor]?.background,
       color:
         props.textColor === "default" || !props.textColor
           ? undefined
-          : this.options.colors[
-              props.textColor as keyof typeof this.options.colors
-            ].text,
+          : this.options.colors[props.textColor]?.text,
       alignItems:
         props.textAlignment === "right"
           ? "flex-end"

--- a/packages/xl-odt-exporter/src/odt/defaultSchema/blocks.tsx
+++ b/packages/xl-odt-exporter/src/odt/defaultSchema/blocks.tsx
@@ -41,9 +41,7 @@ const createParagraphStyle = (
 
   const backgroundColor =
     props.backgroundColor && props.backgroundColor !== "default"
-      ? exporter.options.colors[
-          props.backgroundColor as keyof typeof exporter.options.colors
-        ].background
+      ? exporter.options.colors[props.backgroundColor]?.background
       : undefined;
 
   if (backgroundColor) {
@@ -54,7 +52,7 @@ const createParagraphStyle = (
     const color =
       exporter.options.colors[
         props.textColor as keyof typeof exporter.options.colors
-      ].text;
+      ]?.text ?? props.textColor;
     textStyles["fo:color"] = color;
   }
 
@@ -115,18 +113,14 @@ const createTableCellStyle = (
           fo:background-color={
             cell.props.backgroundColor !== "default" &&
             cell.props.backgroundColor
-              ? exporter.options.colors[
-                  cell.props
-                    .backgroundColor as keyof typeof exporter.options.colors
-                ].background
+              ? exporter.options.colors?.[cell.props.backgroundColor]
+                  ?.background
               : undefined
           }
           // TODO This is not applying because the children set their own colors
           fo:color={
             cell.props.textColor !== "default" && cell.props.textColor
-              ? exporter.options.colors[
-                  cell.props.textColor as keyof typeof exporter.options.colors
-                ].text
+              ? exporter.options.colors[cell.props.textColor]?.text
               : undefined
           }
         />

--- a/packages/xl-odt-exporter/src/odt/defaultSchema/styles.ts
+++ b/packages/xl-odt-exporter/src/odt/defaultSchema/styles.ts
@@ -35,8 +35,10 @@ export const odtStyleMappingForDefaultSchema: StyleMapping<
     if (!val) {
       return {};
     }
-    const color =
-      exporter.options.colors[val as keyof typeof exporter.options.colors].text;
+    const color = exporter.options.colors[val]?.text;
+    if (!color) {
+      return {};
+    }
     return { "fo:color": color };
   },
 
@@ -44,9 +46,10 @@ export const odtStyleMappingForDefaultSchema: StyleMapping<
     if (!val) {
       return {};
     }
-    const color =
-      exporter.options.colors[val as keyof typeof exporter.options.colors]
-        .background;
+    const color = exporter.options.colors[val]?.background;
+    if (!color) {
+      return {};
+    }
     return { "fo:background-color": color };
   },
 

--- a/packages/xl-pdf-exporter/src/pdf/defaultSchema/styles.tsx
+++ b/packages/xl-pdf-exporter/src/pdf/defaultSchema/styles.tsx
@@ -42,9 +42,7 @@ export const pdfStyleMappingForDefaultSchema: StyleMapping<
       return {};
     }
     return {
-      backgroundColor:
-        exporter.options.colors[val as keyof typeof exporter.options.colors]
-          .background,
+      backgroundColor: exporter.options.colors[val]?.background,
     };
   },
   textColor: (val, exporter) => {
@@ -52,9 +50,7 @@ export const pdfStyleMappingForDefaultSchema: StyleMapping<
       return {};
     }
     return {
-      color:
-        exporter.options.colors[val as keyof typeof exporter.options.colors]
-          .text,
+      color: exporter.options.colors[val]?.text,
     };
   },
   code: (val) => {

--- a/packages/xl-pdf-exporter/src/pdf/pdfExporter.tsx
+++ b/packages/xl-pdf-exporter/src/pdf/pdfExporter.tsx
@@ -296,15 +296,11 @@ export class PDFExporter<
       backgroundColor:
         props.backgroundColor === "default" || !props.backgroundColor
           ? undefined
-          : this.options.colors[
-              props.backgroundColor as keyof typeof this.options.colors
-            ].background,
+          : this.options.colors[props.backgroundColor]?.background,
       color:
         props.textColor === "default" || !props.textColor
           ? undefined
-          : this.options.colors[
-              props.textColor as keyof typeof this.options.colors
-            ].text,
+          : this.options.colors[props.textColor]?.text,
       alignItems:
         props.textAlignment === "right"
           ? "flex-end"

--- a/packages/xl-pdf-exporter/src/pdf/util/table/Table.tsx
+++ b/packages/xl-pdf-exporter/src/pdf/util/table/Table.tsx
@@ -88,17 +88,14 @@ export const Table = (props: {
                     color:
                       cell.props.textColor === "default"
                         ? undefined
-                        : props.transformer.options.colors[
-                            cell.props
-                              .textColor as keyof typeof props.transformer.options.colors
-                          ].text,
+                        : props.transformer.options.colors[cell.props.textColor]
+                            ?.text,
                     backgroundColor:
                       cell.props.backgroundColor === "default"
                         ? undefined
                         : props.transformer.options.colors[
-                            cell.props
-                              .backgroundColor as keyof typeof props.transformer.options.colors
-                          ].background,
+                            cell.props.backgroundColor
+                          ]?.background,
                     textAlign: cell.props.textAlignment,
                   },
                 ]}


### PR DESCRIPTION
# Summary
There can be invalid `textColor` or `backgroundColor` in a document. We were assuming that it always was a valid color. This changes all of the places where we read the backgroundColor or textColor to not make that assumption & access a property which does not actually exist.

There is some digging to be done here to understand whether we can prevent these invalid values from getting within the document, but at this point I think having this defensive code is still needed as I'm unsure that we can actually fully validate these string attributes in prosemirror.

Perhaps this is helped with the zod props, so this may not be required soon.
<!-- Briefly describe the feature being introduced. -->

## Rationale

<!-- Explain the reasoning behind this feature and its benefits to the project. -->

## Changes

<!-- List the major changes made in this pull request. -->

## Impact

<!-- Discuss any potential impacts this feature may have on existing functionalities. -->

## Testing

<!-- Describe how the feature has been tested, including both automated and manual testing strategies. -->

## Screenshots/Video

<!-- Include screenshots or video demonstrating the new feature, if applicable. -->

## Checklist

- [ ] Code follows the project's coding standards.
- [ ] Unit tests covering the new feature have been added.
- [ ] All existing tests pass.
- [ ] The documentation has been updated to reflect the new feature

## Additional Notes

#2176
<!-- Any additional information or context relevant to this PR. -->
