### PR TITLE
fix: always include the cursor extension #2244

### DIFF
--- a/packages/core/src/editor/managers/ExtensionManager/extensions.ts
+++ b/packages/core/src/editor/managers/ExtensionManager/extensions.ts
@@ -191,11 +191,9 @@ export function getDefaultExtensions(
 
   if (options.collaboration) {
     extensions.push(ForkYDocExtension(options.collaboration));
-    if (options.collaboration.provider?.awareness) {
-      extensions.push(YCursorExtension(options.collaboration));
-    }
+    extensions.push(YCursorExtension(options.collaboration));
     extensions.push(YSyncExtension(options.collaboration));
-    extensions.push(YUndoExtension(options.collaboration));
+    extensions.push(YUndoExtension());
     extensions.push(SchemaMigration(options.collaboration));
   } else {
     // YUndo is not compatible with ProseMirror's history plugin

--- a/packages/core/src/extensions/Collaboration/ForkYDoc.ts
+++ b/packages/core/src/extensions/Collaboration/ForkYDoc.ts
@@ -107,7 +107,7 @@ export const ForkYDocExtension = createExtension(
         editor.registerExtension([
           YSyncExtension(newOptions),
           // No need to register the cursor plugin again, it's a local fork
-          YUndoExtension({}),
+          YUndoExtension(),
         ]);
 
         // Tell the store that the editor is now forked
@@ -131,7 +131,7 @@ export const ForkYDocExtension = createExtension(
         editor.registerExtension([
           YSyncExtension(options),
           YCursorExtension(options),
-          YUndoExtension({}),
+          YUndoExtension(),
         ]);
 
         // Reset the undo stack to the original undo stack

--- a/packages/core/src/extensions/Collaboration/YCursorPlugin.ts
+++ b/packages/core/src/extensions/Collaboration/YCursorPlugin.ts
@@ -73,12 +73,11 @@ export const YCursorExtension = createExtension(
     NonNullable<BlockNoteEditorOptions<any, any, any>["collaboration"]>
   >) => {
     const recentlyUpdatedCursors = new Map();
-
-    if (
+    const hasAwareness =
       options.provider &&
       "awareness" in options.provider &&
-      typeof options.provider.awareness === "object"
-    ) {
+      typeof options.provider.awareness === "object";
+    if (hasAwareness) {
       if (
         "setLocalStateField" in options.provider.awareness &&
         typeof options.provider.awareness.setLocalStateField === "function"
@@ -126,54 +125,56 @@ export const YCursorExtension = createExtension(
     return {
       key: "yCursor",
       prosemirrorPlugins: [
-        yCursorPlugin(options.provider.awareness, {
-          selectionBuilder: defaultSelectionBuilder,
-          cursorBuilder(user: CollaborationUser, clientID: number) {
-            let cursorData = recentlyUpdatedCursors.get(clientID);
+        hasAwareness
+          ? yCursorPlugin(options.provider.awareness, {
+              selectionBuilder: defaultSelectionBuilder,
+              cursorBuilder(user: CollaborationUser, clientID: number) {
+                let cursorData = recentlyUpdatedCursors.get(clientID);
 
-            if (!cursorData) {
-              const cursorElement = (
-                options.renderCursor ?? defaultCursorRender
-              )(user);
+                if (!cursorData) {
+                  const cursorElement = (
+                    options.renderCursor ?? defaultCursorRender
+                  )(user);
 
-              if (options.showCursorLabels !== "always") {
-                cursorElement.addEventListener("mouseenter", () => {
-                  const cursor = recentlyUpdatedCursors.get(clientID)!;
-                  cursor.element.setAttribute("data-active", "");
+                  if (options.showCursorLabels !== "always") {
+                    cursorElement.addEventListener("mouseenter", () => {
+                      const cursor = recentlyUpdatedCursors.get(clientID)!;
+                      cursor.element.setAttribute("data-active", "");
 
-                  if (cursor.hideTimeout) {
-                    clearTimeout(cursor.hideTimeout);
-                    recentlyUpdatedCursors.set(clientID, {
-                      element: cursor.element,
-                      hideTimeout: undefined,
+                      if (cursor.hideTimeout) {
+                        clearTimeout(cursor.hideTimeout);
+                        recentlyUpdatedCursors.set(clientID, {
+                          element: cursor.element,
+                          hideTimeout: undefined,
+                        });
+                      }
+                    });
+
+                    cursorElement.addEventListener("mouseleave", () => {
+                      const cursor = recentlyUpdatedCursors.get(clientID)!;
+
+                      recentlyUpdatedCursors.set(clientID, {
+                        element: cursor.element,
+                        hideTimeout: setTimeout(() => {
+                          cursor.element.removeAttribute("data-active");
+                        }, 2000),
+                      });
                     });
                   }
-                });
 
-                cursorElement.addEventListener("mouseleave", () => {
-                  const cursor = recentlyUpdatedCursors.get(clientID)!;
+                  cursorData = {
+                    element: cursorElement,
+                    hideTimeout: undefined,
+                  };
 
-                  recentlyUpdatedCursors.set(clientID, {
-                    element: cursor.element,
-                    hideTimeout: setTimeout(() => {
-                      cursor.element.removeAttribute("data-active");
-                    }, 2000),
-                  });
-                });
-              }
+                  recentlyUpdatedCursors.set(clientID, cursorData);
+                }
 
-              cursorData = {
-                element: cursorElement,
-                hideTimeout: undefined,
-              };
-
-              recentlyUpdatedCursors.set(clientID, cursorData);
-            }
-
-            return cursorData.element;
-          },
-        }),
-      ],
+                return cursorData.element;
+              },
+            })
+          : undefined,
+      ].filter(Boolean),
       dependsOn: ["ySync"],
       updateUser(user: { name: string; color: string; [key: string]: string }) {
         options.provider.awareness.setLocalStateField("user", user);

--- a/packages/core/src/extensions/Collaboration/YUndo.ts
+++ b/packages/core/src/extensions/Collaboration/YUndo.ts
@@ -1,10 +1,10 @@
 import { redoCommand, undoCommand, yUndoPlugin } from "y-prosemirror";
 import { createExtension } from "../../editor/BlockNoteExtension.js";
 
-export const YUndoExtension = createExtension(({ editor }) => {
+export const YUndoExtension = createExtension(() => {
   return {
     key: "yUndo",
-    prosemirrorPlugins: [yUndoPlugin({ trackedOrigins: [editor] })],
+    prosemirrorPlugins: [yUndoPlugin()],
     dependsOn: ["yCursor", "ySync"],
     undoCommand: undoCommand,
     redoCommand: redoCommand,


### PR DESCRIPTION
# Summary

Since extensions can depend on one another, I think that we need for this extension to always be present if in collab mode, and just remove the prosemirror plugin if it should not actually apply to the current editor.
<!-- Briefly describe the feature being introduced. -->

## Rationale

<!-- Explain the reasoning behind this feature and its benefits to the project. -->

## Changes

<!-- List the major changes made in this pull request. -->

## Impact

<!-- Discuss any potential impacts this feature may have on existing functionalities. -->

## Testing

<!-- Describe how the feature has been tested, including both automated and manual testing strategies. -->

## Screenshots/Video

<!-- Include screenshots or video demonstrating the new feature, if applicable. -->

## Checklist

- [ ] Code follows the project's coding standards.
- [ ] Unit tests covering the new feature have been added.
- [ ] All existing tests pass.
- [ ] The documentation has been updated to reflect the new feature

## Additional Notes

<!-- Any additional information or context relevant to this PR. -->

#2244 