### PR TITLE
fix: table handles would crash

### DIFF
--- a/packages/core/src/extensions/TableHandles/TableHandles.ts
+++ b/packages/core/src/extensions/TableHandles/TableHandles.ts
@@ -296,9 +296,13 @@ export class TableHandlesView implements PluginView {
         event.clientX >= tableRect.right - 1 &&
         event.clientX < tableRect.right + 20;
 
-      // without this check, we'd also hide draghandles when hovering over them
       const hideHandles =
-        event.clientX > tableRect.right || event.clientY > tableRect.bottom;
+        // always hide handles when the actively hovered table changed
+        this.state?.block.id !== tableBlock.id ||
+        // make sure we don't hide existing handles (keep col / row index) when
+        // we're hovering just above or to the right of a table
+        event.clientX > tableRect.right ||
+        event.clientY > tableRect.bottom;
 
       this.state = {
         ...this.state!,


### PR DESCRIPTION
# Summary

When hovering between tables of different sizes (a larger table above a smaller one), this would crash in `TableHandlesController` because the table id and rowIndex / colIndex would be out of sync.

Closes https://github.com/TypeCellOS/BlockNote/issues/2355

## Rationale

This is a quick fix to fix the crash, without a test. While looking into this, we encountered some related issues that can occur when using tables and collaboration. The table component needs a larger refactoring to accommodate for this which we'll add to the roadmap. As part of that refactor we'll also make sure this scenario will be covered in tests

## Changes

Reset hovered table cell / row / col state when table changes

## Impact

- 

## Testing

manual testing, see above for rationale

## Checklist

- [x] Code follows the project's coding standards.
- [ ] Unit tests covering the new feature have been added.
- [x] All existing tests pass.
- [-] The documentation has been updated to reflect the new feature


