### PR TITLE
fix: filter the default tiptap extensions #2282

### DIFF
--- a/packages/core/src/editor/managers/ExtensionManager/index.ts
+++ b/packages/core/src/editor/managers/ExtensionManager/index.ts
@@ -317,8 +317,7 @@ export class ExtensionManager {
     const tiptapExtensions = getDefaultTiptapExtensions(
       this.editor,
       this.options,
-    );
-    // TODO filter out the default extensions via the disabledExtensions set?
+    ).filter((extension) => !this.disabledExtensions.has(extension.name));
 
     const getPriority = sortByDependencies(this.extensions);
 


### PR DESCRIPTION
# Summary
Filter out the default tiptap extensions according to the `disableExtensions` array in EditorOptions #2282
<!-- Briefly describe the feature being introduced. -->

## Rationale

<!-- Explain the reasoning behind this feature and its benefits to the project. -->

## Changes

<!-- List the major changes made in this pull request. -->

## Impact

<!-- Discuss any potential impacts this feature may have on existing functionalities. -->

## Testing

<!-- Describe how the feature has been tested, including both automated and manual testing strategies. -->

## Screenshots/Video

<!-- Include screenshots or video demonstrating the new feature, if applicable. -->

## Checklist

- [ ] Code follows the project's coding standards.
- [ ] Unit tests covering the new feature have been added.
- [ ] All existing tests pass.
- [ ] The documentation has been updated to reflect the new feature

## Additional Notes

<!-- Any additional information or context relevant to this PR. -->
