### PR TITLE
fix: opening suggestion menu in collab mode on empty document

### DIFF
--- a/packages/core/src/extensions/SuggestionMenu/SuggestionMenu.ts
+++ b/packages/core/src/extensions/SuggestionMenu/SuggestionMenu.ts
@@ -263,7 +263,8 @@ export const SuggestionMenu = createExtension(({ editor }) => {
               }
 
               const userDidTypeTriggerCharacter =
-                !!suggestionPluginTransactionMeta.userDidTypeTriggerCharacter;
+                suggestionPluginTransactionMeta.userDidTypeTriggerCharacter !==
+                false;
 
               const trackedPosition = trackPosition(
                 editor,
@@ -276,9 +277,7 @@ export const SuggestionMenu = createExtension(({ editor }) => {
               return {
                 triggerCharacter:
                   suggestionPluginTransactionMeta.triggerCharacter,
-                userDidTypeTriggerCharacter:
-                  suggestionPluginTransactionMeta.userDidTypeTriggerCharacter !==
-                  false,
+                userDidTypeTriggerCharacter,
                 // When reading the queryStartPos, we offset the result by the length of the trigger character, to make it easy on the caller
                 queryStartPos: () =>
                   trackedPosition() +

--- a/packages/core/src/extensions/SuggestionMenu/getDefaultSlashMenuItems.ts
+++ b/packages/core/src/extensions/SuggestionMenu/getDefaultSlashMenuItems.ts
@@ -343,7 +343,7 @@ export function getDefaultSlashMenuItems<
   items.push({
     onItemClick: () => {
       editor.getExtension(SuggestionMenu)?.openSuggestionMenu(":", {
-        deleteTriggerCharacter: true,
+        insertTriggerCharacter: true,
         ignoreQueryLength: true,
       });
     },


### PR DESCRIPTION
There's a bug that hitting the + button doesn't work in collaboration mode, on an empty document. I tried to address it here but didn't get to the root cause yet.

In this PR, I have:

- improved some of the naming in the suggestion plugin to make it easier for me to untangle the code
- removed some of the offsets that I think shouldn't be there when opening the suggestion menu programmatically

However, this doesn't fix the issue yet. I think there's an issue with using `trackPosition` in this specific case.

We can diagnose further by adding a breakpoint in the if-statement marked by `// Checks if the menu should be hidden.`