### PR TITLE
fix: add delay for data-active in collab cursors

### DIFF
--- a/packages/core/src/extensions/Collaboration/YCursorPlugin.ts
+++ b/packages/core/src/extensions/Collaboration/YCursorPlugin.ts
@@ -97,7 +97,9 @@ export const YCursorExtension = createExtension(
                 const cursor = recentlyUpdatedCursors.get(clientID);
 
                 if (cursor) {
-                  cursor.element.setAttribute("data-active", "");
+                  setTimeout(() => {
+                    cursor.element.setAttribute("data-active", "");
+                  }, 10);
 
                   if (cursor.hideTimeout) {
                     clearTimeout(cursor.hideTimeout);


### PR DESCRIPTION
# Summary

Fixes auto-expanding of collab cursor when it changes position

## Rationale

The CSS transition would not work when the cursor div / decoration element would move after setting the classname. This small delay is a workaround to fix this

## Testing

Manual testing, small ux fix which will be really difficult to test otherwise

## Screenshots/Video

![cursor-fix](https://github.com/user-attachments/assets/6855004b-73fe-4bf6-9946-478019a8737f)

## Checklist

- [x] Code follows the project's coding standards.
- [ ] Unit tests covering the new feature have been added.
- [ ] All existing tests pass.
- [ ] The documentation has been updated to reflect the new feature

