### PR TITLE
fix: correct return type of getDefaultReactSlashMenuItems to include key

### DIFF
--- a/packages/react/src/blocks/PageBreak/getPageBreakReactSlashMenuItems.tsx
+++ b/packages/react/src/blocks/PageBreak/getPageBreakReactSlashMenuItems.tsx
@@ -18,7 +18,7 @@ export function getPageBreakReactSlashMenuItems<
   S extends StyleSchema,
 >(
   editor: BlockNoteEditor<BSchema, I, S>,
-): (Omit<DefaultReactSuggestionItem, "key"> & { key: "page_break" })[] {
+): (DefaultReactSuggestionItem & { key: "page_break" })[] {
   return getPageBreakSlashMenuItems(editor).map((item) => {
     const Icon = icons[item.key];
     return {

--- a/packages/react/src/components/SuggestionMenu/getDefaultReactSlashMenuItems.tsx
+++ b/packages/react/src/components/SuggestionMenu/getDefaultReactSlashMenuItems.tsx
@@ -1,6 +1,7 @@
 import {
   BlockNoteEditor,
   BlockSchema,
+  Dictionary,
   InlineContentSchema,
   StyleSchema,
 } from "@blocknote/core";
@@ -61,7 +62,11 @@ export function getDefaultReactSlashMenuItems<
   BSchema extends BlockSchema,
   I extends InlineContentSchema,
   S extends StyleSchema,
->(editor: BlockNoteEditor<BSchema, I, S>): DefaultReactSuggestionItem[] {
+>(
+  editor: BlockNoteEditor<BSchema, I, S>,
+): (DefaultReactSuggestionItem & {
+  key: keyof Omit<Dictionary["slash_menu"], "page_break">;
+})[] {
   return getDefaultSlashMenuItems(editor).map((item) => {
     const Icon = icons[item.key];
     return {


### PR DESCRIPTION
# Summary

Fix incorrect return type of `getDefaultReactSlashMenuItems()` to properly include the `key` property.

## Rationale

Items returned by `getDefaultReactSlashMenuItems()` actually contain a `key` property (inherited from `getDefaultSlashMenuItems()`), but the return type `DefaultReactSuggestionItem[]` omits `key`. This causes type errors when users try to access `item.key`:

```typescript
getDefaultReactSlashMenuItems(editor).filter((item) => {
  console.log(item.key); // Error: Property 'key' does not exist
});
```

## Changes

- Updated return type of `getDefaultReactSlashMenuItems()` to include `key` property
- Simplified return type of `getPageBreakReactSlashMenuItems()` by removing unnecessary `Omit`

## Impact

- Users can now access `item.key` without type errors
- No breaking changes to runtime behavior

## Testing

- Type checking passes for all packages

## Screenshots/Video

N/A (type-only change)

## Checklist

- [x] Code follows the project's coding standards.
- [ ] Unit tests covering the new feature have been added.
- [x] All existing tests pass.
- [ ] The documentation has been updated to reflect the new feature

## Additional Notes
