### PR TITLE
fix: Suggestion menu positioning

### DIFF
--- a/packages/react/src/components/SuggestionMenu/GridSuggestionMenu/GridSuggestionMenuController.tsx
+++ b/packages/react/src/components/SuggestionMenu/GridSuggestionMenu/GridSuggestionMenuController.tsx
@@ -9,10 +9,7 @@ import {
   useExtensionState,
 } from "../../../hooks/useExtension.js";
 import { FloatingUIOptions } from "../../Popovers/FloatingUIOptions.js";
-import {
-  GenericPopover,
-  GenericPopoverReference,
-} from "../../Popovers/GenericPopover.js";
+import { GenericPopover } from "../../Popovers/GenericPopover.js";
 import { getDefaultReactEmojiPickerItems } from "./getDefaultReactEmojiPickerItems.js";
 import { GridSuggestionMenu } from "./GridSuggestionMenu.js";
 import { GridSuggestionMenuWrapper } from "./GridSuggestionMenuWrapper.js";
@@ -97,20 +94,15 @@ export function GridSuggestionMenuController<
   }, [suggestionMenu, triggerCharacter]);
 
   const state = useExtensionState(SuggestionMenu);
-  const referencePos = useExtensionState(SuggestionMenu, {
-    selector: (state) => state?.referencePos || new DOMRect(),
-  });
-
-  const reference = useMemo<GenericPopoverReference>(
-    () => ({
+  const reference = useExtensionState(SuggestionMenu, {
+    selector: (state) => ({
       // Use first child as the editor DOM element may itself be scrollable.
       // For FloatingUI to auto-update the position during scrolling, the
       // `contextElement` must be a descendant of the scroll container.
       element: editor.domElement?.firstChild || undefined,
-      getBoundingClientRect: () => referencePos,
+      getBoundingClientRect: () => state?.referencePos || new DOMRect(),
     }),
-    [editor.domElement?.firstChild, referencePos],
-  );
+  });
 
   const floatingUIOptions = useMemo<FloatingUIOptions>(
     () => ({

--- a/packages/react/src/components/SuggestionMenu/SuggestionMenuController.tsx
+++ b/packages/react/src/components/SuggestionMenu/SuggestionMenuController.tsx
@@ -15,10 +15,7 @@ import { FC, useEffect, useMemo } from "react";
 import { useBlockNoteEditor } from "../../hooks/useBlockNoteEditor.js";
 import { useExtension, useExtensionState } from "../../hooks/useExtension.js";
 import { FloatingUIOptions } from "../Popovers/FloatingUIOptions.js";
-import {
-  GenericPopover,
-  GenericPopoverReference,
-} from "../Popovers/GenericPopover.js";
+import { GenericPopover } from "../Popovers/GenericPopover.js";
 import { SuggestionMenu } from "./SuggestionMenu.js";
 import { SuggestionMenuWrapper } from "./SuggestionMenuWrapper.js";
 import { getDefaultReactSlashMenuItems } from "./getDefaultReactSlashMenuItems.js";
@@ -98,20 +95,15 @@ export function SuggestionMenuController<
   }, [suggestionMenu, triggerCharacter]);
 
   const state = useExtensionState(SuggestionMenuExtension);
-  const referencePos = useExtensionState(SuggestionMenuExtension, {
-    selector: (state) => state?.referencePos || new DOMRect(),
-  });
-
-  const reference = useMemo<GenericPopoverReference>(
-    () => ({
+  const reference = useExtensionState(SuggestionMenuExtension, {
+    selector: (state) => ({
       // Use first child as the editor DOM element may itself be scrollable.
       // For FloatingUI to auto-update the position during scrolling, the
       // `contextElement` must be a descendant of the scroll container.
       element: editor.domElement?.firstChild || undefined,
-      getBoundingClientRect: () => referencePos,
+      getBoundingClientRect: () => state?.referencePos || new DOMRect(),
     }),
-    [editor.domElement?.firstChild, referencePos],
-  );
+  });
 
   const floatingUIOptions = useMemo<FloatingUIOptions>(
     () => ({


### PR DESCRIPTION
# Summary

<!-- Briefly describe the feature being introduced. -->

This PR fixes an issue where if the suggestion menu was displayed above the trigger character (when there was not enough space to display it below), and only showed a few items, there would be a large gap between the menu and trigger character. This was because the suggestion menu had a hard-coded minimum height, which wasn't filled when displaying a small number of items.

Also, the positioning has generally been improved to better take advantage of the available screen space.

## Rationale

<!-- Explain the reasoning behind this feature and its benefits to the project. -->

This issue has made the suggestion menu feel janky in some situations.

## Changes

<!-- List the major changes made in this pull request. -->

- Removed minimum height being set in `SuggestionMenuController` Floating UI options `size` middleware.
- Replaced `flip` middleware with `autoPlacement`. The difference is that `autoPlacement` always displays the menu on the side that has more space, whereas `flip` only changes the side when there is not enough available space for the menu.

## Impact

<!-- Discuss any potential impacts this feature may have on existing functionalities. -->

N/A

## Testing

<!-- Describe how the feature has been tested, including both automated and manual testing strategies. -->

Updated Notion UI testing doc.

## Screenshots/Video

<!-- Include screenshots or video demonstrating the new feature, if applicable. -->

N/A

## Checklist

- [X] Code follows the project's coding standards.
- [X] Unit tests covering the new feature have been added.
- [X] All existing tests pass.
- [X] The documentation has been updated to reflect the new feature

## Additional Notes

<!-- Any additional information or context relevant to this PR. -->
