### PR TITLE
fix: pass dragHandleMenu prop to DragHandleButton

### DIFF
--- a/packages/react/src/components/SideMenu/SideMenu.tsx
+++ b/packages/react/src/components/SideMenu/SideMenu.tsx
@@ -58,7 +58,7 @@ export const SideMenu = (props: SideMenuProps & { children?: ReactNode }) => {
       {props.children || (
         <>
           <AddBlockButton />
-          <DragHandleButton />
+          <DragHandleButton dragHandleMenu={props.dragHandleMenu} />
         </>
       )}
     </Components.SideMenu.Root>


### PR DESCRIPTION
# Summary

Making sure to pass `dragHandleMenu` prop to `DragHandleButton` as expected 