### PR TITLE
fix: AI menu not updating position on new line

### DIFF
--- a/packages/xl-ai/src/components/AIMenu/AIMenuController.tsx
+++ b/packages/xl-ai/src/components/AIMenu/AIMenuController.tsx
@@ -5,7 +5,7 @@ import {
   useExtension,
   useExtensionState,
 } from "@blocknote/react";
-import { offset, size } from "@floating-ui/react";
+import { autoUpdate, offset, size } from "@floating-ui/react";
 import { FC, useMemo } from "react";
 
 import { AIExtension } from "../../AIExtension.js";
@@ -54,6 +54,11 @@ export const AIMenuController = (props: {
           ) {
             ai.rejectChanges();
           }
+        },
+        whileElementsMounted(reference, floating, update) {
+          return autoUpdate(reference, floating, update, {
+            animationFrame: true,
+          });
         },
       },
       useDismissProps: {


### PR DESCRIPTION
# Summary

<!-- Briefly describe the feature being introduced. -->

There was a regression introduced in #2143 which made the AI menu no longer update its position when it creates a new line.

## Rationale

<!-- Explain the reasoning behind this feature and its benefits to the project. -->

See above.

## Changes

<!-- List the major changes made in this pull request. -->

- Made `AIMenuController` FloatingUI options call `autoUpdate` on each animation frame.

## Impact

<!-- Discuss any potential impacts this feature may have on existing functionalities. -->

N/A

## Testing

<!-- Describe how the feature has been tested, including both automated and manual testing strategies. -->

Added test case to Notion UI testing doc.

## Screenshots/Video

<!-- Include screenshots or video demonstrating the new feature, if applicable. -->

N/A

## Checklist

- [X] Code follows the project's coding standards.
- [X] Unit tests covering the new feature have been added.
- [X] All existing tests pass.
- [X] The documentation has been updated to reflect the new feature

## Additional Notes

<!-- Any additional information or context relevant to this PR. -->
