### PR TITLE
fix: correct the code blocks documentation

### DIFF
--- a/docs/content/docs/features/blocks/code-blocks.mdx
+++ b/docs/content/docs/features/blocks/code-blocks.mdx
@@ -80,7 +80,7 @@ To create your own syntax highlighter, you can use the [shiki-codegen](https://s
 For example, to create a syntax highlighter using the optimized javascript engine, javascript, typescript, vue, with light and dark themes, you can run the following command:
 
 ```bash
-npx shiki-codegen --langs javascript,typescript,vue --themes light,dark --engine javascript --precompiled ./shiki.bundle.ts
+npx shiki-codegen --langs javascript,typescript,vue --themes light-plus,dark-plus --engine javascript --precompiled ./shiki.bundle.ts
 ```
 
 This will generate a `shiki.bundle.ts` file that you can use to create a syntax highlighter for your editor.
@@ -93,21 +93,23 @@ import { createHighlighter } from "./shiki.bundle.js";
 export default function App() {
   const editor = useCreateBlockNote({
     schema: BlockNoteSchema.create().extend({
-      codeBlock: createCodeBlockSpec({
-        indentLineWithTab: true,
-        defaultLanguage: "typescript",
-        supportedLanguages: {
-          typescript: {
-            name: "TypeScript",
-            aliases: ["ts"],
+      blockSpecs: {
+        codeBlock: createCodeBlockSpec({
+          indentLineWithTab: true,
+          defaultLanguage: "typescript",
+          supportedLanguages: {
+            typescript: {
+              name: "TypeScript",
+              aliases: ["ts"],
+            },
           },
-        },
-        createHighlighter: () =>
-          createHighlighter({
-            themes: ["light-plus", "dark-plus"],
-            langs: [],
-          }),
-      }),
+          createHighlighter: () =>
+            createHighlighter({
+              themes: ["light-plus", "dark-plus"],
+              langs: [],
+            }),
+        }),
+      },
     }),
   });
 


### PR DESCRIPTION
# Summary

I've made two corrections to the code blocks document.

1) Put the `codeBlock` field under the `blockSpecs` field because it's not a root field.  
2) The `dark` and `light` theme is not supported in [shiki](https://shiki.style/themes). 

https://github.com/TypeCellOS/BlockNote/blob/f150e1e91c73e3b18b8b43336402f580444d7ed6/packages/core/src/schema/schema.ts#L174-L227
