### PR TITLE
feat: Versioning & suggesting changes example

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -103,7 +103,8 @@
     "twoslash": "^0.3.4",
     "y-partykit": "^0.0.25",
     "yjs": "^13.6.27",
-    "zod": "^3.25.76"
+    "zod": "^3.25.76",
+    "@floating-ui/react": "^0.27.16"
   },
   "devDependencies": {
     "@blocknote/ariakit": "workspace:*",

--- a/examples/07-collaboration/09-versioning/.bnexample.json
+++ b/examples/07-collaboration/09-versioning/.bnexample.json
@@ -4,7 +4,7 @@
   "author": "matthewlipski",
   "tags": ["Advanced", "Development", "Collaboration"],
   "dependencies": {
-    "y-partykit": "^0.0.25",
+    "react-icons": "^5.2.1",
     "yjs": "^13.6.27"
   }
 }

--- a/examples/07-collaboration/09-versioning/.bnexample.json
+++ b/examples/07-collaboration/09-versioning/.bnexample.json
@@ -1,0 +1,10 @@
+{
+  "playground": true,
+  "docs": true,
+  "author": "matthewlipski",
+  "tags": ["Advanced", "Development", "Collaboration"],
+  "dependencies": {
+    "y-partykit": "^0.0.25",
+    "yjs": "^13.6.27"
+  }
+}

--- a/examples/07-collaboration/09-versioning/.bnexample.json
+++ b/examples/07-collaboration/09-versioning/.bnexample.json
@@ -4,6 +4,7 @@
   "author": "matthewlipski",
   "tags": ["Advanced", "Development", "Collaboration"],
   "dependencies": {
+    "@floating-ui/react": "^0.27.16",
     "react-icons": "^5.2.1",
     "yjs": "^13.6.27"
   }

--- a/examples/07-collaboration/09-versioning/README.md
+++ b/examples/07-collaboration/09-versioning/README.md
@@ -1,0 +1,9 @@
+# Collaborative Editing with Versioning
+
+In this example, we can save snapshots of the document that we can later preview and revert to. 
+
+**Try it out:** Press the save button in the versioning sidebar to save a document snapshot!
+
+**Relevant Docs:**
+
+- [Editor Setup](/docs/getting-started/editor-setup)

--- a/examples/07-collaboration/09-versioning/README.md
+++ b/examples/07-collaboration/09-versioning/README.md
@@ -1,9 +1,15 @@
-# Collaborative Editing with Versioning
+# Collaborative Editing Features Showcase
 
-In this example, we can save snapshots of the document that we can later preview and revert to. 
+In this example, you can play with all of the collaboration features BlockNote has to offer:
 
-**Try it out:** Press the save button in the versioning sidebar to save a document snapshot!
+**Comments**: Add comments to parts of the document - other users can then view, reply to, react to, and resolve them.
+
+**Versioning**: Save snapshots of the document - later preview saved snapshots and restore them to ensure work is never lost.
+
+**Suggestions**: Suggest changes directly in the editor - users can choose to then apply or reject those changes.
 
 **Relevant Docs:**
 
 - [Editor Setup](/docs/getting-started/editor-setup)
+- [Comments](/docs/features/collaboration/comments)
+- [Real-time collaboration](/docs/features/collaboration)

--- a/examples/07-collaboration/09-versioning/index.html
+++ b/examples/07-collaboration/09-versioning/index.html
@@ -1,0 +1,14 @@
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Collaborative Editing with Versioning</title>
+    <script>
+      <!-- AUTO-GENERATED FILE, DO NOT EDIT DIRECTLY -->
+    </script>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="./main.tsx"></script>
+  </body>
+</html>

--- a/examples/07-collaboration/09-versioning/index.html
+++ b/examples/07-collaboration/09-versioning/index.html
@@ -2,7 +2,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Collaborative Editing with Versioning</title>
+    <title>Collaborative Editing Features Showcase</title>
     <script>
       <!-- AUTO-GENERATED FILE, DO NOT EDIT DIRECTLY -->
     </script>

--- a/examples/07-collaboration/09-versioning/main.tsx
+++ b/examples/07-collaboration/09-versioning/main.tsx
@@ -1,0 +1,11 @@
+// AUTO-GENERATED FILE, DO NOT EDIT DIRECTLY
+import React from "react";
+import { createRoot } from "react-dom/client";
+import App from "./src/App.jsx";
+
+const root = createRoot(document.getElementById("root")!);
+root.render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/examples/07-collaboration/09-versioning/package.json
+++ b/examples/07-collaboration/09-versioning/package.json
@@ -21,6 +21,7 @@
     "@mantine/utils": "^6.0.22",
     "react": "^19.2.1",
     "react-dom": "^19.2.1",
+    "@floating-ui/react": "^0.27.16",
     "react-icons": "^5.2.1",
     "yjs": "^13.6.27"
   },

--- a/examples/07-collaboration/09-versioning/package.json
+++ b/examples/07-collaboration/09-versioning/package.json
@@ -21,7 +21,7 @@
     "@mantine/utils": "^6.0.22",
     "react": "^19.2.1",
     "react-dom": "^19.2.1",
-    "y-partykit": "^0.0.25",
+    "react-icons": "^5.2.1",
     "yjs": "^13.6.27"
   },
   "devDependencies": {

--- a/examples/07-collaboration/09-versioning/package.json
+++ b/examples/07-collaboration/09-versioning/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "@blocknote/example-collaboration-versioning",
+  "description": "AUTO-GENERATED FILE, DO NOT EDIT DIRECTLY",
+  "type": "module",
+  "private": true,
+  "version": "0.12.4",
+  "scripts": {
+    "start": "vite",
+    "dev": "vite",
+    "build:prod": "tsc && vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@blocknote/ariakit": "latest",
+    "@blocknote/core": "latest",
+    "@blocknote/mantine": "latest",
+    "@blocknote/react": "latest",
+    "@blocknote/shadcn": "latest",
+    "@mantine/core": "^8.3.4",
+    "@mantine/hooks": "^8.3.4",
+    "@mantine/utils": "^6.0.22",
+    "react": "^19.2.1",
+    "react-dom": "^19.2.1",
+    "y-partykit": "^0.0.25",
+    "yjs": "^13.6.27"
+  },
+  "devDependencies": {
+    "@types/react": "^19.2.2",
+    "@types/react-dom": "^19.2.2",
+    "@vitejs/plugin-react": "^4.7.0",
+    "vite": "^5.4.20"
+  }
+}

--- a/examples/07-collaboration/09-versioning/src/App.tsx
+++ b/examples/07-collaboration/09-versioning/src/App.tsx
@@ -155,32 +155,34 @@ export default function App() {
                     isSelected: user.id === activeUser.id,
                   }))}
                 />
-                <SettingsSelect
-                  label={"Mode"}
-                  items={[
-                    {
-                      text: "Editing",
-                      icon: null,
-                      onClick: () => {
-                        disableSuggestions();
-                        setEditingMode("editing");
+                {activeUser.role === "editor" && (
+                  <SettingsSelect
+                    label={"Mode"}
+                    items={[
+                      {
+                        text: "Editing",
+                        icon: null,
+                        onClick: () => {
+                          disableSuggestions();
+                          setEditingMode("editing");
+                        },
+                        isSelected: editingMode === "editing",
                       },
-                      isSelected: editingMode === "editing",
-                    },
-                    {
-                      text: "Suggestions",
-                      icon: null,
-                      onClick: () => {
-                        enableSuggestions();
-                        setEditingMode("suggestions");
+                      {
+                        text: "Suggestions",
+                        icon: null,
+                        onClick: () => {
+                          enableSuggestions();
+                          setEditingMode("suggestions");
+                        },
+                        isSelected: editingMode === "suggestions",
                       },
-                      isSelected: editingMode === "suggestions",
-                    },
-                  ]}
-                />
-                {editingMode === "suggestions" && hasUnresolvedSuggestions && (
-                  <SuggestionActions />
+                    ]}
+                  />
                 )}
+                {activeUser.role === "editor" &&
+                  editingMode === "suggestions" &&
+                  hasUnresolvedSuggestions && <SuggestionActions />}
               </div>
             )}
             {/* Because we set `renderEditor` to false, we can now manually place

--- a/examples/07-collaboration/09-versioning/src/App.tsx
+++ b/examples/07-collaboration/09-versioning/src/App.tsx
@@ -6,23 +6,21 @@ import {
 import {
   BlockNoteViewEditor,
   useCreateBlockNote,
+  useExtensionState,
   VersioningSidebar,
 } from "@blocknote/react";
 import { BlockNoteView } from "@blocknote/mantine";
 import "@blocknote/mantine/style.css";
+import * as Y from "yjs";
 
 import "./style.css";
-// import YPartyKitProvider from "y-partykit/provider";
-import * as Y from "yjs";
 
 const doc = new Y.Doc();
 
 export default function App() {
   const editor = useCreateBlockNote({
     collaboration: {
-      // Where to store BlockNote data in the Y.Doc:
       fragment: doc.getXmlFragment(),
-      // Information (name and color) for this user:
       user: {
         name: "My Username",
         color: "#ff0000",
@@ -36,7 +34,10 @@ export default function App() {
     ],
   });
 
-  // Renders the editor instance.
+  const { selectedSnapshotId } = useExtensionState(VersioningExtension, {
+    editor,
+  });
+
   return (
     <BlockNoteView
       className={"version-history-main-container"}
@@ -45,7 +46,7 @@ export default function App() {
       onChange={() => console.log(doc.getXmlFragment().toJSON())}
     >
       <div className={"editor-section"}>
-        <h1>Editor</h1>
+        <h1>Editor {selectedSnapshotId !== undefined ? "(Preview)" : ""}</h1>
         <BlockNoteViewEditor />
       </div>
       <div className={"version-history-section"}>

--- a/examples/07-collaboration/09-versioning/src/App.tsx
+++ b/examples/07-collaboration/09-versioning/src/App.tsx
@@ -1,0 +1,57 @@
+import "@blocknote/core/fonts/inter.css";
+import {
+  localStorageEndpoints,
+  VersioningExtension,
+} from "@blocknote/core/extensions";
+import {
+  BlockNoteViewEditor,
+  useCreateBlockNote,
+  VersioningSidebar,
+} from "@blocknote/react";
+import { BlockNoteView } from "@blocknote/mantine";
+import "@blocknote/mantine/style.css";
+
+import "./style.css";
+// import YPartyKitProvider from "y-partykit/provider";
+import * as Y from "yjs";
+
+const doc = new Y.Doc();
+
+export default function App() {
+  const editor = useCreateBlockNote({
+    collaboration: {
+      // Where to store BlockNote data in the Y.Doc:
+      fragment: doc.getXmlFragment(),
+      // Information (name and color) for this user:
+      user: {
+        name: "My Username",
+        color: "#ff0000",
+      },
+    },
+    extensions: [
+      VersioningExtension({
+        endpoints: localStorageEndpoints,
+        fragment: doc.getXmlFragment(),
+      }),
+    ],
+  });
+
+  // Renders the editor instance.
+  return (
+    <BlockNoteView
+      className={"version-history-main-container"}
+      editor={editor}
+      renderEditor={false}
+      onChange={() => console.log(doc.getXmlFragment().toJSON())}
+    >
+      <div className={"editor-section"}>
+        <h1>Editor</h1>
+        <BlockNoteViewEditor />
+      </div>
+      <div className={"version-history-section"}>
+        <h1>Version History</h1>
+        <VersioningSidebar />
+      </div>
+    </BlockNoteView>
+  );
+}

--- a/examples/07-collaboration/09-versioning/src/App.tsx
+++ b/examples/07-collaboration/09-versioning/src/App.tsx
@@ -5,28 +5,62 @@ import {
 } from "@blocknote/core/extensions";
 import {
   BlockNoteViewEditor,
+  FloatingComposerController,
   useCreateBlockNote,
+  useExtension,
   useExtensionState,
-  VersioningSidebar,
 } from "@blocknote/react";
 import { BlockNoteView } from "@blocknote/mantine";
 import "@blocknote/mantine/style.css";
+import { useMemo, useState } from "react";
+import { RiChat3Line, RiHistoryLine } from "react-icons/ri";
 import * as Y from "yjs";
 
+import { getRandomColor, HARDCODED_USERS, MyUserType } from "./userdata";
+import { SettingsSelect } from "./SettingsSelect";
 import "./style.css";
+import {
+  YjsThreadStore,
+  DefaultThreadStoreAuth,
+  CommentsExtension,
+} from "@blocknote/core/comments";
+
+import { CommentsSidebar } from "./CommentsSidebar";
+import { VersionHistorySidebar } from "./VersionHistorySidebar";
 
 const doc = new Y.Doc();
 
+async function resolveUsers(userIds: string[]) {
+  // fake a (slow) network request
+  await new Promise((resolve) => setTimeout(resolve, 1000));
+
+  return HARDCODED_USERS.filter((user) => userIds.includes(user.id));
+}
+
 export default function App() {
+  const [activeUser, setActiveUser] = useState<MyUserType>(HARDCODED_USERS[0]);
+  const [editingMode, setEditingMode] = useState<"editing" | "suggestions">(
+    "editing",
+  );
+  const [sidebar, setSidebar] = useState<
+    "comments" | "versionHistory" | "none"
+  >("none");
+
+  const threadStore = useMemo(() => {
+    return new YjsThreadStore(
+      activeUser.id,
+      doc.getMap("threads"),
+      new DefaultThreadStoreAuth(activeUser.id, activeUser.role),
+    );
+  }, [doc, activeUser]);
+
   const editor = useCreateBlockNote({
     collaboration: {
       fragment: doc.getXmlFragment(),
-      user: {
-        name: "My Username",
-        color: "#ff0000",
-      },
+      user: { color: getRandomColor(), name: activeUser.username },
     },
     extensions: [
+      CommentsExtension({ threadStore, resolveUsers }),
       VersioningExtension({
         endpoints: localStorageEndpoints,
         fragment: doc.getXmlFragment(),
@@ -34,23 +68,112 @@ export default function App() {
     ],
   });
 
+  const { selectSnapshot } = useExtension(VersioningExtension, { editor });
   const { selectedSnapshotId } = useExtensionState(VersioningExtension, {
     editor,
   });
 
   return (
     <BlockNoteView
-      className={"version-history-main-container"}
+      className={"full-collaboration"}
       editor={editor}
+      editable={
+        (sidebar !== "versionHistory" || selectedSnapshotId === undefined) &&
+        activeUser.role === "editor"
+      }
+      // In other examples, `BlockNoteView` renders both editor element itself,
+      // and the container element which contains the necessary context for
+      // BlockNote UI components. However, in this example, we want more control
+      // over the rendering of the editor, so we set `renderEditor` to `false`.
+      // Now, `BlockNoteView` will only render the container element, and we can
+      // render the editor element anywhere we want using `BlockNoteEditorView`.
       renderEditor={false}
+      // We also disable the default rendering of comments in the editor, as we
+      // want to render them in the `ThreadsSidebar` component instead.
+      comments={sidebar !== "comments"}
     >
-      <div className={"editor-section"}>
-        <h1>Editor {selectedSnapshotId !== undefined ? "(Preview)" : ""}</h1>
-        <BlockNoteViewEditor />
-      </div>
-      <div className={"version-history-section"}>
-        <h1>Version History</h1>
-        <VersioningSidebar />
+      <div className="full-collaboration-main-container">
+        {/* We place the editor, the sidebar, and any settings selects within
+        `BlockNoteView` as they use BlockNote UI components and need the context
+        for them. */}
+        <div className={"editor-layout-wrapper"}>
+          <div className="sidebar-selectors">
+            <div
+              className={`sidebar-selector ${sidebar === "versionHistory" ? "selected" : ""}`}
+              onClick={() => {
+                setSidebar((sidebar) =>
+                  sidebar !== "versionHistory" ? "versionHistory" : "none",
+                );
+                selectSnapshot(undefined);
+              }}
+            >
+              <RiHistoryLine />
+              <span>Version History</span>
+            </div>
+            <div
+              className={`sidebar-selector ${sidebar === "comments" ? "selected" : ""}`}
+              onClick={() =>
+                setSidebar((sidebar) =>
+                  sidebar !== "comments" ? "comments" : "none",
+                )
+              }
+            >
+              <RiChat3Line />
+              <span>Comments</span>
+            </div>
+          </div>
+          <div className={"editor-section"}>
+            {/* <h1>Editor</h1> */}
+            {selectedSnapshotId === undefined && (
+              <div className={"settings"}>
+                <SettingsSelect
+                  label={"User"}
+                  items={HARDCODED_USERS.map((user) => ({
+                    text: `${user.username} (${
+                      user.role === "editor" ? "Editor" : "Commenter"
+                    })`,
+                    icon: null,
+                    onClick: () => {
+                      setActiveUser(user);
+                    },
+                    isSelected: user.id === activeUser.id,
+                  }))}
+                />
+                <SettingsSelect
+                  label={"Mode"}
+                  items={[
+                    {
+                      text: "Editing",
+                      icon: null,
+                      onClick: () => {
+                        setEditingMode("editing");
+                      },
+                      isSelected: editingMode === "editing",
+                    },
+                    {
+                      text: "Suggestions",
+                      icon: null,
+                      onClick: () => {
+                        setEditingMode("suggestions");
+                      },
+                      isSelected: editingMode === "suggestions",
+                    },
+                  ]}
+                />
+              </div>
+            )}
+            {/* Because we set `renderEditor` to false, we can now manually place
+            `BlockNoteViewEditor` (the actual editor component) in its own
+            section below the user settings select. */}
+            <BlockNoteViewEditor />
+            {/* Since we disabled rendering of comments with `comments={false}`,
+            we need to re-add the floating composer, which is the UI element that
+            appears when creating new threads. */}
+            {sidebar === "comments" && <FloatingComposerController />}
+          </div>
+        </div>
+        {sidebar === "comments" && <CommentsSidebar />}
+        {sidebar === "versionHistory" && <VersionHistorySidebar />}
       </div>
     </BlockNoteView>
   );

--- a/examples/07-collaboration/09-versioning/src/App.tsx
+++ b/examples/07-collaboration/09-versioning/src/App.tsx
@@ -43,7 +43,6 @@ export default function App() {
       className={"version-history-main-container"}
       editor={editor}
       renderEditor={false}
-      onChange={() => console.log(doc.getXmlFragment().toJSON())}
     >
       <div className={"editor-section"}>
         <h1>Editor {selectedSnapshotId !== undefined ? "(Preview)" : ""}</h1>

--- a/examples/07-collaboration/09-versioning/src/CommentsSidebar.tsx
+++ b/examples/07-collaboration/09-versioning/src/CommentsSidebar.tsx
@@ -1,0 +1,65 @@
+import { ThreadsSidebar } from "@blocknote/react";
+import { useState } from "react";
+
+import { SettingsSelect } from "./SettingsSelect";
+
+export const CommentsSidebar = () => {
+  const [filter, setFilter] = useState<"open" | "resolved" | "all">("open");
+  const [sort, setSort] = useState<"position" | "recent-activity" | "oldest">(
+    "position",
+  );
+
+  return (
+    <div className={"sidebar-section"}>
+      <div className={"settings"}>
+        <SettingsSelect
+          label={"Filter"}
+          items={[
+            {
+              text: "All",
+              icon: null,
+              onClick: () => setFilter("all"),
+              isSelected: filter === "all",
+            },
+            {
+              text: "Open",
+              icon: null,
+              onClick: () => setFilter("open"),
+              isSelected: filter === "open",
+            },
+            {
+              text: "Resolved",
+              icon: null,
+              onClick: () => setFilter("resolved"),
+              isSelected: filter === "resolved",
+            },
+          ]}
+        />
+        <SettingsSelect
+          label={"Sort"}
+          items={[
+            {
+              text: "Position",
+              icon: null,
+              onClick: () => setSort("position"),
+              isSelected: sort === "position",
+            },
+            {
+              text: "Recent activity",
+              icon: null,
+              onClick: () => setSort("recent-activity"),
+              isSelected: sort === "recent-activity",
+            },
+            {
+              text: "Oldest",
+              icon: null,
+              onClick: () => setSort("oldest"),
+              isSelected: sort === "oldest",
+            },
+          ]}
+        />
+      </div>
+      <ThreadsSidebar filter={filter} sort={sort} />
+    </div>
+  );
+};

--- a/examples/07-collaboration/09-versioning/src/SettingsSelect.tsx
+++ b/examples/07-collaboration/09-versioning/src/SettingsSelect.tsx
@@ -1,0 +1,24 @@
+import { ComponentProps, useComponentsContext } from "@blocknote/react";
+
+// This component is used to display a selection dropdown with a label. By using
+// the useComponentsContext hook, we can create it out of existing components
+// within the same UI library that `BlockNoteView` uses (Mantine, Ariakit, or
+// ShadCN), to match the design of the editor.
+export const SettingsSelect = (props: {
+  label: string;
+  items: ComponentProps["FormattingToolbar"]["Select"]["items"];
+}) => {
+  const Components = useComponentsContext()!;
+
+  return (
+    <div className={"settings-select"}>
+      <Components.Generic.Toolbar.Root className={"bn-toolbar"}>
+        <h2>{props.label + ":"}</h2>
+        <Components.Generic.Toolbar.Select
+          className={"bn-select"}
+          items={props.items}
+        />
+      </Components.Generic.Toolbar.Root>
+    </div>
+  );
+};

--- a/examples/07-collaboration/09-versioning/src/SuggestionActions.tsx
+++ b/examples/07-collaboration/09-versioning/src/SuggestionActions.tsx
@@ -1,0 +1,31 @@
+import { SuggestionsExtension } from "@blocknote/core/extensions";
+import { useComponentsContext, useExtension } from "@blocknote/react";
+import { RiArrowGoBackLine, RiCheckLine } from "react-icons/ri";
+
+export const SuggestionActions = () => {
+  const Components = useComponentsContext()!;
+
+  const { applyAllSuggestions, revertAllSuggestions } =
+    useExtension(SuggestionsExtension);
+
+  return (
+    <Components.Generic.Toolbar.Root className={"bn-toolbar"}>
+      <Components.Generic.Toolbar.Button
+        label="Apply All Changes"
+        icon={<RiCheckLine />}
+        onClick={() => applyAllSuggestions()}
+        mainTooltip="Apply All Changes"
+      >
+        {/* Apply All Changes */}
+      </Components.Generic.Toolbar.Button>
+      <Components.Generic.Toolbar.Button
+        label="Revert All Changes"
+        icon={<RiArrowGoBackLine />}
+        onClick={() => revertAllSuggestions()}
+        mainTooltip="Revert All Changes"
+      >
+        {/* Revert All Changes */}
+      </Components.Generic.Toolbar.Button>
+    </Components.Generic.Toolbar.Root>
+  );
+};

--- a/examples/07-collaboration/09-versioning/src/SuggestionActionsPopup.tsx
+++ b/examples/07-collaboration/09-versioning/src/SuggestionActionsPopup.tsx
@@ -1,0 +1,176 @@
+import { SuggestionsExtension } from "@blocknote/core/extensions";
+import {
+  FloatingUIOptions,
+  GenericPopover,
+  GenericPopoverReference,
+  useBlockNoteEditor,
+  useComponentsContext,
+  useExtension,
+} from "@blocknote/react";
+import { flip, offset, safePolygon } from "@floating-ui/react";
+import { useEffect, useMemo, useState } from "react";
+import { RiArrowGoBackLine, RiCheckLine } from "react-icons/ri";
+
+export const SuggestionActionsPopup = () => {
+  const Components = useComponentsContext()!;
+
+  const editor = useBlockNoteEditor<any, any, any>();
+
+  const [toolbarOpen, setToolbarOpen] = useState(false);
+
+  const {
+    applySuggestion,
+    getSuggestionAtCoords,
+    getSuggestionAtSelection,
+    getSuggestionElementAtPos,
+    revertSuggestion,
+  } = useExtension(SuggestionsExtension);
+
+  const [suggestion, setSuggestion] = useState<
+    | {
+        cursorType: "text" | "mouse";
+        id: string;
+        element: HTMLElement;
+      }
+    | undefined
+  >(undefined);
+
+  useEffect(() => {
+    const textCursorCallback = () => {
+      const textCursorSuggestion = getSuggestionAtSelection();
+      if (!textCursorSuggestion) {
+        setSuggestion(undefined);
+        setToolbarOpen(false);
+
+        return;
+      }
+
+      setSuggestion({
+        cursorType: "text",
+        id: textCursorSuggestion.mark.attrs.id as string,
+        element: getSuggestionElementAtPos(textCursorSuggestion.range.from)!,
+      });
+
+      setToolbarOpen(true);
+    };
+
+    const mouseCursorCallback = (event: MouseEvent) => {
+      if (suggestion !== undefined && suggestion.cursorType === "text") {
+        return;
+      }
+
+      if (!(event.target instanceof HTMLElement)) {
+        return;
+      }
+
+      const mouseCursorSuggestion = getSuggestionAtCoords({
+        left: event.clientX,
+        top: event.clientY,
+      });
+      if (!mouseCursorSuggestion) {
+        return;
+      }
+
+      const element = getSuggestionElementAtPos(
+        mouseCursorSuggestion.range.from,
+      )!;
+      if (element === suggestion?.element) {
+        return;
+      }
+
+      setSuggestion({
+        cursorType: "mouse",
+        id: mouseCursorSuggestion.mark.attrs.id as string,
+        element: getSuggestionElementAtPos(mouseCursorSuggestion.range.from)!,
+      });
+    };
+
+    const destroyOnChangeHandler = editor.onChange(textCursorCallback);
+    const destroyOnSelectionChangeHandler =
+      editor.onSelectionChange(textCursorCallback);
+
+    editor.domElement?.addEventListener("mousemove", mouseCursorCallback);
+
+    return () => {
+      destroyOnChangeHandler();
+      destroyOnSelectionChangeHandler();
+
+      editor.domElement?.removeEventListener("mousemove", mouseCursorCallback);
+    };
+  }, [editor.domElement, suggestion]);
+
+  const floatingUIOptions = useMemo<FloatingUIOptions>(
+    () => ({
+      useFloatingOptions: {
+        open: toolbarOpen,
+        onOpenChange: (open, _event, reason) => {
+          if (
+            suggestion !== undefined &&
+            suggestion.cursorType === "text" &&
+            reason === "hover"
+          ) {
+            return;
+          }
+
+          if (reason === "escape-key") {
+            editor.focus();
+          }
+
+          setToolbarOpen(open);
+        },
+        placement: "top-start",
+        middleware: [offset(10), flip()],
+      },
+      useHoverProps: {
+        enabled: suggestion !== undefined && suggestion.cursorType === "mouse",
+        delay: {
+          open: 250,
+          close: 250,
+        },
+        handleClose: safePolygon({
+          blockPointerEvents: true,
+        }),
+      },
+      elementProps: {
+        style: {
+          zIndex: 50,
+        },
+      },
+    }),
+    [editor, suggestion, toolbarOpen],
+  );
+
+  const reference = useMemo<GenericPopoverReference | undefined>(
+    () => (suggestion?.element ? { element: suggestion.element } : undefined),
+    [suggestion?.element],
+  );
+
+  if (!editor.isEditable) {
+    return null;
+  }
+
+  return (
+    <GenericPopover reference={reference} {...floatingUIOptions}>
+      {suggestion && (
+        <Components.Generic.Toolbar.Root className={"bn-toolbar"}>
+          <Components.Generic.Toolbar.Button
+            label="Apply Change"
+            icon={<RiCheckLine />}
+            onClick={() => applySuggestion(suggestion.id)}
+            mainTooltip="Apply Change"
+          >
+            {/* Apply Change */}
+          </Components.Generic.Toolbar.Button>
+          <Components.Generic.Toolbar.Button
+            label="Revert Change"
+            icon={<RiArrowGoBackLine />}
+            onClick={() => revertSuggestion(suggestion.id)}
+            mainTooltip="Revert Change"
+          >
+            {/* Revert Change */}
+          </Components.Generic.Toolbar.Button>
+        </Components.Generic.Toolbar.Root>
+      )}
+    </GenericPopover>
+  );
+};

--- a/examples/07-collaboration/09-versioning/src/VersionHistorySidebar.tsx
+++ b/examples/07-collaboration/09-versioning/src/VersionHistorySidebar.tsx
@@ -1,0 +1,33 @@
+import { VersioningSidebar } from "@blocknote/react";
+import { useState } from "react";
+
+import { SettingsSelect } from "./SettingsSelect";
+
+export const VersionHistorySidebar = () => {
+  const [filter, setFilter] = useState<"named" | "all">("all");
+
+  return (
+    <div className={"sidebar-section"}>
+      <div className={"settings"}>
+        <SettingsSelect
+          label={"Filter"}
+          items={[
+            {
+              text: "All",
+              icon: null,
+              onClick: () => setFilter("all"),
+              isSelected: filter === "all",
+            },
+            {
+              text: "Named",
+              icon: null,
+              onClick: () => setFilter("named"),
+              isSelected: filter === "named",
+            },
+          ]}
+        />
+      </div>
+      <VersioningSidebar filter={filter} />
+    </div>
+  );
+};

--- a/examples/07-collaboration/09-versioning/src/style.css
+++ b/examples/07-collaboration/09-versioning/src/style.css
@@ -221,3 +221,23 @@
   background-color: #20242a;
   border: 2px solid #23405b;
 }
+
+.full-collaboration ins {
+  background-color: hsl(120 100 90);
+  color: hsl(120 100 30);
+}
+
+.dark.full-collaboration ins {
+  background-color: hsl(120 100 10);
+  color: hsl(120 80 70);
+}
+
+.full-collaboration del {
+  background-color: hsl(0 100 90);
+  color: hsl(0 100 30);
+}
+
+.dark.full-collaboration del {
+  background-color: hsl(0 100 10);
+  color: hsl(0 80 70);
+}

--- a/examples/07-collaboration/09-versioning/src/style.css
+++ b/examples/07-collaboration/09-versioning/src/style.css
@@ -70,6 +70,10 @@
   width: 100%;
 }
 
+.bn-snapshot-name:focus {
+  outline: none;
+}
+
 .bn-snapshot-body {
   display: flex;
   flex-direction: column;

--- a/examples/07-collaboration/09-versioning/src/style.css
+++ b/examples/07-collaboration/09-versioning/src/style.css
@@ -148,7 +148,7 @@
 }
 
 .full-collaboration .bn-threads-sidebar > .bn-thread {
-  box-shadow: var(--bn-shadow-medium);
+  box-shadow: var(--bn-shadow-medium) !important;
   min-width: auto;
 }
 

--- a/examples/07-collaboration/09-versioning/src/style.css
+++ b/examples/07-collaboration/09-versioning/src/style.css
@@ -1,0 +1,106 @@
+.version-history-main-container {
+  background-color: var(--bn-colors-disabled-background);
+  display: flex;
+  gap: 10px;
+  height: 100%;
+  max-width: none;
+  padding: 10px;
+  width: 100%;
+}
+
+.version-history-main-container .editor-section,
+.version-history-section {
+  border-radius: var(--bn-border-radius-large);
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  gap: 10px;
+  max-height: 100%;
+  min-width: 350px;
+  width: 0;
+}
+
+.version-history-main-container .editor-section h1,
+.version-history-section h1 {
+  color: var(--bn-colors-menu-text);
+  margin: 0;
+  font-size: 32px;
+}
+
+.version-history-main-container .bn-editor,
+.bn-versioning-sidebar {
+  border-radius: var(--bn-border-radius-medium);
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  height: 100%;
+  overflow: auto;
+}
+
+.version-history-main-container .editor-section {
+  max-width: 700px;
+}
+
+.bn-versioning-sidebar {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.bn-snapshot {
+  background-color: var(--bn-colors-menu-background);
+  border: var(--bn-border);
+  border-radius: var(--bn-border-radius-medium);
+  color: var(--bn-colors-menu-text);
+  cursor: pointer;
+  flex-direction: column;
+  gap: 16px;
+  display: flex;
+  overflow: visible;
+  padding: 16px 32px;
+  width: 100%;
+}
+
+.bn-snapshot-name {
+  background: transparent;
+  border: none;
+  color: var(--bn-colors-menu-text);
+  font-size: 16px;
+  font-weight: 600;
+  padding: 0;
+  width: 100%;
+}
+
+.bn-snapshot-body {
+  display: flex;
+  flex-direction: column;
+  font-size: 12px;
+  gap: 4px;
+}
+
+.bn-snapshot-button {
+  /* align-self: flex-end; */
+  background-color: #c2dcf8;
+  border: none;
+  border-radius: 4px;
+  color: var(--bn-colors-menu-text);
+  cursor: pointer;
+  font-size: 12px;
+  font-weight: 600;
+  padding: 0 8px;
+  width: fit-content;
+}
+
+.dark .bn-snapshot-button {
+  background-color: #226fb7;
+}
+
+.bn-versioning-sidebar .bn-snapshot.selected {
+  background-color: #f5f9fd;
+  border: 2px solid #c2dcf8;
+}
+
+.dark .bn-versioning-sidebar .bn-snapshot.selected {
+  background-color: #20242a;
+  border: 2px solid #23405b;
+}

--- a/examples/07-collaboration/09-versioning/src/style.css
+++ b/examples/07-collaboration/09-versioning/src/style.css
@@ -16,7 +16,6 @@
   flex-direction: column;
   gap: 10px;
   max-height: 100%;
-  min-width: 350px;
   width: 0;
 }
 
@@ -79,11 +78,10 @@
 }
 
 .bn-snapshot-button {
-  /* align-self: flex-end; */
-  background-color: #c2dcf8;
+  background-color: #4da3ff;
   border: none;
   border-radius: 4px;
-  color: var(--bn-colors-menu-text);
+  color: var(--bn-colors-selected-text);
   cursor: pointer;
   font-size: 12px;
   font-weight: 600;
@@ -92,7 +90,15 @@
 }
 
 .dark .bn-snapshot-button {
-  background-color: #226fb7;
+  background-color: #0070e8;
+}
+
+.bn-snapshot-button:hover {
+  background-color: #73b7ff;
+}
+
+.dark .bn-snapshot-button:hover {
+  background-color: #3785d8;
 }
 
 .bn-versioning-sidebar .bn-snapshot.selected {

--- a/examples/07-collaboration/09-versioning/src/style.css
+++ b/examples/07-collaboration/09-versioning/src/style.css
@@ -1,33 +1,92 @@
-.version-history-main-container {
+.full-collaboration {
+  align-items: flex-end;
   background-color: var(--bn-colors-disabled-background);
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  height: 100%;
+  max-width: none;
+  overflow: auto;
+  padding: 10px;
+}
+
+.full-collaboration .full-collaboration-main-container {
   display: flex;
   gap: 10px;
   height: 100%;
   max-width: none;
-  padding: 10px;
   width: 100%;
 }
 
-.version-history-main-container .editor-section,
-.version-history-section {
-  border-radius: var(--bn-border-radius-large);
+.full-collaboration .editor-layout-wrapper {
+  align-items: center;
   display: flex;
-  flex: 1;
+  flex: 2;
   flex-direction: column;
   gap: 10px;
-  max-height: 100%;
-  width: 0;
+  justify-content: center;
+  width: 100%;
 }
 
-.version-history-main-container .editor-section h1,
-.version-history-section h1 {
+.full-collaboration .sidebar-selectors {
+  align-items: center;
+  display: flex;
+  flex-direction: row;
+  gap: 10px;
+  justify-content: space-between;
+  max-width: 700px;
+  width: 100%;
+}
+
+.full-collaboration .sidebar-selector {
+  align-items: center;
+  background-color: var(--bn-colors-menu-background);
+  border-radius: var(--bn-border-radius-medium);
+  box-shadow: var(--bn-shadow-medium);
+  color: var(--bn-colors-menu-text);
+  cursor: pointer;
+  display: flex;
+  flex-direction: row;
+  font-family: var(--bn-font-family);
+  font-weight: 600;
+  gap: 8px;
+  justify-content: center;
+  padding: 10px;
+  user-select: none;
+  width: 100%;
+}
+
+.full-collaboration .sidebar-selector:hover {
+  background-color: var(--bn-colors-hovered-background);
+  color: var(--bn-colors-hovered-text);
+}
+
+.full-collaboration .sidebar-selector.selected {
+  background-color: var(--bn-colors-selected-background);
+  color: var(--bn-colors-selected-text);
+}
+
+.full-collaboration .editor-section,
+.full-collaboration .sidebar-section {
+  border-radius: var(--bn-border-radius-large);
+  box-shadow: var(--bn-shadow-medium);
+  display: flex;
+  flex-direction: column;
+  max-height: 100%;
+  min-width: 350px;
+  width: 100%;
+}
+
+.full-collaboration .editor-section h1,
+.full-collaboration .sidebar-section h1 {
   color: var(--bn-colors-menu-text);
   margin: 0;
   font-size: 32px;
 }
 
-.version-history-main-container .bn-editor,
-.bn-versioning-sidebar {
+.full-collaboration .bn-editor,
+.full-collaboration .bn-threads-sidebar,
+.full-collaboration .bn-versioning-sidebar {
   border-radius: var(--bn-border-radius-medium);
   display: flex;
   flex-direction: column;
@@ -36,20 +95,68 @@
   overflow: auto;
 }
 
-.version-history-main-container .editor-section {
+.full-collaboration .editor-section {
+  background-color: var(--bn-colors-editor-background);
+  border-radius: var(--bn-border-radius-large);
+  flex: 1;
+  gap: 16px;
   max-width: 700px;
+  padding-block: 16px;
 }
 
-.bn-versioning-sidebar {
+.full-collaboration .editor-section .settings {
+  padding-inline: 54px;
+}
+
+.full-collaboration .sidebar-section {
+  background-color: var(--bn-colors-editor-background);
+  border-radius: var(--bn-border-radius-large);
+  width: 350px;
+}
+
+.full-collaboration .sidebar-section .settings {
+  padding-block: 16px;
+  padding-inline: 16px;
+}
+
+.full-collaboration .bn-threads-sidebar,
+.full-collaboration .bn-versioning-sidebar {
+  padding-inline: 16px;
+}
+
+.full-collaboration .settings {
   display: flex;
-  flex-direction: column;
-  gap: 8px;
+  flex-wrap: wrap;
+  gap: 10px;
 }
 
-.bn-snapshot {
+.full-collaboration .settings-select {
+  display: flex;
+  gap: 10px;
+}
+
+.full-collaboration .settings-select .bn-toolbar {
+  align-items: center;
+}
+
+.full-collaboration .settings-select h2 {
+  color: var(--bn-colors-menu-text);
+  margin: 0;
+  font-size: 12px;
+  line-height: 12px;
+  padding-left: 14px;
+}
+
+.full-collaboration .bn-threads-sidebar > .bn-thread {
+  box-shadow: var(--bn-shadow-medium);
+  min-width: auto;
+}
+
+.full-collaboration .bn-snapshot {
   background-color: var(--bn-colors-menu-background);
   border: var(--bn-border);
   border-radius: var(--bn-border-radius-medium);
+  box-shadow: var(--bn-shadow-medium);
   color: var(--bn-colors-menu-text);
   cursor: pointer;
   flex-direction: column;
@@ -60,7 +167,7 @@
   width: 100%;
 }
 
-.bn-snapshot-name {
+.full-collaboration .bn-snapshot-name {
   background: transparent;
   border: none;
   color: var(--bn-colors-menu-text);
@@ -70,18 +177,18 @@
   width: 100%;
 }
 
-.bn-snapshot-name:focus {
+.full-collaboration .bn-snapshot-name:focus {
   outline: none;
 }
 
-.bn-snapshot-body {
+.full-collaboration .bn-snapshot-body {
   display: flex;
   flex-direction: column;
   font-size: 12px;
   gap: 4px;
 }
 
-.bn-snapshot-button {
+.full-collaboration .bn-snapshot-button {
   background-color: #4da3ff;
   border: none;
   border-radius: 4px;
@@ -93,24 +200,24 @@
   width: fit-content;
 }
 
-.dark .bn-snapshot-button {
+.full-collaboration.dark .bn-snapshot-button {
   background-color: #0070e8;
 }
 
-.bn-snapshot-button:hover {
+.full-collaboration .bn-snapshot-button:hover {
   background-color: #73b7ff;
 }
 
-.dark .bn-snapshot-button:hover {
+.full-collaboration.dark .bn-snapshot-button:hover {
   background-color: #3785d8;
 }
 
-.bn-versioning-sidebar .bn-snapshot.selected {
+.full-collaboration .bn-versioning-sidebar .bn-snapshot.selected {
   background-color: #f5f9fd;
   border: 2px solid #c2dcf8;
 }
 
-.dark .bn-versioning-sidebar .bn-snapshot.selected {
+.full-collaboration.dark .bn-versioning-sidebar .bn-snapshot.selected {
   background-color: #20242a;
   border: 2px solid #23405b;
 }

--- a/examples/07-collaboration/09-versioning/src/userdata.ts
+++ b/examples/07-collaboration/09-versioning/src/userdata.ts
@@ -1,0 +1,47 @@
+import type { User } from "@blocknote/core/comments";
+
+const colors = [
+  "#958DF1",
+  "#F98181",
+  "#FBBC88",
+  "#FAF594",
+  "#70CFF8",
+  "#94FADB",
+  "#B9F18D",
+];
+
+const getRandomElement = (list: any[]) =>
+  list[Math.floor(Math.random() * list.length)];
+
+export const getRandomColor = () => getRandomElement(colors);
+
+export type MyUserType = User & {
+  role: "editor" | "comment";
+};
+
+export const HARDCODED_USERS: MyUserType[] = [
+  {
+    id: "1",
+    username: "John Doe",
+    avatarUrl: "https://placehold.co/100x100?text=John",
+    role: "editor",
+  },
+  {
+    id: "2",
+    username: "Jane Doe",
+    avatarUrl: "https://placehold.co/100x100?text=Jane",
+    role: "editor",
+  },
+  {
+    id: "3",
+    username: "Bob Smith",
+    avatarUrl: "https://placehold.co/100x100?text=Bob",
+    role: "comment",
+  },
+  {
+    id: "4",
+    username: "Betty Smith",
+    avatarUrl: "https://placehold.co/100x100?text=Betty",
+    role: "comment",
+  },
+];

--- a/examples/07-collaboration/09-versioning/tsconfig.json
+++ b/examples/07-collaboration/09-versioning/tsconfig.json
@@ -1,0 +1,36 @@
+{
+  "__comment": "AUTO-GENERATED FILE, DO NOT EDIT DIRECTLY",
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": [
+      "DOM",
+      "DOM.Iterable",
+      "ESNext"
+    ],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "composite": true
+  },
+  "include": [
+    "."
+  ],
+  "__ADD_FOR_LOCAL_DEV_references": [
+    {
+      "path": "../../../packages/core/"
+    },
+    {
+      "path": "../../../packages/react/"
+    }
+  ]
+}

--- a/examples/07-collaboration/09-versioning/vite.config.ts
+++ b/examples/07-collaboration/09-versioning/vite.config.ts
@@ -1,0 +1,32 @@
+// AUTO-GENERATED FILE, DO NOT EDIT DIRECTLY
+import react from "@vitejs/plugin-react";
+import * as fs from "fs";
+import * as path from "path";
+import { defineConfig } from "vite";
+// import eslintPlugin from "vite-plugin-eslint";
+// https://vitejs.dev/config/
+export default defineConfig((conf) => ({
+  plugins: [react()],
+  optimizeDeps: {},
+  build: {
+    sourcemap: true,
+  },
+  resolve: {
+    alias:
+      conf.command === "build" ||
+      !fs.existsSync(path.resolve(__dirname, "../../packages/core/src"))
+        ? {}
+        : ({
+            // Comment out the lines below to load a built version of blocknote
+            // or, keep as is to load live from sources with live reload working
+            "@blocknote/core": path.resolve(
+              __dirname,
+              "../../packages/core/src/"
+            ),
+            "@blocknote/react": path.resolve(
+              __dirname,
+              "../../packages/react/src/"
+            ),
+          } as any),
+  },
+}));

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -109,6 +109,7 @@
     "emoji-mart": "^5.6.0",
     "fast-deep-equal": "^3.1.3",
     "hast-util-from-dom": "^5.0.1",
+    "lib0": "0.2.116",
     "prosemirror-dropcursor": "^1.8.2",
     "prosemirror-highlight": "^0.13.0",
     "prosemirror-model": "^1.25.4",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -91,6 +91,7 @@
   "dependencies": {
     "@emoji-mart/data": "^1.2.1",
     "@handlewithcare/prosemirror-inputrules": "^0.1.3",
+    "@handlewithcare/prosemirror-suggest-changes": "^0.1.8",
     "@shikijs/types": "^3",
     "@tanstack/store": "^0.7.7",
     "@tiptap/core": "^3.13.0",

--- a/packages/core/src/editor/BlockNoteEditor.ts
+++ b/packages/core/src/editor/BlockNoteEditor.ts
@@ -53,6 +53,8 @@ import {
 import type { Selection } from "./selectionTypes.js";
 import { transformPasted } from "./transformPasted.js";
 
+import { withSuggestChanges } from "@handlewithcare/prosemirror-suggest-changes";
+
 export type BlockCache<
   BSchema extends BlockSchema = any,
   ISchema extends InlineContentSchema = any,
@@ -546,6 +548,14 @@ export class BlockNoteEditor<
         { cause: e },
       );
     }
+
+    const origDispatchTransaction = (
+      this._tiptapEditor as any
+    ).dispatchTransaction.bind(this._tiptapEditor);
+
+    (this._tiptapEditor as any).dispatchTransaction = withSuggestChanges(
+      origDispatchTransaction,
+    );
 
     // When y-prosemirror creates an empty document, the `blockContainer` node is created with an `id` of `null`.
     // This causes the unique id extension to generate a new id for the initial block, which is not what we want

--- a/packages/core/src/extensions/Collaboration/ForkYDoc.ts
+++ b/packages/core/src/extensions/Collaboration/ForkYDoc.ts
@@ -13,7 +13,7 @@ import { YUndoExtension } from "./YUndo.js";
 /**
  * To find a fragment in another ydoc, we need to search for it.
  */
-function findTypeInOtherYdoc<T extends Y.AbstractType<any>>(
+export function findTypeInOtherYdoc<T extends Y.AbstractType<any>>(
   ytype: T,
   otherYdoc: Y.Doc,
 ): T {

--- a/packages/core/src/extensions/LinkToolbar/LinkToolbar.ts
+++ b/packages/core/src/extensions/LinkToolbar/LinkToolbar.ts
@@ -65,10 +65,14 @@ export const LinkToolbarExtension = createExtension(({ editor }) => {
     getLinkElementAtPos,
     getMarkAtPos,
 
-    getLinkAtElement(element: HTMLElement) {
+    getLinkAtCoords(coords: { left: number; top: number }) {
       return editor.transact(() => {
-        const posAtElement = editor.prosemirrorView.posAtDOM(element, 0) + 1;
-        return getMarkAtPos(posAtElement, "link");
+        const posAtCoords = editor.prosemirrorView.posAtCoords(coords);
+        if (posAtCoords === null || posAtCoords.inside === -1) {
+          return undefined;
+        }
+
+        return getMarkAtPos(posAtCoords.pos, "link");
       });
     },
 

--- a/packages/core/src/extensions/Suggestions/Suggestions.ts
+++ b/packages/core/src/extensions/Suggestions/Suggestions.ts
@@ -1,0 +1,171 @@
+import {
+  applySuggestion,
+  applySuggestions,
+  disableSuggestChanges,
+  enableSuggestChanges,
+  revertSuggestion,
+  revertSuggestions,
+  suggestChanges,
+  withSuggestChanges,
+} from "@handlewithcare/prosemirror-suggest-changes";
+import { getMarkRange, posToDOMRect } from "@tiptap/core";
+
+import { createExtension } from "../../editor/BlockNoteExtension.js";
+
+export const SuggestionsExtension = createExtension(({ editor }) => {
+  function getSuggestionElementAtPos(pos: number) {
+    let currentNode = editor.prosemirrorView.nodeDOM(pos);
+    while (currentNode && currentNode.parentElement) {
+      if (currentNode.nodeName === "INS" || currentNode.nodeName === "DEL") {
+        return currentNode as HTMLElement;
+      }
+      currentNode = currentNode.parentElement;
+    }
+    return null;
+  }
+
+  function getMarkAtPos(pos: number, markType: string) {
+    return editor.transact((tr) => {
+      const resolvedPos = tr.doc.resolve(pos);
+      const mark = resolvedPos
+        .marks()
+        .find((mark) => mark.type.name === markType);
+
+      if (!mark) {
+        return;
+      }
+
+      const markRange = getMarkRange(resolvedPos, mark.type);
+      if (!markRange) {
+        return;
+      }
+
+      return {
+        range: markRange,
+        mark,
+        get text() {
+          return tr.doc.textBetween(markRange.from, markRange.to);
+        },
+        get position() {
+          // to minimize re-renders, we convert to JSON, which is the same shape anyway
+          return posToDOMRect(
+            editor.prosemirrorView,
+            markRange.from,
+            markRange.to,
+          ).toJSON() as DOMRect;
+        },
+      };
+    });
+  }
+
+  function getSuggestionAtSelection() {
+    return editor.transact((tr) => {
+      const selection = tr.selection;
+      if (!selection.empty) {
+        return undefined;
+      }
+      return (
+        getMarkAtPos(selection.anchor, "insertion") ||
+        getMarkAtPos(selection.anchor, "deletion") ||
+        getMarkAtPos(selection.anchor, "modification")
+      );
+    });
+  }
+
+  return {
+    key: "suggestions",
+    prosemirrorPlugins: [suggestChanges()],
+    // mount: () => {
+    //   const origDispatchTransaction = (
+    //     editor._tiptapEditor as any
+    //   ).dispatchTransaction.bind(editor._tiptapEditor);
+
+    //   (editor._tiptapEditor as any).dispatchTransaction = withSuggestChanges(
+    //     origDispatchTransaction,
+    //   );
+    // },
+    enableSuggestions: () =>
+      enableSuggestChanges(
+        editor.prosemirrorState,
+        (editor._tiptapEditor as any).dispatchTransaction.bind(
+          editor._tiptapEditor,
+        ),
+      ),
+    disableSuggestions: () =>
+      disableSuggestChanges(
+        editor.prosemirrorState,
+        (editor._tiptapEditor as any).dispatchTransaction.bind(
+          editor._tiptapEditor,
+        ),
+      ),
+    applySuggestion: (id: string) =>
+      applySuggestion(id)(
+        editor.prosemirrorState,
+        withSuggestChanges(editor.prosemirrorView.dispatch).bind(
+          editor._tiptapEditor,
+        ),
+        editor.prosemirrorView,
+      ),
+    revertSuggestion: (id: string) =>
+      revertSuggestion(id)(
+        editor.prosemirrorState,
+        withSuggestChanges(editor.prosemirrorView.dispatch).bind(
+          editor._tiptapEditor,
+        ),
+        editor.prosemirrorView,
+      ),
+    applyAllSuggestions: () =>
+      applySuggestions(
+        editor.prosemirrorState,
+        withSuggestChanges(editor.prosemirrorView.dispatch).bind(
+          editor._tiptapEditor,
+        ),
+      ),
+    revertAllSuggestions: () =>
+      revertSuggestions(
+        editor.prosemirrorState,
+        withSuggestChanges(editor.prosemirrorView.dispatch).bind(
+          editor._tiptapEditor,
+        ),
+      ),
+
+    getSuggestionElementAtPos,
+    getMarkAtPos,
+    getSuggestionAtSelection,
+    getSuggestionAtCoords: (coords: { left: number; top: number }) => {
+      return editor.transact(() => {
+        const posAtCoords = editor.prosemirrorView.posAtCoords(coords);
+        if (posAtCoords === null || posAtCoords?.inside === -1) {
+          return undefined;
+        }
+
+        return (
+          getMarkAtPos(posAtCoords.pos, "insertion") ||
+          getMarkAtPos(posAtCoords.pos, "deletion") ||
+          getMarkAtPos(posAtCoords.pos, "modification")
+        );
+      });
+    },
+    checkUnresolvedSuggestions: () => {
+      let hasUnresolvedSuggestions = false;
+
+      editor.prosemirrorState.doc.descendants((node) => {
+        if (hasUnresolvedSuggestions) {
+          return false;
+        }
+
+        hasUnresolvedSuggestions =
+          node.marks.findIndex(
+            (mark) =>
+              mark.type.name === "insertion" ||
+              mark.type.name === "deletion" ||
+              mark.type.name === "modification",
+          ) !== -1;
+
+        return true;
+      });
+
+      return hasUnresolvedSuggestions;
+    },
+  } as const;
+});

--- a/packages/core/src/extensions/Versioning/Versioning.ts
+++ b/packages/core/src/extensions/Versioning/Versioning.ts
@@ -1,3 +1,4 @@
+import { yXmlFragmentToProseMirrorRootNode } from "y-prosemirror";
 import * as Y from "yjs";
 
 import {
@@ -9,7 +10,8 @@ import {
   findTypeInOtherYdoc,
   ForkYDocExtension,
 } from "../Collaboration/ForkYDoc.js";
-import { yXmlFragmentToProseMirrorRootNode } from "y-prosemirror";
+
+import { SuggestionsExtension } from "../Suggestions/Suggestions.js";
 
 export interface VersionSnapshot {
   /**
@@ -214,7 +216,14 @@ export const VersioningExtension = createExtension(
           }
         : undefined,
 
-      selectSnapshot,
+      selectSnapshot: async (id: string | undefined) => {
+        const suggestions = editor.getExtension(SuggestionsExtension);
+        if (suggestions !== undefined) {
+          suggestions.disableSuggestions();
+        }
+
+        await selectSnapshot(id);
+      },
     } as const;
   },
 );

--- a/packages/core/src/extensions/Versioning/Versioning.ts
+++ b/packages/core/src/extensions/Versioning/Versioning.ts
@@ -97,7 +97,7 @@ export interface VersioningEndpoints {
    *
    * @note if not provided, the UI will not allow the user to update the name
    */
-  updateSnapshotName?: (id: string, name: string) => Promise<void>;
+  updateSnapshotName?: (id: string, name?: string) => Promise<void>;
 }
 
 export const VersioningExtension = createExtension(
@@ -163,13 +163,11 @@ export const VersioningExtension = createExtension(
       }));
 
       if (id === undefined) {
-        editor.isEditable = true;
         // when we go back to the original document, just revert changes `.merge({ keepChanges: false })`
         editor.getExtension(ForkYDocExtension)!.merge({ keepChanges: false });
         return;
       }
       editor.getExtension(ForkYDocExtension)!.fork();
-      editor.isEditable = false;
       const snapshotContent = await endpoints.fetchSnapshotContent(id);
 
       // replace editor contents with the snapshot contents (affecting the forked document not the original)
@@ -210,7 +208,7 @@ export const VersioningExtension = createExtension(
         : undefined,
       canUpdateSnapshotName: endpoints.updateSnapshotName !== undefined,
       updateSnapshotName: endpoints.updateSnapshotName
-        ? async (id: string, name: string): Promise<void> => {
+        ? async (id: string, name?: string): Promise<void> => {
             await endpoints.updateSnapshotName!(id, name);
             await updateSnapshots();
           }

--- a/packages/core/src/extensions/Versioning/Versioning.ts
+++ b/packages/core/src/extensions/Versioning/Versioning.ts
@@ -1,0 +1,284 @@
+import * as Y from "yjs";
+
+import {
+  createExtension,
+  createStore,
+  ExtensionOptions,
+} from "../../editor/BlockNoteExtension.js";
+
+export interface VersionSnapshot {
+  /**
+   * The unique identifier for the snapshot.
+   */
+  id: string;
+  /**
+   * The name of the snapshot.
+   */
+  name?: string;
+  /**
+   * The timestamp when the snapshot was created (unix timestamp).
+   */
+  createdAt: number;
+  /**
+   * The timestamp when the snapshot was last updated (unix timestamp).
+   */
+  updatedAt: number;
+  /**
+   * If defined, indicates that the snapshot was created by reverting to a
+   * previous snapshot with the given ID.
+   */
+  revertedSnapshotId?: string;
+  /**
+   * Additional metadata about the snapshot.
+   */
+  meta: {
+    /**
+     * The user IDs associated with the snapshot.
+     */
+    userIds?: string[];
+    /**
+     * The content of the snapshot.
+     */
+    contents?: Uint8Array;
+    selected?: boolean;
+    /**
+     * Additional metadata about the snapshot.
+     */
+    [key: string]: unknown;
+  };
+}
+
+export interface VersioningEndpoints {
+  /**
+   * List all created snapshots for this document.
+   */
+  listSnapshots: () => Promise<VersionSnapshot[]>;
+  /**
+   * Create a new snapshot for this document with the current content.
+   */
+  createSnapshot: (
+    fragment: Y.XmlFragment,
+    /**
+     * The optional name for this snapshot.
+     */
+    name?: string,
+  ) => Promise<VersionSnapshot>;
+  /**
+   * Restore the current document to the provided snapshot ID. This should also
+   * append a new snapshot to the list with the reverted changes, and may
+   * include additional actions like appending a backup snapshot with the
+   * document content, just before reverting.
+   *
+   * @note if not provided, the UI will not allow the user to restore a
+   * snapshot.
+   * @returns the binary contents of the `Y.Doc` of the snapshot.
+   */
+  restoreSnapshot?: (
+    fragment: Y.XmlFragment,
+    id: string,
+  ) => Promise<Uint8Array>;
+  /**
+   * Fetch the contents of a snapshot. This is useful for previewing a
+   * snapshot before choosing to revert it.
+   *
+   * @returns the binary contents of the `Y.Doc` of the snapshot.
+   */
+  fetchSnapshotContent: (
+    /**
+     * The id of the snapshot to fetch the contents of.
+     */
+    id: string,
+  ) => Promise<Uint8Array>;
+  /**
+   * Update the name of a snapshot.
+   *
+   * @note if not provided, the UI will not allow the user to update the name
+   */
+  updateSnapshotName?: (id: string, name: string) => Promise<void>;
+}
+
+export const VersioningExtension = createExtension(
+  ({
+    options: { endpoints, fragment },
+  }: ExtensionOptions<{
+    /**
+     * There are different endpoints that need to be provided to implement the versioning API.
+     */
+    endpoints: VersioningEndpoints;
+    fragment: Y.XmlFragment;
+  }>) => {
+    const store = createStore<{
+      snapshots: VersionSnapshot[];
+      selectedSnapshotId?: string;
+    }>({
+      snapshots: [],
+      selectedSnapshotId: undefined,
+    });
+
+    const updateSnapshots = async () => {
+      const snapshots = await endpoints.listSnapshots();
+      store.setState((state) => ({
+        ...state,
+        snapshots,
+      }));
+    };
+    const updateSnapshotsSync = () => {
+      updateSnapshots();
+    };
+
+    return {
+      key: "versioning",
+      store,
+      mount: () => updateSnapshotsSync(),
+      // TODO I'd probably have:
+      // canRestoreSnapshot: () => boolean;
+      // canUpdateSnapshotName: () => boolean;
+      listSnapshots: async (): Promise<VersionSnapshot[]> => {
+        await updateSnapshots();
+
+        return store.state.snapshots;
+      },
+      createSnapshot: async (name?: string): Promise<VersionSnapshot> => {
+        await endpoints.createSnapshot(fragment, name);
+        await updateSnapshots();
+
+        return store.state.snapshots[0];
+      },
+      restoreSnapshot: endpoints.restoreSnapshot
+        ? async (id: string): Promise<Uint8Array> => {
+            const snapshotContent = await endpoints.restoreSnapshot!(
+              fragment,
+              id,
+            );
+            await updateSnapshots();
+
+            return snapshotContent;
+          }
+        : undefined,
+      fetchSnapshotContent: async (id: string): Promise<Uint8Array> => {
+        const storeSnapshot = store.state.snapshots.find(
+          (snapshot) => snapshot.id === id,
+        );
+        if (storeSnapshot && storeSnapshot.meta.contents !== undefined) {
+          return storeSnapshot.meta.contents;
+        }
+
+        const snapshotContent = await endpoints.fetchSnapshotContent(id);
+        await updateSnapshots();
+
+        return snapshotContent;
+      },
+      updateSnapshotName: endpoints.updateSnapshotName
+        ? async (id: string, name: string): Promise<void> => {
+            await endpoints.updateSnapshotName!(id, name);
+            await updateSnapshots();
+          }
+        : undefined,
+
+      selectSnapshot: (id: string | undefined) => {
+        store.setState((state) => ({
+          ...state,
+          selectedSnapshotId: id,
+        }));
+      },
+    } as const;
+  },
+);
+
+// /**
+//  * Here is a mock implementation of the VersionAPI for the demo
+//  */
+// export const MockVersionAPI = Object.assign(
+//   {
+//     listSnapshots: async () => {
+//       await new Promise((resolve) =>
+//         setTimeout(resolve, 600 + Math.random() * 1000),
+//       );
+//       return JSON.parse(
+//         localStorage.getItem("versions") ?? "[]",
+//       ) as VersionSnapshot[];
+//     },
+//     createSnapshot: async (name, fragment) => {
+//       await new Promise((resolve) =>
+//         setTimeout(resolve, 600 + Math.random() * 1000),
+//       );
+//       const snapshot = {
+//         id: v4(),
+//         name,
+//         createdAt: Date.now(),
+//         updatedAt: Date.now(),
+//         meta: {
+//           userIds: ["User"],
+//           // @ts-expect-error - toBase64 is not a method on Uint8Array in types, but exists in chrome
+//           contents: Y.encodeStateAsUpdateV2(fragment.doc!).toBase64(),
+//         },
+//       } satisfies VersionSnapshot;
+//       localStorage.setItem(
+//         "versions",
+//         JSON.stringify([
+//           snapshot,
+//           ...(JSON.parse(
+//             localStorage.getItem("versions") ?? "[]",
+//           ) as VersionSnapshot[]),
+//         ]),
+//       );
+//       return Promise.resolve(snapshot);
+//     },
+//     fetchSnapshotContent: async (id: string) => {
+//       await new Promise((resolve) =>
+//         setTimeout(resolve, 600 + Math.random() * 1000),
+//       );
+//       const snapshot = (
+//         JSON.parse(
+//           localStorage.getItem("versions") ?? "[]",
+//         ) as VersionSnapshot[]
+//       ).find((snapshot) => snapshot.id === id);
+//       if (snapshot === undefined) {
+//         throw new Error(`Document snapshot ${id} could not be found.`);
+//       }
+//       const binaryString = atob(snapshot.meta.contents as string);
+//       const uint8Array = Uint8Array.from(binaryString, (c) => c.charCodeAt(0));
+//       return Promise.resolve(uint8Array);
+//     },
+//     restoreSnapshot: async (id: string) => {
+//       await new Promise((resolve) =>
+//         setTimeout(resolve, 600 + Math.random() * 1000),
+//       );
+//       const versions = JSON.parse(
+//         localStorage.getItem("versions") ?? "[]",
+//       ) as VersionSnapshot[];
+//       const snapshotIndex = versions.findIndex(
+//         (snapshot: VersionSnapshot) => snapshot.id === id,
+//       );
+//       if (snapshotIndex === -1) {
+//         throw new Error(`Document snapshot ${id} could not be found.`);
+//       }
+//       const snapshot = versions[snapshotIndex].meta.contents as string;
+//       const binaryString = atob(snapshot);
+//       const uint8Array = Uint8Array.from(binaryString, (c) => c.charCodeAt(0));
+//       return Promise.resolve(uint8Array);
+//     },
+//     updateSnapshotName: async (id: string, name: string) => {
+//       await new Promise((resolve) =>
+//         setTimeout(resolve, 600 + Math.random() * 1000),
+//       );
+//       const snapshot = JSON.parse(
+//         localStorage.getItem("versions") ?? "[]",
+//       ).find((snapshot: VersionSnapshot) => snapshot.id === id);
+//       if (snapshot === undefined) {
+//         throw new Error(`Document snapshot ${id} could not be found.`);
+//       }
+//       snapshot.name = name;
+//       localStorage.setItem("versions", JSON.stringify(snapshot));
+//       return Promise.resolve();
+//     },
+//   } satisfies VersioningEndpoints,
+//   {
+//     // This will load the initial snapshot from the localStorage for the demo
+//     getInitialSnapshot: () => {
+//       return JSON.parse(
+//         localStorage.getItem("versions") ?? "[]",
+//       )[0] as VersionSnapshot;
+//     },
+//   },
+// );

--- a/packages/core/src/extensions/Versioning/localStorageEndpoints.ts
+++ b/packages/core/src/extensions/Versioning/localStorageEndpoints.ts
@@ -1,0 +1,98 @@
+import { v4 } from "uuid";
+import * as Y from "yjs";
+
+import { VersioningEndpoints, VersionSnapshot } from "./Versioning.js";
+
+const listSnapshots: VersioningEndpoints["listSnapshots"] = async () =>
+  JSON.parse(localStorage.getItem("snapshots") ?? "[]") as VersionSnapshot[];
+
+const createSnapshot = async (
+  fragment: Y.XmlFragment,
+  name?: string,
+  revertedSnapshotId?: string,
+): Promise<VersionSnapshot> => {
+  const snapshot = {
+    id: v4(),
+    name,
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+    revertedSnapshotId,
+    meta: {
+      userIds: ["User1"],
+      // @ts-expect-error - toBase64 is not a method on Uint8Array in types, but exists in chrome
+      contents: Y.encodeStateAsUpdateV2(fragment.doc!).toBase64(),
+    },
+  } satisfies VersionSnapshot;
+
+  localStorage.setItem(
+    "snapshots",
+    JSON.stringify([snapshot, ...(await listSnapshots())]),
+  );
+
+  return Promise.resolve(snapshot);
+};
+
+const fetchSnapshotContent: VersioningEndpoints["fetchSnapshotContent"] =
+  async (id) => {
+    const snapshots = await listSnapshots();
+
+    const snapshot = snapshots.find(
+      (snapshot: VersionSnapshot) => snapshot.id === id,
+    );
+    if (snapshot === undefined) {
+      throw new Error(`Document snapshot ${id} could not be found.`);
+    }
+    if (!("contents" in snapshot.meta)) {
+      throw new Error(`Document snapshot ${id} doesn't contain content.`);
+    }
+    if (typeof snapshot.meta.contents !== "string") {
+      throw new Error(`Document snapshot ${id} contains invalid content.`);
+    }
+
+    return Promise.resolve(
+      Uint8Array.from(atob(snapshot.meta.contents), (c) => c.charCodeAt(0)),
+    );
+  };
+
+const restoreSnapshot: VersioningEndpoints["restoreSnapshot"] = async (
+  fragment,
+  id,
+) => {
+  await createSnapshot(fragment, "Backup");
+
+  Y.mergeUpdatesV2([await fetchSnapshotContent(id)]);
+
+  await createSnapshot(fragment, "Restored Snapshot", id);
+
+  return Promise.resolve(
+    // @ts-expect-error - toBase64 is not a method on Uint8Array in types, but exists in chrome
+    Y.encodeStateAsUpdateV2(fragment.doc!).toBase64(),
+  );
+};
+
+const updateSnapshotName: VersioningEndpoints["updateSnapshotName"] = async (
+  id,
+  name,
+) => {
+  const snapshots = await listSnapshots();
+
+  const snapshot = snapshots.find(
+    (snapshot: VersionSnapshot) => snapshot.id === id,
+  );
+  if (snapshot === undefined) {
+    throw new Error(`Document snapshot ${id} could not be found.`);
+  }
+
+  snapshot.name = name;
+  localStorage.setItem("snapshots", JSON.stringify(snapshots));
+
+  return Promise.resolve();
+};
+
+export const localStorageEndpoints: VersioningEndpoints = {
+  listSnapshots,
+  createSnapshot,
+  fetchSnapshotContent,
+  restoreSnapshot,
+  updateSnapshotName,
+};

--- a/packages/core/src/extensions/Versioning/localStorageEndpoints.ts
+++ b/packages/core/src/extensions/Versioning/localStorageEndpoints.ts
@@ -1,5 +1,6 @@
 import { v4 } from "uuid";
 import * as Y from "yjs";
+import { toBase64, fromBase64 } from "lib0/buffer";
 
 import { VersioningEndpoints, VersionSnapshot } from "./Versioning.js";
 
@@ -19,8 +20,7 @@ const createSnapshot = async (
     meta: {
       restoredFromSnapshotId,
       userIds: ["User1"],
-      // @ts-expect-error - toBase64 is not a method on Uint8Array in types, but exists in chrome
-      contents: Y.encodeStateAsUpdateV2(fragment.doc!).toBase64(),
+      contents: toBase64(Y.encodeStateAsUpdateV2(fragment.doc!)),
     },
   } satisfies VersionSnapshot;
 
@@ -49,9 +49,7 @@ const fetchSnapshotContent: VersioningEndpoints["fetchSnapshotContent"] =
       throw new Error(`Document snapshot ${id} contains invalid content.`);
     }
 
-    return Promise.resolve(
-      Uint8Array.from(atob(snapshot.meta.contents), (c) => c.charCodeAt(0)),
-    );
+    return Promise.resolve(fromBase64(snapshot.meta.contents));
   };
 
 const restoreSnapshot: VersioningEndpoints["restoreSnapshot"] = async (

--- a/packages/core/src/extensions/Versioning/localStorageEndpoints.ts
+++ b/packages/core/src/extensions/Versioning/localStorageEndpoints.ts
@@ -88,6 +88,8 @@ const updateSnapshotName: VersioningEndpoints["updateSnapshotName"] = async (
   }
 
   snapshot.name = name;
+  snapshot.updatedAt = Date.now();
+
   localStorage.setItem("snapshots", JSON.stringify(snapshots));
 
   return Promise.resolve();

--- a/packages/core/src/extensions/index.ts
+++ b/packages/core/src/extensions/index.ts
@@ -20,6 +20,7 @@ export * from "./SuggestionMenu/getDefaultSlashMenuItems.js";
 export * from "./SuggestionMenu/getDefaultEmojiPickerItems.js";
 export * from "./SuggestionMenu/DefaultSuggestionItem.js";
 export * from "./SuggestionMenu/DefaultGridSuggestionItem.js";
+export * from "./Suggestions/Suggestions.js";
 export * from "./TableHandles/TableHandles.js";
 export * from "./TrailingNode/TrailingNode.js";
 export * from "./Versioning/Versioning.js";

--- a/packages/core/src/extensions/index.ts
+++ b/packages/core/src/extensions/index.ts
@@ -22,3 +22,5 @@ export * from "./SuggestionMenu/DefaultSuggestionItem.js";
 export * from "./SuggestionMenu/DefaultGridSuggestionItem.js";
 export * from "./TableHandles/TableHandles.js";
 export * from "./TrailingNode/TrailingNode.js";
+export * from "./Versioning/Versioning.js";
+export * from "./Versioning/localStorageEndpoints.js";

--- a/packages/react/src/components/LinkToolbar/LinkToolbarController.tsx
+++ b/packages/react/src/components/LinkToolbar/LinkToolbarController.tsx
@@ -80,8 +80,18 @@ export const LinkToolbarController = (props: {
         return;
       }
 
-      const mouseCursorLink = linkToolbar.getLinkAtElement(event.target);
+      const mouseCursorLink = linkToolbar.getLinkAtCoords({
+        left: event.clientX,
+        top: event.clientY,
+      });
       if (!mouseCursorLink) {
+        return;
+      }
+
+      const element = linkToolbar.getLinkElementAtPos(
+        mouseCursorLink.range.from,
+      )!;
+      if (element === link?.element) {
         return;
       }
 
@@ -98,13 +108,13 @@ export const LinkToolbarController = (props: {
     const destroyOnSelectionChangeHandler =
       editor.onSelectionChange(textCursorCallback);
 
-    editor.domElement?.addEventListener("mouseover", mouseCursorCallback);
+    editor.domElement?.addEventListener("mousemove", mouseCursorCallback);
 
     return () => {
       destroyOnChangeHandler();
       destroyOnSelectionChangeHandler();
 
-      editor.domElement?.removeEventListener("mouseover", mouseCursorCallback);
+      editor.domElement?.removeEventListener("mousemove", mouseCursorCallback);
     };
   }, [editor, linkToolbar, link, toolbarPositionFrozen]);
 

--- a/packages/react/src/components/Versioning/CurrentSnapshot.tsx
+++ b/packages/react/src/components/Versioning/CurrentSnapshot.tsx
@@ -1,0 +1,43 @@
+import { VersioningExtension } from "@blocknote/core/extensions";
+import { useState } from "react";
+
+import { useExtension, useExtensionState } from "../../hooks/useExtension.js";
+
+export const CurrentSnapshot = () => {
+  const { createSnapshot, selectSnapshot } = useExtension(VersioningExtension);
+  const selected = useExtensionState(VersioningExtension, {
+    selector: (state) => state.selectedSnapshotId === undefined,
+  });
+
+  const [snapshotName, setSnapshotName] = useState("Current Version");
+
+  return (
+    <div
+      className={`bn-snapshot ${selected ? "selected" : ""}`}
+      onClick={() => selectSnapshot(undefined)}
+    >
+      <div className="bn-snapshot-body">
+        <input
+          className="bn-snapshot-name"
+          type="text"
+          value={snapshotName}
+          onChange={(event) => setSnapshotName(event.target.value)}
+        />
+        {snapshotName !== "Current Version" && (
+          <div className="bn-snapshot-date">Current Version</div>
+        )}
+      </div>
+      <button
+        className="bn-snapshot-button"
+        onClick={() => {
+          createSnapshot(
+            snapshotName !== "Current Version" ? snapshotName : undefined,
+          );
+          setSnapshotName("Current Version");
+        }}
+      >
+        Save
+      </button>
+    </div>
+  );
+};

--- a/packages/react/src/components/Versioning/CurrentSnapshot.tsx
+++ b/packages/react/src/components/Versioning/CurrentSnapshot.tsx
@@ -29,7 +29,11 @@ export const CurrentSnapshot = () => {
       </div>
       <button
         className="bn-snapshot-button"
-        onClick={() => {
+        onClick={(event) => {
+          // Prevent event bubbling to avoid calling `selectSnapshot`.
+          event.preventDefault();
+          event.stopPropagation();
+
           createSnapshot(
             snapshotName !== "Current Version" ? snapshotName : undefined,
           );

--- a/packages/react/src/components/Versioning/Snapshot.tsx
+++ b/packages/react/src/components/Versioning/Snapshot.tsx
@@ -45,7 +45,7 @@ export const Snapshot = ({ snapshot }: { snapshot: VersionSnapshot }) => {
         <input
           className="bn-snapshot-name"
           type="text"
-          readOnly={canUpdateSnapshotName}
+          readOnly={!canUpdateSnapshotName}
           value={snapshotName}
           onChange={(e) => setSnapshotName(e.target.value)}
           onBlur={() => updateSnapshotName?.(snapshot.id, snapshotName)}
@@ -65,7 +65,13 @@ export const Snapshot = ({ snapshot }: { snapshot: VersionSnapshot }) => {
       {canRestoreSnapshot && (
         <button
           className="bn-snapshot-button"
-          onClick={() => restoreSnapshot?.(snapshot.id)}
+          onClick={(event) => {
+            // Prevent event bubbling to avoid calling `selectSnapshot`.
+            event.preventDefault();
+            event.stopPropagation();
+
+            restoreSnapshot?.(snapshot.id);
+          }}
         >
           Restore
         </button>

--- a/packages/react/src/components/Versioning/Snapshot.tsx
+++ b/packages/react/src/components/Versioning/Snapshot.tsx
@@ -8,8 +8,13 @@ import { dateToString } from "./dateToString.js";
 import { useState } from "react";
 
 export const Snapshot = ({ snapshot }: { snapshot: VersionSnapshot }) => {
-  const { restoreSnapshot, updateSnapshotName, selectSnapshot } =
-    useExtension(VersioningExtension);
+  const {
+    canRestoreSnapshot,
+    restoreSnapshot,
+    canUpdateSnapshotName,
+    updateSnapshotName,
+    selectSnapshot,
+  } = useExtension(VersioningExtension);
   const selected = useExtensionState(VersioningExtension, {
     selector: (state) => state.selectedSnapshotId === snapshot.id,
   });
@@ -40,6 +45,7 @@ export const Snapshot = ({ snapshot }: { snapshot: VersionSnapshot }) => {
         <input
           className="bn-snapshot-name"
           type="text"
+          readOnly={canUpdateSnapshotName}
           value={snapshotName}
           onChange={(e) => setSnapshotName(e.target.value)}
           onBlur={() => updateSnapshotName?.(snapshot.id, snapshotName)}
@@ -56,12 +62,14 @@ export const Snapshot = ({ snapshot }: { snapshot: VersionSnapshot }) => {
             <div className="bn-snapshot-user">{`Edited by ${snapshot.meta.userIds.join(", ")}`}</div>
           )}
       </div>
-      <button
-        className="bn-snapshot-button"
-        onClick={() => restoreSnapshot?.(snapshot.id)}
-      >
-        Restore
-      </button>
+      {canRestoreSnapshot && (
+        <button
+          className="bn-snapshot-button"
+          onClick={() => restoreSnapshot?.(snapshot.id)}
+        >
+          Restore
+        </button>
+      )}
     </div>
   );
 };

--- a/packages/react/src/components/Versioning/Snapshot.tsx
+++ b/packages/react/src/components/Versioning/Snapshot.tsx
@@ -1,0 +1,64 @@
+import {
+  VersioningExtension,
+  VersionSnapshot,
+} from "@blocknote/core/extensions";
+
+import { useExtension, useExtensionState } from "../../hooks/useExtension.js";
+import { dateToString } from "./dateToString.js";
+
+export const Snapshot = ({ snapshot }: { snapshot: VersionSnapshot }) => {
+  const { restoreSnapshot, updateSnapshotName, selectSnapshot } =
+    useExtension(VersioningExtension);
+  const selected = useExtensionState(VersioningExtension, {
+    selector: (state) => state.selectedSnapshotId === snapshot.id,
+  });
+  const revertedSnapshot = useExtensionState(VersioningExtension, {
+    selector: (state) =>
+      snapshot?.revertedSnapshotId !== undefined
+        ? state.snapshots.find(
+            (snap) => snap.id === snapshot.revertedSnapshotId,
+          )
+        : undefined,
+  });
+
+  const dateString = dateToString(new Date(snapshot?.createdAt || 0));
+
+  if (snapshot === undefined) {
+    return null;
+  }
+
+  return (
+    <div
+      className={`bn-snapshot ${selected ? "selected" : ""}`}
+      onClick={() => selectSnapshot(snapshot.id)}
+    >
+      <div className="bn-snapshot-body">
+        <input
+          className="bn-snapshot-name"
+          type="text"
+          defaultValue={snapshot?.name || dateString}
+          onBlur={(event) => {
+            updateSnapshotName?.(snapshot.id, event.target.value);
+          }}
+        />
+        {snapshot.name && snapshot.name !== dateString && (
+          <div className="bn-snapshot-date">{dateString}</div>
+        )}
+        {revertedSnapshot && (
+          <div className="bn-snapshot-original-date">{`Restored from ${dateToString(new Date(revertedSnapshot.createdAt))}`}</div>
+        )}
+        {/* TODO: Fetch user name */}
+        {snapshot.meta.userIds !== undefined &&
+          snapshot.meta.userIds.length > 0 && (
+            <div className="bn-snapshot-user">{`Edited by ${snapshot.meta.userIds.join(", ")}`}</div>
+          )}
+      </div>
+      <button
+        className="bn-snapshot-button"
+        onClick={() => restoreSnapshot?.(snapshot.id)}
+      >
+        Restore
+      </button>
+    </div>
+  );
+};

--- a/packages/react/src/components/Versioning/Snapshot.tsx
+++ b/packages/react/src/components/Versioning/Snapshot.tsx
@@ -48,7 +48,12 @@ export const Snapshot = ({ snapshot }: { snapshot: VersionSnapshot }) => {
           readOnly={!canUpdateSnapshotName}
           value={snapshotName}
           onChange={(e) => setSnapshotName(e.target.value)}
-          onBlur={() => updateSnapshotName?.(snapshot.id, snapshotName)}
+          onBlur={() =>
+            updateSnapshotName?.(
+              snapshot.id,
+              snapshotName === dateString ? undefined : snapshotName,
+            )
+          }
         />
         {snapshot.name && snapshot.name !== dateString && (
           <div className="bn-snapshot-date">{dateString}</div>

--- a/packages/react/src/components/Versioning/Snapshot.tsx
+++ b/packages/react/src/components/Versioning/Snapshot.tsx
@@ -5,6 +5,7 @@ import {
 
 import { useExtension, useExtensionState } from "../../hooks/useExtension.js";
 import { dateToString } from "./dateToString.js";
+import { useState } from "react";
 
 export const Snapshot = ({ snapshot }: { snapshot: VersionSnapshot }) => {
   const { restoreSnapshot, updateSnapshotName, selectSnapshot } =
@@ -14,14 +15,17 @@ export const Snapshot = ({ snapshot }: { snapshot: VersionSnapshot }) => {
   });
   const revertedSnapshot = useExtensionState(VersioningExtension, {
     selector: (state) =>
-      snapshot?.revertedSnapshotId !== undefined
+      snapshot?.meta.restoredFromSnapshotId !== undefined
         ? state.snapshots.find(
-            (snap) => snap.id === snapshot.revertedSnapshotId,
+            (snap) => snap.id === snapshot.meta.restoredFromSnapshotId,
           )
         : undefined,
   });
 
   const dateString = dateToString(new Date(snapshot?.createdAt || 0));
+  const [snapshotName, setSnapshotName] = useState(
+    snapshot?.name || dateString,
+  );
 
   if (snapshot === undefined) {
     return null;
@@ -36,10 +40,9 @@ export const Snapshot = ({ snapshot }: { snapshot: VersionSnapshot }) => {
         <input
           className="bn-snapshot-name"
           type="text"
-          defaultValue={snapshot?.name || dateString}
-          onBlur={(event) => {
-            updateSnapshotName?.(snapshot.id, event.target.value);
-          }}
+          value={snapshotName}
+          onChange={(e) => setSnapshotName(e.target.value)}
+          onBlur={() => updateSnapshotName?.(snapshot.id, snapshotName)}
         />
         {snapshot.name && snapshot.name !== dateString && (
           <div className="bn-snapshot-date">{dateString}</div>

--- a/packages/react/src/components/Versioning/VersioningSidebar.tsx
+++ b/packages/react/src/components/Versioning/VersioningSidebar.tsx
@@ -1,0 +1,18 @@
+import { VersioningExtension } from "@blocknote/core/extensions";
+
+import { useExtensionState } from "../../hooks/useExtension.js";
+import { CurrentSnapshot } from "./CurrentSnapshot.js";
+import { Snapshot } from "./Snapshot.js";
+
+export const VersioningSidebar = () => {
+  const { snapshots } = useExtensionState(VersioningExtension);
+
+  return (
+    <div className="bn-versioning-sidebar">
+      <CurrentSnapshot />
+      {snapshots.map((snapshot, index) => {
+        return <Snapshot key={index} snapshot={snapshot} />;
+      })}
+    </div>
+  );
+};

--- a/packages/react/src/components/Versioning/VersioningSidebar.tsx
+++ b/packages/react/src/components/Versioning/VersioningSidebar.tsx
@@ -10,8 +10,8 @@ export const VersioningSidebar = () => {
   return (
     <div className="bn-versioning-sidebar">
       <CurrentSnapshot />
-      {snapshots.map((snapshot, index) => {
-        return <Snapshot key={index} snapshot={snapshot} />;
+      {snapshots.map((snapshot) => {
+        return <Snapshot key={snapshot.id} snapshot={snapshot} />;
       })}
     </div>
   );

--- a/packages/react/src/components/Versioning/VersioningSidebar.tsx
+++ b/packages/react/src/components/Versioning/VersioningSidebar.tsx
@@ -4,15 +4,19 @@ import { useExtensionState } from "../../hooks/useExtension.js";
 import { CurrentSnapshot } from "./CurrentSnapshot.js";
 import { Snapshot } from "./Snapshot.js";
 
-export const VersioningSidebar = () => {
+export const VersioningSidebar = (props: { filter?: "named" | "all" }) => {
   const { snapshots } = useExtensionState(VersioningExtension);
 
   return (
     <div className="bn-versioning-sidebar">
       <CurrentSnapshot />
-      {snapshots.map((snapshot) => {
-        return <Snapshot key={snapshot.id} snapshot={snapshot} />;
-      })}
+      {snapshots
+        .filter((snapshot) =>
+          props.filter === "named" ? snapshot.name !== undefined : true,
+        )
+        .map((snapshot) => {
+          return <Snapshot key={snapshot.id} snapshot={snapshot} />;
+        })}
     </div>
   );
 };

--- a/packages/react/src/components/Versioning/dateToString.ts
+++ b/packages/react/src/components/Versioning/dateToString.ts
@@ -1,0 +1,9 @@
+export const dateToString = (date: Date) =>
+  `${date.toLocaleDateString(undefined, {
+    day: "numeric",
+    month: "long",
+    year: "numeric",
+  })}, ${date.toLocaleTimeString(undefined, {
+    hour: "numeric",
+    minute: "2-digit",
+  })}`;

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -114,6 +114,8 @@ export * from "./components/Comments/ThreadsSidebar.js";
 export * from "./components/Comments/useThreads.js";
 export * from "./components/Comments/useUsers.js";
 
+export * from "./components/Versioning/VersioningSidebar.js";
+
 export * from "./hooks/useActiveStyles.js";
 export * from "./hooks/useBlockNoteEditor.js";
 export * from "./hooks/useCreateBlockNote.js";

--- a/playground/src/examples.gen.tsx
+++ b/playground/src/examples.gen.tsx
@@ -1622,7 +1622,7 @@
             "Collaboration"
           ],
           "dependencies": {
-            "y-partykit": "^0.0.25",
+            "react-icons": "^5.2.1",
             "yjs": "^13.6.27"
           } as any
         },

--- a/playground/src/examples.gen.tsx
+++ b/playground/src/examples.gen.tsx
@@ -1607,6 +1607,31 @@
           "slug": "collaboration"
         },
         "readme": "In this example, we can fork a document and edit it independently of other collaborators. Then, we can choose to merge the changes back into the original document, or discard the changes.\n\n**Try it out:** Open this page in a new browser tab or window to see it in action!\n\n**Relevant Docs:**\n\n- [Editor Setup](/docs/getting-started/editor-setup)"
+      },
+      {
+        "projectSlug": "versioning",
+        "fullSlug": "collaboration/versioning",
+        "pathFromRoot": "examples/07-collaboration/09-versioning",
+        "config": {
+          "playground": true,
+          "docs": true,
+          "author": "matthewlipski",
+          "tags": [
+            "Advanced",
+            "Development",
+            "Collaboration"
+          ],
+          "dependencies": {
+            "y-partykit": "^0.0.25",
+            "yjs": "^13.6.27"
+          } as any
+        },
+        "title": "Collaborative Editing with Versioning",
+        "group": {
+          "pathFromRoot": "examples/07-collaboration",
+          "slug": "collaboration"
+        },
+        "readme": "In this example, we can save snapshots of the document that we can later preview and revert to. \n\n**Try it out:** Press the save button in the versioning sidebar to save a document snapshot!\n\n**Relevant Docs:**\n\n- [Editor Setup](/docs/getting-started/editor-setup)"
       }
     ]
   },

--- a/playground/src/examples.gen.tsx
+++ b/playground/src/examples.gen.tsx
@@ -1627,12 +1627,12 @@
             "yjs": "^13.6.27"
           } as any
         },
-        "title": "Collaborative Editing with Versioning",
+        "title": "Collaborative Editing Features Showcase",
         "group": {
           "pathFromRoot": "examples/07-collaboration",
           "slug": "collaboration"
         },
-        "readme": "In this example, we can save snapshots of the document that we can later preview and revert to. \n\n**Try it out:** Press the save button in the versioning sidebar to save a document snapshot!\n\n**Relevant Docs:**\n\n- [Editor Setup](/docs/getting-started/editor-setup)"
+        "readme": "In this example, you can play with all of the collaboration features BlockNote has to offer:\n\n**Comments**: Add comments to parts of the document - other users can then view, reply to, react to, and resolve them.\n\n**Versioning**: Save snapshots of the document - later preview saved snapshots and restore them to ensure work is never lost.\n\n**Suggestions**: Suggest changes directly in the editor - users can choose to then apply or reject those changes.\n\n**Relevant Docs:**\n\n- [Editor Setup](/docs/getting-started/editor-setup)\n- [Comments](/docs/features/collaboration/comments)\n- [Real-time collaboration](/docs/features/collaboration)"
       }
     ]
   },

--- a/playground/src/examples.gen.tsx
+++ b/playground/src/examples.gen.tsx
@@ -1622,6 +1622,7 @@
             "Collaboration"
           ],
           "dependencies": {
+            "@floating-ui/react": "^0.27.16",
             "react-icons": "^5.2.1",
             "yjs": "^13.6.27"
           } as any

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3854,6 +3854,58 @@ importers:
         specifier: ^5.4.20
         version: 5.4.20(@types/node@24.8.1)(lightningcss@1.30.1)(terser@5.44.1)
 
+  examples/07-collaboration/09-versioning:
+    dependencies:
+      '@blocknote/ariakit':
+        specifier: latest
+        version: link:../../../packages/ariakit
+      '@blocknote/core':
+        specifier: latest
+        version: link:../../../packages/core
+      '@blocknote/mantine':
+        specifier: latest
+        version: link:../../../packages/mantine
+      '@blocknote/react':
+        specifier: latest
+        version: link:../../../packages/react
+      '@blocknote/shadcn':
+        specifier: latest
+        version: link:../../../packages/shadcn
+      '@mantine/core':
+        specifier: ^8.3.4
+        version: 8.3.4(@mantine/hooks@8.3.4(react@19.2.1))(@types/react@19.2.2)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@mantine/hooks':
+        specifier: ^8.3.4
+        version: 8.3.4(react@19.2.1)
+      '@mantine/utils':
+        specifier: ^6.0.22
+        version: 6.0.22(react@19.2.1)
+      react:
+        specifier: ^19.2.1
+        version: 19.2.1
+      react-dom:
+        specifier: ^19.2.1
+        version: 19.2.1(react@19.2.1)
+      y-partykit:
+        specifier: ^0.0.25
+        version: 0.0.25
+      yjs:
+        specifier: ^13.6.27
+        version: 13.6.27
+    devDependencies:
+      '@types/react':
+        specifier: ^19.2.2
+        version: 19.2.2
+      '@types/react-dom':
+        specifier: ^19.2.2
+        version: 19.2.2(@types/react@19.2.2)
+      '@vitejs/plugin-react':
+        specifier: ^4.7.0
+        version: 4.7.0(vite@5.4.20(@types/node@24.8.1)(lightningcss@1.30.1)(terser@5.44.1))
+      vite:
+        specifier: ^5.4.20
+        version: 5.4.20(@types/node@24.8.1)(lightningcss@1.30.1)(terser@5.44.1)
+
   examples/08-extensions/01-tiptap-arrow-conversion:
     dependencies:
       '@blocknote/ariakit':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -115,6 +115,9 @@ importers:
       '@emotion/styled':
         specifier: ^11.11.5
         version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.2)(react@19.2.1))(@types/react@19.2.2)(react@19.2.1)
+      '@floating-ui/react':
+        specifier: ^0.27.16
+        version: 0.27.16(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       '@fumadocs/mdx-remote':
         specifier: 1.3.0
         version: 1.3.0(fumadocs-core@15.5.4(@types/react@19.2.2)(next@15.5.9(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.51.1)(babel-plugin-react-compiler@19.1.0-rc.2)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react@19.2.1)
@@ -3871,6 +3874,9 @@ importers:
       '@blocknote/shadcn':
         specifier: latest
         version: link:../../../packages/shadcn
+      '@floating-ui/react':
+        specifier: ^0.27.16
+        version: 0.27.16(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       '@mantine/core':
         specifier: ^8.3.4
         version: 8.3.4(@mantine/hooks@8.3.4(react@19.2.1))(@types/react@19.2.2)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
@@ -4575,6 +4581,9 @@ importers:
       '@handlewithcare/prosemirror-inputrules':
         specifier: ^0.1.3
         version: 0.1.3(prosemirror-model@1.25.4)(prosemirror-state@1.4.4)(prosemirror-view@1.41.4)
+      '@handlewithcare/prosemirror-suggest-changes':
+        specifier: ^0.1.8
+        version: 0.1.8(prosemirror-model@1.25.4)(prosemirror-state@1.4.4)(prosemirror-transform@1.10.5)(prosemirror-view@1.41.4)
       '@hocuspocus/provider':
         specifier: ^2.15.2 || ^3.0.0
         version: 2.15.3(y-protocols@1.0.6(yjs@13.6.27))(yjs@13.6.27)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4638,6 +4638,9 @@ importers:
       hast-util-from-dom:
         specifier: ^5.0.1
         version: 5.0.1
+      lib0:
+        specifier: 0.2.116
+        version: 0.2.116
       prosemirror-dropcursor:
         specifier: ^1.8.2
         version: 1.8.2
@@ -12975,6 +12978,11 @@ packages:
     engines: {node: '>=16'}
     hasBin: true
 
+  lib0@0.2.116:
+    resolution: {integrity: sha512-4zsosjzmt33rx5XjmFVYUAeLNh+BTeDTiwGdLt4muxiir2btsc60Nal0EvkvDRizg+pnlK1q+BtYi7M+d4eStw==}
+    engines: {node: '>=16'}
+    hasBin: true
+
   lie@3.3.0:
     resolution: {integrity: sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==}
 
@@ -17859,13 +17867,13 @@ snapshots:
 
   '@hocuspocus/common@2.15.3':
     dependencies:
-      lib0: 0.2.114
+      lib0: 0.2.116
 
   '@hocuspocus/provider@2.15.3(y-protocols@1.0.6(yjs@13.6.27))(yjs@13.6.27)':
     dependencies:
       '@hocuspocus/common': 2.15.3
       '@lifeomic/attempt': 3.1.0
-      lib0: 0.2.114
+      lib0: 0.2.116
       ws: 8.18.3
       y-protocols: 1.0.6(yjs@13.6.27)
       yjs: 13.6.27
@@ -24599,6 +24607,10 @@ snapshots:
     dependencies:
       isomorphic.js: 0.2.5
 
+  lib0@0.2.116:
+    dependencies:
+      isomorphic.js: 0.2.5
+
   lie@3.3.0:
     dependencies:
       immediate: 3.0.6
@@ -28209,7 +28221,7 @@ snapshots:
 
   y-indexeddb@9.0.12(yjs@13.6.27):
     dependencies:
-      lib0: 0.2.114
+      lib0: 0.2.116
       yjs: 13.6.27
 
   y-partykit@0.0.25:
@@ -28222,7 +28234,7 @@ snapshots:
 
   y-prosemirror@1.3.7(prosemirror-model@1.25.4)(prosemirror-state@1.4.4)(prosemirror-view@1.41.4)(y-protocols@1.0.6(yjs@13.6.27))(yjs@13.6.27):
     dependencies:
-      lib0: 0.2.114
+      lib0: 0.2.116
       prosemirror-model: 1.25.4
       prosemirror-state: 1.4.4
       prosemirror-view: 1.41.4
@@ -28231,7 +28243,7 @@ snapshots:
 
   y-protocols@1.0.6(yjs@13.6.27):
     dependencies:
-      lib0: 0.2.114
+      lib0: 0.2.116
       yjs: 13.6.27
 
   y18n@5.0.8: {}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3886,9 +3886,9 @@ importers:
       react-dom:
         specifier: ^19.2.1
         version: 19.2.1(react@19.2.1)
-      y-partykit:
-        specifier: ^0.0.25
-        version: 0.0.25
+      react-icons:
+        specifier: ^5.2.1
+        version: 5.5.0(react@19.2.1)
       yjs:
         specifier: ^13.6.27
         version: 13.6.27


### PR DESCRIPTION
# Summary

<!-- Briefly describe the feature being introduced. -->

This PR adds an example which combines all available collaboration features, including comments, versioning, and suggesting changes.

There's a sidebar that can show the comments or saved version snapshots. The snapshots can be previewed, renamed and reverted. Reverting a snapshot also creates a backup snapshot just before the revert, and one just after.

If the sidebar is displaying comments, then clicking a comment in the editor will scroll to and select the comment in the sidebar (works vice-versa when clicking a comment in the sidebar). Otherwise, the floating comment viewer will be used.

Aside from being able to change users for editing/commenting rights, you can also change the editing mode from regular editing to suggesting changes. Suggested additions and removals are highlighted in green and red, and can be either individually applied/reverted or all at once.

## Rationale

<!-- Explain the reasoning behind this feature and its benefits to the project. -->

This is a nice showcase of everything collaboration related that BlockNote has to offer, and is useful for testing those features.

## Changes

<!-- List the major changes made in this pull request. -->

- Added example
- Added versioning and suggestions extensions
- Added versioning sidebar component
- Added example versioning backend implementation that uses local storage
- Made slight improvements to link toolbar behaviour

## Impact

<!-- Discuss any potential impacts this feature may have on existing functionalities. -->

N/A

## Testing

<!-- Describe how the feature has been tested, including both automated and manual testing strategies. -->

Did a decent amount of manual testing but there might still be some rough edges I haven't found, especially using the 3 different features together.

## Screenshots/Video

<!-- Include screenshots or video demonstrating the new feature, if applicable. -->

## Checklist

- [X] Code follows the project's coding standards.
- [X] Unit tests covering the new feature have been added.
- [X] All existing tests pass.
- [X] The documentation has been updated to reflect the new feature

## Additional Notes

<!-- Any additional information or context relevant to this PR. -->

TODOs:

- [ ] Replace versioning and suggestions extension logic with new Yjs code from @nperez0111.
- [ ] Fix bug where add comment button in the formatting toolbar doesn't show for users with only commenting rights.
- [ ] Fix bug where comments are removed after saving a snapshot and then reloading the page.
- [ ] Fix bug where hovering between adjacent additions and removals with the same ID causes weird behaviour.
  - The current suggestions implementation uses the `@handlewithcare/prosemirror-suggest-changes` package, which is ID based. This bug **should** be fixed after moving to the new Yjs implementation, but should be double checked.
- [x] For suggestions, `withSuggestChanges` is applied to `dispatch` in the `BlockNoteEditor` constructor. It should really be in the suggestions extension `mount` method, but I couldn't get this to work.
  - Should be redundant after moving to the new Yjs implementation.
- [ ] Maybe move link toolbar improvements to a separate PR.
  - These improvements fix a bug where if a link is at the start of a block, hovering text in the same block will select it in the `LinkToolbarController` component. This is because hovering a text node in the block, the mouse event target will point to the parent `.bn-inline-content` rather than the text node itself. Therefore, `posAtDOM` resolves to a position at the start of the block's inline content, which is also the start of the link. Using `posAtCoords` and using the mouse coords fixes this.
- [ ] Add screenshots/videos to PR description.
- [ ] @nperez0111 needs to re-think the versioning API, to better support using Y.js snapshots vs. full-doc snapshots. See the `re-think-snapshot` branch for more thoughts
- [ ] @nperez0111 needs to come up with a migration strategy for going from y.js 13 to 14






