### PR TITLE
fix: set the priority of the link extension to be 100 #2240

### DIFF
--- a/packages/core/src/editor/managers/ExtensionManager/extensions.ts
+++ b/packages/core/src/editor/managers/ExtensionManager/extensions.ts
@@ -85,6 +85,7 @@ export function getDefaultTiptapExtensions(
     SuggestionModificationMark,
     Link.extend({
       inclusive: false,
+      priority: 100,
     }).configure({
       defaultProtocol: DEFAULT_LINK_PROTOCOL,
       // only call this once if we have multiple editors installed. Or fix https://github.com/ueberdosis/tiptap/issues/5450


### PR DESCRIPTION
# Summary

I'm actually unsure that we should do this, but I just wanted to keep my idea of what to do in mind.


I think what we really should do here is to either:
 - try to implement links in terms of the blocknote API as a custom inline content
 - if we can't do that, then we should try to re-implement the Tiptap Link extension from scratch. I really have been wanting to get rid of the dependency on linkify, I believe that we should be able to get away with a regex or something simpler. I don't like how heavy it is, and the errors it throws are just annoying
<!-- Briefly describe the feature being introduced. -->

## Rationale

<!-- Explain the reasoning behind this feature and its benefits to the project. -->

## Changes

<!-- List the major changes made in this pull request. -->

## Impact

<!-- Discuss any potential impacts this feature may have on existing functionalities. -->

## Testing

<!-- Describe how the feature has been tested, including both automated and manual testing strategies. -->

## Screenshots/Video

<!-- Include screenshots or video demonstrating the new feature, if applicable. -->

## Checklist

- [ ] Code follows the project's coding standards.
- [ ] Unit tests covering the new feature have been added.
- [ ] All existing tests pass.
- [ ] The documentation has been updated to reflect the new feature

## Additional Notes
#2240
<!-- Any additional information or context relevant to this PR. -->
