### PR TITLE
fix: add preload option to video blocks

### DIFF
--- a/packages/core/src/blocks/Video/block.ts
+++ b/packages/core/src/blocks/Video/block.ts
@@ -11,6 +11,7 @@ export const FILE_VIDEO_ICON_SVG =
 
 export interface VideoOptions {
   icon?: string;
+  preload?: "none" | "metadata" | "auto";
 }
 
 export type VideoBlockConfig = ReturnType<typeof createVideoBlockConfig>;
@@ -93,6 +94,9 @@ export const createVideoBlockSpec = createBlockSpec(
       video.contentEditable = "false";
       video.draggable = false;
       video.width = block.props.previewWidth;
+      if (config.preload) {
+        video.preload = config.preload;
+      }
       videoWrapper.appendChild(video);
 
       return createResizableFileBlockWrapper(

--- a/packages/react/src/blocks/Video/block.tsx
+++ b/packages/react/src/blocks/Video/block.tsx
@@ -1,14 +1,14 @@
-import { createVideoBlockConfig, videoParse } from "@blocknote/core";
+import { createVideoBlockConfig, VideoOptions, videoParse } from "@blocknote/core";
 import { RiVideoFill } from "react-icons/ri";
 
 import {
   createReactBlockSpec,
   ReactCustomBlockRenderProps,
 } from "../../schema/ReactBlockSpec.js";
-import { useResolveUrl } from "../File/useResolveUrl.js";
-import { FigureWithCaption } from "../File/helpers/toExternalHTML/FigureWithCaption.js";
 import { ResizableFileBlockWrapper } from "../File/helpers/render/ResizableFileBlockWrapper.js";
+import { FigureWithCaption } from "../File/helpers/toExternalHTML/FigureWithCaption.js";
 import { LinkWithCaption } from "../File/helpers/toExternalHTML/LinkWithCaption.js";
+import { useResolveUrl } from "../File/useResolveUrl.js";
 
 export const VideoPreview = (
   props: Omit<
@@ -18,7 +18,9 @@ export const VideoPreview = (
       ReturnType<typeof createVideoBlockConfig>["content"]
     >,
     "contentRef"
-  >,
+  > & {
+    preload?: "none" | "metadata" | "auto";
+  },
 ) => {
   const resolved = useResolveUrl(props.block.props.url!);
 
@@ -33,6 +35,7 @@ export const VideoPreview = (
       controls={true}
       contentEditable={false}
       draggable={false}
+      preload={props.preload}
     />
   );
 };
@@ -74,7 +77,7 @@ export const VideoToExternalHTML = (
   return video;
 };
 
-export const VideoBlock = (
+export const VideoBlock = (config: VideoOptions) => (
   props: ReactCustomBlockRenderProps<
     ReturnType<typeof createVideoBlockConfig>["type"],
     ReturnType<typeof createVideoBlockConfig>["propSchema"],
@@ -86,7 +89,7 @@ export const VideoBlock = (
       {...(props as any)}
       buttonIcon={<RiVideoFill size={24} />}
     >
-      <VideoPreview {...(props as any)} />
+      <VideoPreview preload={config.preload} {...(props as any)} />
     </ResizableFileBlockWrapper>
   );
 };
@@ -94,7 +97,7 @@ export const VideoBlock = (
 export const ReactVideoBlock = createReactBlockSpec(
   createVideoBlockConfig,
   (config) => ({
-    render: VideoBlock,
+    render: VideoBlock(config),
     parse: videoParse(config),
     toExternalHTML: VideoToExternalHTML,
   }),


### PR DESCRIPTION
# Summary

Closes https://github.com/TypeCellOS/BlockNote/issues/2203

## Rationale

With this fix, it's possible to set a `preload` option in the config of your video block in the schema.

I think this is cleaner than setting it on a block prop (as "preload" seems a UI concern, that something that should be stored in the document). The downside is that it's a single configuration that applies to all blocks

## Changes

x

## Impact

x

## Testing

manual

## Screenshots/Video

x

## Checklist

- [ ] Code follows the project's coding standards.
- [ ] Unit tests covering the new feature have been added.
- [ ] All existing tests pass.
- [ ] The documentation has been updated to reflect the new feature

## Additional Notes

<!-- Any additional information or context relevant to this PR. -->
