### PR TITLE
fix(email-exporter): ReadableByteStreamController for safari react-email

### DIFF
--- a/packages/xl-email-exporter/package.json
+++ b/packages/xl-email-exporter/package.json
@@ -54,6 +54,7 @@
     "email": "email dev"
   },
   "dependencies": {
+    "web-streams-polyfill": "^4.2.0",
     "@blocknote/core": "0.44.2",
     "@blocknote/react": "0.44.2",
     "@react-email/components": "^0.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5336,6 +5336,9 @@ importers:
       react-email:
         specifier: ^4.3.0
         version: 4.3.0
+      web-streams-polyfill:
+        specifier: ^4.2.0
+        version: 4.2.0
     devDependencies:
       '@types/jsdom':
         specifier: ^21.1.7
@@ -15626,6 +15629,10 @@ packages:
 
   web-namespaces@2.0.1:
     resolution: {integrity: sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==}
+
+  web-streams-polyfill@4.2.0:
+    resolution: {integrity: sha512-0rYDzGOh9EZpig92umN5g5D/9A1Kff7k0/mzPSSCY8jEQeYkgRMoY7LhbXtUCWzLCMX0TUE9aoHkjFNB7D9pfA==}
+    engines: {node: '>= 8'}
 
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
@@ -27939,6 +27946,8 @@ snapshots:
       defaults: 1.0.4
 
   web-namespaces@2.0.1: {}
+
+  web-streams-polyfill@4.2.0: {}
 
   webidl-conversions@3.0.1: {}
 


### PR DESCRIPTION
# Summary

fixes react-email compatibility on safari

## Rationale

See notice here: https://github.com/resend/react-email/blob/f02e21e998d507aa3fdfbb7b8639f915b8df6cb5/apps/docs/utilities/render.mdx#3-convert-to-html or reproduce the error in the email-exporter playground

## Changes

Add a polyfill for `ReadableByteStreamController`

## Impact

Resetting the polyfill should make sure there's no outside impact

## Testing

Tested running the example in safari

## Checklist

- [x] Code follows the project's coding standards.
- [ ] Unit tests covering the new feature have been added.
- [x] All existing tests pass.
- [ ] The documentation has been updated to reflect the new feature

