### PR TITLE
fix: put back `onBeforeChange` method #2221

### DIFF
--- a/packages/core/src/editor/BlockNoteEditor.test.ts
+++ b/packages/core/src/editor/BlockNoteEditor.test.ts
@@ -6,6 +6,7 @@ import {
   getNearestBlockPos,
 } from "../api/getBlockInfoFromPos.js";
 import { BlockNoteEditor } from "./BlockNoteEditor.js";
+import { BlocksChanged } from "../api/getBlocksChangedByTransaction.js";
 
 /**
  * @vitest-environment jsdom
@@ -189,4 +190,63 @@ it("sets an initial block id when using Y.js", async () => {
   expect(fragment.toJSON()).toMatchInlineSnapshot(
     `"<blockgroup><blockcontainer id="0"><paragraph backgroundColor="default" textAlignment="left" textColor="default">Hello</paragraph></blockcontainer><blockcontainer id="1"><paragraph backgroundColor="default" textAlignment="left" textColor="default"></paragraph></blockcontainer></blockgroup>"`,
   );
+});
+
+it("onBeforeChange", () => {
+  const editor = BlockNoteEditor.create();
+  let beforeChangeCalled = false;
+  let changes: BlocksChanged<any, any, any> = [];
+  editor.onBeforeChange(({ getChanges }) => {
+    beforeChangeCalled = true;
+    changes = getChanges();
+    return true;
+  });
+  editor.mount(document.createElement("div"));
+  editor.replaceBlocks(editor.document, [
+    {
+      type: "paragraph",
+      content: [{ text: "Hello", styles: {}, type: "text" }],
+    },
+  ]);
+  expect(beforeChangeCalled).toBe(true);
+  expect(changes).toMatchInlineSnapshot(`
+    [
+      {
+        "block": {
+          "children": [],
+          "content": [],
+          "id": "3",
+          "props": {
+            "backgroundColor": "default",
+            "textAlignment": "left",
+            "textColor": "default",
+          },
+          "type": "paragraph",
+        },
+        "prevBlock": undefined,
+        "source": {
+          "type": "local",
+        },
+        "type": "insert",
+      },
+      {
+        "block": {
+          "children": [],
+          "content": [],
+          "id": "2",
+          "props": {
+            "backgroundColor": "default",
+            "textAlignment": "left",
+            "textColor": "default",
+          },
+          "type": "paragraph",
+        },
+        "prevBlock": undefined,
+        "source": {
+          "type": "local",
+        },
+        "type": "delete",
+      },
+    ]
+  `);
 });

--- a/packages/core/src/editor/BlockNoteEditor.ts
+++ b/packages/core/src/editor/BlockNoteEditor.ts
@@ -52,6 +52,7 @@ import {
 } from "./managers/index.js";
 import type { Selection } from "./selectionTypes.js";
 import { transformPasted } from "./transformPasted.js";
+import { BlockChangeExtension } from "../extensions/index.js";
 
 export type BlockCache<
   BSchema extends BlockSchema = any,
@@ -902,6 +903,22 @@ export class BlockNoteEditor<
    */
   public onEditorSelectionChange(callback: () => void) {
     this._tiptapEditor.on("selectionUpdate", callback);
+  }
+
+  /**
+   * Executes a callback before any change is applied to the editor, allowing you to cancel the change.
+   * @param callback The callback to execute.
+   * @returns A function to remove the callback.
+   */
+  public onBeforeChange(
+    callback: (context: {
+      getChanges: () => BlocksChanged<any, any, any>;
+      tr: Transaction;
+    }) => boolean | void,
+  ) {
+    return this._extensionManager
+      .getExtension(BlockChangeExtension)
+      ?.subscribe(callback);
   }
 
   /**


### PR DESCRIPTION
# Summary
The `onBeforeChange` method was accidentally removed in a previous refactor. This puts it back, and adds a test to make sure it stays there
<!-- Briefly describe the feature being introduced. -->

## Rationale

<!-- Explain the reasoning behind this feature and its benefits to the project. -->

## Changes

<!-- List the major changes made in this pull request. -->

## Impact

<!-- Discuss any potential impacts this feature may have on existing functionalities. -->

## Testing

<!-- Describe how the feature has been tested, including both automated and manual testing strategies. -->

## Screenshots/Video

<!-- Include screenshots or video demonstrating the new feature, if applicable. -->

## Checklist

- [ ] Code follows the project's coding standards.
- [ ] Unit tests covering the new feature have been added.
- [ ] All existing tests pass.
- [ ] The documentation has been updated to reflect the new feature

## Additional Notes

<!-- Any additional information or context relevant to this PR. -->
