### PR TITLE
fix: conditionally access the TableHandles extension from React

### DIFF
--- a/packages/react/src/components/FormattingToolbar/DefaultButtons/TableCellMergeButton.tsx
+++ b/packages/react/src/components/FormattingToolbar/DefaultButtons/TableCellMergeButton.tsx
@@ -13,7 +13,7 @@ import { useEditorState } from "../../../hooks/useEditorState.js";
 import { useExtension } from "../../../hooks/useExtension.js";
 import { useDictionary } from "../../../i18n/dictionary.js";
 
-export const TableCellMergeButton = () => {
+const TableCellMergeButtonInner = () => {
   const dict = useDictionary();
   const Components = useComponentsContext()!;
 
@@ -76,4 +76,12 @@ export const TableCellMergeButton = () => {
       onClick={onClick}
     />
   );
+};
+
+export const TableCellMergeButton = () => {
+  const editor = useBlockNoteEditor();
+  if (!editor.getExtension(TableHandlesExtension)) {
+    return null;
+  }
+  return <TableCellMergeButtonInner />;
 };

--- a/packages/react/src/components/FormattingToolbar/DefaultButtons/TextAlignButton.tsx
+++ b/packages/react/src/components/FormattingToolbar/DefaultButtons/TextAlignButton.tsx
@@ -22,7 +22,6 @@ import {
 import { useComponentsContext } from "../../../editor/ComponentsContext.js";
 import { useBlockNoteEditor } from "../../../hooks/useBlockNoteEditor.js";
 import { useEditorState } from "../../../hooks/useEditorState.js";
-import { useExtension } from "../../../hooks/useExtension.js";
 import { useDictionary } from "../../../i18n/dictionary.js";
 
 type TextAlignment = DefaultProps["textAlignment"];
@@ -43,8 +42,6 @@ export const TextAlignButton = (props: { textAlignment: TextAlignment }) => {
     InlineContentSchema,
     StyleSchema
   >();
-
-  const tableHandles = useExtension(TableHandlesExtension);
 
   const state = useEditorState({
     editor,
@@ -74,7 +71,10 @@ export const TextAlignButton = (props: { textAlignment: TextAlignment }) => {
         selectedBlocks.length === 1 &&
         blockHasType(firstBlock, editor, "table")
       ) {
-        const cellSelection = tableHandles.getCellSelection();
+        const cellSelection = editor
+          .getExtension(TableHandlesExtension)
+          ?.getCellSelection();
+
         if (!cellSelection) {
           return undefined;
         }
@@ -112,7 +112,9 @@ export const TextAlignButton = (props: { textAlignment: TextAlignment }) => {
             props: { textAlignment: textAlignment },
           });
         } else if (block.type === "table") {
-          const cellSelection = tableHandles.getCellSelection();
+          const cellSelection = editor
+            .getExtension(TableHandlesExtension)
+            ?.getCellSelection();
           if (!cellSelection) {
             continue;
           }
@@ -148,7 +150,7 @@ export const TextAlignButton = (props: { textAlignment: TextAlignment }) => {
         }
       }
     },
-    [editor, state, tableHandles],
+    [editor, state],
   );
 
   if (state === undefined) {


### PR DESCRIPTION
# Summary
Fixes #2238 by conditionally accessing the tableHandles extension, and bailing if it is not early. This takes the same approach as accessing the comments extension.

We can consider changing this in the future (perhaps instead of throwing an error it should just allow undefineds), but for the moment this should be fine since it is one of the only extensions that is actually conditional
<!-- Briefly describe the feature being introduced. -->

## Rationale

<!-- Explain the reasoning behind this feature and its benefits to the project. -->

## Changes

<!-- List the major changes made in this pull request. -->

## Impact

<!-- Discuss any potential impacts this feature may have on existing functionalities. -->

## Testing

<!-- Describe how the feature has been tested, including both automated and manual testing strategies. -->

## Screenshots/Video

<!-- Include screenshots or video demonstrating the new feature, if applicable. -->

## Checklist

- [ ] Code follows the project's coding standards.
- [ ] Unit tests covering the new feature have been added.
- [ ] All existing tests pass.
- [ ] The documentation has been updated to reflect the new feature

## Additional Notes

<!-- Any additional information or context relevant to this PR. -->
