### PR TITLE
Catch failure on getting block position.

### DIFF
--- a/packages/react/src/schema/ReactBlockSpec.tsx
+++ b/packages/react/src/schema/ReactBlockSpec.tsx
@@ -262,15 +262,24 @@ export function createReactBlockSpec<
                 // only created once, so the block we get in the node view will
                 // be outdated. Therefore, we have to get the block in the
                 // `ReactNodeViewRenderer` instead.
-                const block = getBlockFromPos(
-                  props.getPos,
-                  editor,
-                  props.editor,
-                  blockConfig.type,
-                );
+                let block;
+                try {
+                  block = getBlockFromPos(
+                    props.getPos,
+                    editor,
+                    props.editor,
+                    blockConfig.type,
+                  );
+                } catch (error) {
+                  console.error("Error getting block from pos:", error);
+                }
 
                 const ref = useReactNodeView().nodeViewContentRef;
 
+                if (!block) {
+                  return
+                }
+                
                 if (!ref) {
                   throw new Error("nodeViewContentRef is not set");
                 }


### PR DESCRIPTION
# Summary

<!-- Briefly describe the feature being introduced. -->
I was encountering a similar problem to this issue: https://github.com/TypeCellOS/BlockNote/issues/2106 but when I unmounted the BlockNoteView.

The problem seems to be that when the view is unmounted, the react view renderer tries to render the node one more time (not sure why). But the node still exists as does the reference, but it has been disconnected from it's parent (the document tree), causing the `getBlockFromPos` call to fail. So instead catching this failure and early exiting the `render` method prevents this from happening.

A simple way to test this is to create a schema with a block created using `createReactBlockSpec` - then add one of those blocks to the blocknote view. If you put the blocknote view in a toggleable state (i.e. in a popout panel) it will throw the `cannot find node at position` error when you unmount the blocknote view programmatically.

## Rationale

<!-- Explain the reasoning behind this feature and its benefits to the project. -->

## Changes

<!-- List the major changes made in this pull request. -->

## Impact

<!-- Discuss any potential impacts this feature may have on existing functionalities. -->

## Testing

<!-- Describe how the feature has been tested, including both automated and manual testing strategies. -->

## Screenshots/Video

<!-- Include screenshots or video demonstrating the new feature, if applicable. -->

## Checklist

- [ ] Code follows the project's coding standards.
- [ ] Unit tests covering the new feature have been added.
- [ ] All existing tests pass.
- [ ] The documentation has been updated to reflect the new feature

## Additional Notes

<!-- Any additional information or context relevant to this PR. -->
