### PR TITLE
fix: disallow access to the `domElement` or `isFocused` if the editor is unmounted

### DIFF
--- a/packages/core/src/editor/BlockNoteEditor.ts
+++ b/packages/core/src/editor/BlockNoteEditor.ts
@@ -1082,10 +1082,16 @@ export class BlockNoteEditor<
   }
 
   public get domElement() {
+    if (this.headless) {
+      return undefined;
+    }
     return this.prosemirrorView?.dom as HTMLDivElement | undefined;
   }
 
   public isFocused() {
+    if (this.headless) {
+      return false;
+    }
     return this.prosemirrorView?.hasFocus() || false;
   }
 
@@ -1673,7 +1679,7 @@ export class BlockNoteEditor<
       ignoreQueryLength?: boolean;
     },
   ) {
-    if (!this.prosemirrorView) {
+    if (!this.prosemirrorView || this.headless) {
       return;
     }
 


### PR DESCRIPTION
# Summary
This fixes a race condition where the editor is `unmount`ed before the suggestion menu has time to react to this change.

This fixes the issue by making sure that the element that it is trying to access is just `undefined` if accessed when unmounted.
<!-- Briefly describe the feature being introduced. -->

## Rationale

<!-- Explain the reasoning behind this feature and its benefits to the project. -->

## Changes

<!-- List the major changes made in this pull request. -->

## Impact

<!-- Discuss any potential impacts this feature may have on existing functionalities. -->

## Testing

<!-- Describe how the feature has been tested, including both automated and manual testing strategies. -->

## Screenshots/Video

<!-- Include screenshots or video demonstrating the new feature, if applicable. -->

## Checklist

- [x] Code follows the project's coding standards.
- [ ] Unit tests covering the new feature have been added.
- [x] All existing tests pass.
- [ ] The documentation has been updated to reflect the new feature

## Additional Notes

Fixes #2138
<!-- Any additional information or context relevant to this PR. -->
