### PR TITLE
fix: prevent nested bullet list icon rendering as emoji on iOS 18+

### DIFF
--- a/packages/core/src/editor/Block.css
+++ b/packages/core/src/editor/Block.css
@@ -372,7 +372,7 @@ NESTED BLOCKS
   > .bn-block-outer[data-prev-type="bulletListItem"]
   > .bn-block
   > .bn-block-content::before {
-  content: "▪";
+  content: "▪\FE0E";
 }
 
 [data-content-type="bulletListItem"]
@@ -390,7 +390,7 @@ NESTED BLOCKS
   > .bn-block
   > div[data-type="modification"]
   > .bn-block-content[data-content-type="bulletListItem"]::before {
-  content: "▪";
+  content: "▪\FE0E";
 }
 
 /* CODE BLOCKS */


### PR DESCRIPTION
# Summary

Fix nested bullet list items (level 3+) rendering as emoji squares on iOS 18+ browsers instead of small text bullet points.

Fixes #2394

## Rationale

On iOS 18+, Apple changed how certain Unicode characters are rendered, defaulting some geometric symbols to emoji presentation. The Black Small Square character (`▪`, U+25AA) used for deeply nested bullet lists was being rendered as a large black square emoji (`⬛`) instead of the intended small text bullet, making nested lists look broken on iOS Safari and Chrome.

## Changes

- Added Unicode Variation Selector 15 (`\FE0E`) to the Black Small Square character in `packages/core/src/editor/Block.css`

## Impact

- Visual fix only - no changes to functionality or document structure
- Nested bullet lists now display correctly on iOS 18+ (Safari and Chrome)
- No impact on other browsers - VS15 is ignored when not needed
- Other bullet characters (`•` and `◦`) were verified to not need this fix as they are not in the Unicode Emoji Variation Sequences list

## Testing

- Verified the generated CSS includes the variation selector correctly
- Manual testing on iOS 18+ device to confirm visual fix:

## Screenshots/Video

Level 3+ bullet items show as small `▪` text character (as intended)

<img width="346" height="153" alt="Screenshot 2026-02-01 at 5 22 13 AM" src="https://github.com/user-attachments/assets/d45bc7ef-4f03-4416-8f8a-1a3c63ba8273" />


## Checklist

- [x] Code follows the project's coding standards.
- [ ] Unit tests covering the new feature have been added.
- [x] All existing tests pass.
- [ ] The documentation has been updated to reflect the new feature

## Additional Notes

This is a CSS-only fix. The Unicode Variation Selector 15 (U+FE0E) is a standard Unicode mechanism to request text presentation for characters that have both text and emoji variants. This is the recommended approach per [Unicode Technical Standard #51 (Unicode Emoji)](https://www.unicode.org/reports/tr51/).