### PR TITLE
fix: add `font-synthesis` for italic & bold in fonts that don't have them specified #2325

### DIFF
--- a/packages/core/src/editor/editor.css
+++ b/packages/core/src/editor/editor.css
@@ -3,6 +3,7 @@
 .bn-editor {
   outline: none;
   padding-inline: 54px;
+  font-synthesis: style weight;
 
   /* Define a set of colors to be used throughout the app for consistency
   see https://atlassian.design/foundations/color for more info */


### PR DESCRIPTION
# Summary

This adds support for italic & bold in fonts that do not already have them specified. See this for more info: https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/font-synthesis
<!-- Briefly describe the feature being introduced. -->

## Rationale

<!-- Explain the reasoning behind this feature and its benefits to the project. -->

## Changes

<!-- List the major changes made in this pull request. -->

## Impact

<!-- Discuss any potential impacts this feature may have on existing functionalities. -->

## Testing

<!-- Describe how the feature has been tested, including both automated and manual testing strategies. -->

## Screenshots/Video

<!-- Include screenshots or video demonstrating the new feature, if applicable. -->

## Checklist

- [ ] Code follows the project's coding standards.
- [ ] Unit tests covering the new feature have been added.
- [ ] All existing tests pass.
- [ ] The documentation has been updated to reflect the new feature

## Additional Notes

<!-- Any additional information or context relevant to this PR. -->
fixes #2325
