### PR TITLE
Fix AI combobox aria-activedescendant

### DIFF
--- a/packages/ariakit/src/input/TextInput.tsx
+++ b/packages/ariakit/src/input/TextInput.tsx
@@ -25,6 +25,7 @@ export const TextInput = forwardRef<
     onChange,
     onSubmit,
     autoComplete,
+    "aria-activedescendant": ariaActivedescendant,
     rightSection,
     ...rest
   } = props;
@@ -52,6 +53,7 @@ export const TextInput = forwardRef<
           onChange={onChange}
           onSubmit={onSubmit}
           autoComplete={autoComplete}
+          aria-activedescendant={ariaActivedescendant}
         />
         {rightSection}
       </div>

--- a/packages/mantine/src/form/TextInput.tsx
+++ b/packages/mantine/src/form/TextInput.tsx
@@ -22,6 +22,7 @@ export const TextInput = forwardRef<
     onChange,
     onSubmit,
     autoComplete,
+    "aria-activedescendant": ariaActivedescendant,
     rightSection,
     ...rest
   } = props;
@@ -49,6 +50,7 @@ export const TextInput = forwardRef<
       onChange={onChange}
       onSubmit={onSubmit}
       autoComplete={autoComplete}
+      aria-activedescendant={ariaActivedescendant}
     />
   );
 });

--- a/packages/react/src/editor/ComponentsContext.tsx
+++ b/packages/react/src/editor/ComponentsContext.tsx
@@ -272,6 +272,7 @@ export type ComponentProps = {
         onChange: (event: ChangeEvent<HTMLInputElement>) => void;
         onSubmit?: () => void;
         autoComplete?: HTMLInputAutoCompleteAttribute;
+        "aria-activedescendant"?: string;
       };
     };
     Menu: {

--- a/packages/shadcn/src/form/TextInput.tsx
+++ b/packages/shadcn/src/form/TextInput.tsx
@@ -23,6 +23,7 @@ export const TextInput = forwardRef<
     onChange,
     onSubmit,
     autoComplete,
+    "aria-activedescendant": ariaActivedescendant,
     rightSection, // TODO: add rightSection
     ...rest
   } = props;
@@ -58,6 +59,7 @@ export const TextInput = forwardRef<
           onChange={onChange}
           onSubmit={onSubmit}
           ref={ref}
+          aria-activedescendant={ariaActivedescendant}
         />
       </div>
       {rightSection}

--- a/packages/xl-ai/src/components/AIMenu/PromptSuggestionMenu.tsx
+++ b/packages/xl-ai/src/components/AIMenu/PromptSuggestionMenu.tsx
@@ -67,6 +67,11 @@ export const PromptSuggestionMenu = (props: PromptSuggestionMenuProps) => {
   const { selectedIndex, setSelectedIndex, handler } =
     useSuggestionMenuKeyboardHandler(items, (item) => item.onItemClick());
 
+  const activeDescendantId =
+    items.length > 0 && selectedIndex >= 0 && selectedIndex < items.length
+      ? `bn-suggestion-menu-item-${selectedIndex}`
+      : undefined;
+
   const handleKeyDown = useCallback(
     (event: KeyboardEvent) => {
       // TODO: handle backspace to close
@@ -107,6 +112,7 @@ export const PromptSuggestionMenu = (props: PromptSuggestionMenuProps) => {
           onChange={handleChange}
           autoComplete={"off"}
           rightSection={props.rightSection}
+          aria-activedescendant={activeDescendantId}
         />
       </Components.Generic.Form.Root>
       <Components.SuggestionMenu.Root


### PR DESCRIPTION
# Summary

Fixes AI suggestion menu accessibility by wiring `aria-activedescendant` to the active option so screen readers announce the current item during keyboard navigation.

issue : https://github.com/TypeCellOS/BlockNote/issues/2412

## Rationale

The combobox/listbox pattern keeps focus on the input, so the active option must be exposed via `aria-activedescendant`. Without it, NVDA/VoiceOver announce “empty” and provide no feedback. This change aligns with WAI-ARIA Authoring Practices

## Changes

- Track the active suggestion index in `PromptSuggestionMenu` and set `aria-activedescendant` on the input.
- Extend `Generic.Form.TextInput` props to accept `aria-activedescendant`.
- 
## Impact

- Improves screen reader output for the AI suggestion menu.
- No visual or behavioral changes for sighted users; focus remains on the input.

## Testing

- Manual: verified arrow-key navigation announces the active option in NVDA/VoiceOver.  
- Automated: not added (no existing tests for this component).

## Screenshots/Video

Sr announce now : 
```
Ask AI Write with AI  1 sur 1
liste
Continue Writing  1 sur 4
Summarize  2 sur 4
Add Action Items  3 sur 4
Write Anything…  4 sur 4
```

N/A (accessibility change).

## Checklist

- [x] Code follows the project's coding standards.

## Additional Notes

This fix targets only the AI suggestion menu combobox. Future work could add `aria-expanded` / `aria-controls` for full parity with the ARIA combobox pattern.