### PR TITLE
fix: if there is no table block, there is no table handles to show #1055

### DIFF
--- a/packages/core/src/extensions/TableHandles/TableHandles.ts
+++ b/packages/core/src/extensions/TableHandles/TableHandles.ts
@@ -621,12 +621,16 @@ export const TableHandlesExtension = createExtension(({ editor }) => {
         key: tableHandlesPluginKey,
         view: (editorView) => {
           view = new TableHandlesView(editor as any, editorView, (state) => {
-            store.setState({
-              ...state,
-              draggingState: state.draggingState
-                ? { ...state.draggingState }
+            store.setState(
+              state.block
+                ? {
+                    ...state,
+                    draggingState: state.draggingState
+                      ? { ...state.draggingState }
+                      : undefined,
+                  }
                 : undefined,
-            });
+            );
           });
           return view;
         },


### PR DESCRIPTION
# Summary
This fixes a bug where you could not delete a table block if your mouse was already hovering over a table handle #1055
<!-- Briefly describe the feature being introduced. -->

## Rationale

<!-- Explain the reasoning behind this feature and its benefits to the project. -->

## Changes

<!-- List the major changes made in this pull request. -->

## Impact

<!-- Discuss any potential impacts this feature may have on existing functionalities. -->

## Testing

<!-- Describe how the feature has been tested, including both automated and manual testing strategies. -->

## Screenshots/Video

<!-- Include screenshots or video demonstrating the new feature, if applicable. -->

## Checklist

- [ ] Code follows the project's coding standards.
- [ ] Unit tests covering the new feature have been added.
- [ ] All existing tests pass.
- [ ] The documentation has been updated to reflect the new feature

## Additional Notes

<!-- Any additional information or context relevant to this PR. -->
