### PR TITLE
fix: Create link button force show selection bug

### DIFF
--- a/packages/react/src/components/FormattingToolbar/DefaultButtons/CreateLinkButton.tsx
+++ b/packages/react/src/components/FormattingToolbar/DefaultButtons/CreateLinkButton.tsx
@@ -50,6 +50,7 @@ export const CreateLinkButton = () => {
   const [showPopover, setShowPopover] = useState(false);
   useEffect(() => {
     showSelection(showPopover);
+    return () => showSelection(false);
   }, [showPopover, showSelection]);
 
   const state = useEditorState({


### PR DESCRIPTION
# Summary

<!-- Briefly describe the feature being introduced. -->

When you click the link creation button, it autofocuses the URL input which blurs the editor and would normally hide the selection. However, `showSelection` from the `ShowSelectionExtension` is called at the same time to prevent this.

However, this is never cleaned up, the the editor selection is still forced to be shown. This PR fixes this issue by calling `showSelection(false)` when the create link button component gets unmounted.

## Rationale

<!-- Explain the reasoning behind this feature and its benefits to the project. -->

This issue causes bad UX and should be fixed.

## Changes

<!-- List the major changes made in this pull request. -->

N/A

## Impact

<!-- Discuss any potential impacts this feature may have on existing functionalities. -->

N/A

## Testing

<!-- Describe how the feature has been tested, including both automated and manual testing strategies. -->

Added case to UI testing Notion doc.

## Screenshots/Video

<!-- Include screenshots or video demonstrating the new feature, if applicable. -->

## Checklist

- [X] Code follows the project's coding standards.
- [X] Unit tests covering the new feature have been added.
- [X] All existing tests pass.
- [X] The documentation has been updated to reflect the new feature

## Additional Notes

<!-- Any additional information or context relevant to this PR. -->
