### PR TITLE
fix: Make quote blocks isolating

### DIFF
--- a/packages/core/src/blocks/Quote/block.ts
+++ b/packages/core/src/blocks/Quote/block.ts
@@ -23,9 +23,6 @@ export const createQuoteBlockConfig = createBlockConfig(
 export const createQuoteBlockSpec = createBlockSpec(
   createQuoteBlockConfig,
   {
-    meta: {
-      isolating: false,
-    },
     parse(element) {
       if (element.tagName === "BLOCKQUOTE") {
         const { backgroundColor, textColor } = parseDefaultProps(element);

--- a/tests/src/unit/core/clipboard/paste/__snapshots__/text/html/pasteEmptyQuote.json
+++ b/tests/src/unit/core/clipboard/paste/__snapshots__/text/html/pasteEmptyQuote.json
@@ -1,0 +1,18 @@
+[
+  {
+    "children": [],
+    "content": [
+      {
+        "styles": {},
+        "text": "Paragraph",
+        "type": "text",
+      },
+    ],
+    "id": "1",
+    "props": {
+      "backgroundColor": "default",
+      "textColor": "default",
+    },
+    "type": "quote",
+  },
+]

--- a/tests/src/unit/core/clipboard/paste/pasteTestInstances.ts
+++ b/tests/src/unit/core/clipboard/paste/pasteTestInstances.ts
@@ -10,7 +10,10 @@ import {
   testPasteHTML,
   testPasteMarkdown,
 } from "../../../shared/clipboard/paste/pasteTestExecutors.js";
-import { getPosOfTextNode } from "../../../shared/testUtil.js";
+import {
+  getPosInEmptyBlockContentNode,
+  getPosOfTextNode,
+} from "../../../shared/testUtil.js";
 import { TestInstance } from "../../../types.js";
 
 export const pasteTestInstancesHTML: TestInstance<
@@ -131,6 +134,23 @@ export const pasteTestInstancesHTML: TestInstance<
       ],
       getPasteSelection: (doc) => {
         const startPos = getPosOfTextNode(doc, "Custom Paragraph 1", true);
+
+        return TextSelection.create(doc, startPos);
+      },
+    },
+    executeTest: testPasteHTML,
+  },
+  {
+    testCase: {
+      name: "pasteEmptyQuote",
+      content: `<p>Paragraph</p>`,
+      document: [
+        {
+          type: "quote",
+        },
+      ],
+      getPasteSelection: (doc) => {
+        const startPos = getPosInEmptyBlockContentNode(doc, "quote");
 
         return TextSelection.create(doc, startPos);
       },

--- a/tests/src/unit/core/schema/__snapshots__/blocks.json
+++ b/tests/src/unit/core/schema/__snapshots__/blocks.json
@@ -434,9 +434,6 @@
       [Function],
     ],
     "implementation": {
-      "meta": {
-        "isolating": false,
-      },
       "node": null,
       "parse": [Function],
       "render": [Function],

--- a/tests/src/unit/shared/testUtil.ts
+++ b/tests/src/unit/shared/testUtil.ts
@@ -34,6 +34,32 @@ export const getPosOfTextNode = (
   return ret;
 };
 
+// Helper function to get the position inside an empty block content node with
+// the given type.
+export const getPosInEmptyBlockContentNode = (
+  doc: Node,
+  blockContentType: string,
+) => {
+  let ret: number | undefined = undefined;
+
+  doc.descendants((node, pos) => {
+    if (node.type.name === blockContentType && node.childCount === 0) {
+      ret = pos + 1;
+      return false;
+    }
+
+    return ret === undefined;
+  });
+
+  if (ret === undefined) {
+    throw new Error(
+      `Block content node with type "${blockContentType}" not found.`,
+    );
+  }
+
+  return ret;
+};
+
 // Helper function to get the position of a table cell node with given text
 // content. Returns the position just before the node.
 export const getPosOfTableCellNode = (doc: Node, textContent: string) => {


### PR DESCRIPTION
# Summary

<!-- Briefly describe the feature being introduced. -->

This PR makes quote blocks isolating. That means when pasting content into an empty quote block, it won't overwrite the block type to that of the clipboard content.

Closes #2236 

## Rationale

<!-- Explain the reasoning behind this feature and its benefits to the project. -->

There is a scenario where the user wants to paste some text for a quote, so they create a new quote block using the slash menu. They then paste the quoted text into the newly created block, and the type changes to something else. This is not great for UX.

## Changes

<!-- List the major changes made in this pull request. -->

- Added `isolating` flag to quote block.

## Impact

<!-- Discuss any potential impacts this feature may have on existing functionalities. -->

N/A

## Testing

<!-- Describe how the feature has been tested, including both automated and manual testing strategies. -->

We already have tests for pasting in custom blocks which are isolating.

## Screenshots/Video

<!-- Include screenshots or video demonstrating the new feature, if applicable. -->

N/A

## Checklist

- [X] Code follows the project's coding standards.
- [X] Unit tests covering the new feature have been added.
- [X] All existing tests pass.
- [X] The documentation has been updated to reflect the new feature

## Additional Notes

<!-- Any additional information or context relevant to this PR. -->
