### PR TITLE
Fix mobile toggle placeholder overlapping issue

### DIFF
--- a/packages/core/src/editor/Block.css
+++ b/packages/core/src/editor/Block.css
@@ -1,6 +1,18 @@
 /*
 BASIC STYLES
 */
+/* Fix placeholder alignment on mobile */
+@media (max-width: 600px) {
+  .bn-inline-content:has(> .ProseMirror-trailingBreak:only-child)::before {
+    position: relative !important;
+    top: 0 !important;
+    left: 0 !important;
+    margin-left: 4px !important;
+    display: inline-block !important;
+    line-height: inherit !important;
+  }
+}
+
 
 .bn-block-outer {
   line-height: 1.5;
@@ -33,8 +45,8 @@ BASIC STYLES
   transition: all 0.2s;
   /* Workaround for selection issue on Chrome, see #1588 and also here:
   https://discuss.prosemirror.net/t/mouse-down-selection-behaviour-different-on-chrome/8426
-  The :before element causes the selection to be set in the wrong place vs 
-  other browsers. Setting no height fixes this, while list item indicators are 
+  The :before element causes the selection to be set in the wrong place vs
+  other browsers. Setting no height fixes this, while list item indicators are
   still displayed fine as overflow is not hidden. */
   height: 0;
   overflow: visible;


### PR DESCRIPTION
# Summary

This PR fixes an issue where the placeholder element overlaps the second list item on mobile devices when the first toggle list item is collapsed.

## Rationale

- On screens ≤ 600px, the .ProseMirror-trailingBreak placeholder was positioned incorrectly, causing visual overlap.
- This affected usability when editing toggle lists in mobile view.


## Changes

- Added responsive CSS to reposition the trailing placeholder element.
- Ensured placeholder displays inline and maintains proper spacing on mobile.
- Updated Block.css with a mobile-specific rule:

``` @media (max-width: 600px) {
  .bn-inline-content:has(> .ProseMirror-trailingBreak:only-child)::before {
    position: relative !important;
    top: 0 !important;
    left: 0 !important;
    margin-left: 4px !important;
    display: inline-block !important;
    line-height: inherit !important;
  }
}
```


## Impact

- No breaking changes.
- Desktop behavior is unchanged.
- Fixes overlapping visual bug for mobile users.

## Testing

- Manual tests performed:
- Created a toggle list with multiple items.
- Collapsed the first item.
- Verified no overlapping placeholder text on mobile viewport (≤ 600px).

## Screenshots/Video

 Before
<img width="914" height="508" alt="image" src="https://github.com/user-attachments/assets/ab927fbd-137c-49e9-9032-d54c7a1316d5" />
After
<img width="472" height="762" alt="image" src="https://github.com/user-attachments/assets/d936c8f6-2e07-4e25-baad-937c37202b75" />


## Checklist

- [ x] Code follows the project's coding standards.
- [ ] Unit tests covering the new feature have been added.
- [ ] All existing tests pass.
- [x ] The documentation has been updated to reflect the new feature

## Additional Notes

<!-- Any additional information or context relevant to this PR. -->
