### PR TITLE
fix: add link on commented text removes the comment highlight (2573)

### DIFF
--- a/packages/core/src/extensions/LinkToolbar/LinkToolbar.ts
+++ b/packages/core/src/extensions/LinkToolbar/LinkToolbar.ts
@@ -79,23 +79,38 @@ export const LinkToolbarExtension = createExtension(({ editor }) => {
     ) {
       editor.transact((tr) => {
         const pmSchema = getPmSchema(tr);
-        const { range } = getMarkAtPos(position + 1, "link") || {
+
+        const linkInfo = getMarkAtPos(position + 1, "link") || {
           range: {
             from: tr.selection.from,
             to: tr.selection.to,
           },
         };
+
+        const { range } = linkInfo;
+
         if (!range) {
           return;
         }
+        const existingMarks =
+          tr.doc.nodeAt(Math.max(range.from, range.to - 1))?.marks ?? [];
+
         tr.insertText(text, range.from, range.to);
+
+        for (const existingMark of existingMarks) {
+          if (existingMark.type.name !== "link") {
+            tr.addMark(range.from, range.from + text.length, existingMark);
+          }
+        }
+
         tr.addMark(
           range.from,
           range.from + text.length,
           pmSchema.mark("link", { href: url }),
         );
-      });
-      editor.prosemirrorView.focus();
+    });
+
+    editor.prosemirrorView.focus();
     },
     deleteLink(position = editor.transact((tr) => tr.selection.anchor)) {
       editor.transact((tr) => {

--- a/tests/src/end-to-end/linktoolbar/linktoolbar.test.ts
+++ b/tests/src/end-to-end/linktoolbar/linktoolbar.test.ts
@@ -1,0 +1,50 @@
+import { expect } from "@playwright/test";
+import { test } from "../../setup/setupScript.js";
+import { BASE_URL, LINK_BUTTON_SELECTOR } from "../../utils/const.js";
+import { focusOnEditor } from "../../utils/editor.js";
+
+test.beforeEach(async ({ page }) => {
+  await page.goto(BASE_URL);
+});
+
+test.describe("Check Link Toolbar functionality", () => {
+  test("Should preserve existing marks when editing a link", async ({
+    page,
+  }) => {
+    await focusOnEditor(page);
+
+    // Type bold text
+    await page.keyboard.type("hello");
+    await page.keyboard.press("Shift+Home");
+
+    // Make it bold via formatting toolbar
+    await page.waitForSelector(`[data-test="bold"]`);
+    await page.click(`[data-test="bold"]`);
+
+    // Add link
+    await page.keyboard.press("Shift+Home");
+    await page.waitForSelector(LINK_BUTTON_SELECTOR);
+    await page.click(LINK_BUTTON_SELECTOR);
+    await page.keyboard.type("https://example.com");
+    await page.keyboard.press("Enter");
+
+    // Move cursor back onto the linked text to trigger link toolbar
+    await page.keyboard.press("ArrowLeft");
+    await page.waitForTimeout(500);
+
+    // Click Edit link button
+    const editButton = page.getByText("Edit link");
+    await editButton.waitFor({ state: "visible" });
+    await editButton.click();
+
+    await page.keyboard.press("Control+A");
+    await page.keyboard.type("https://example2.com");
+    await page.keyboard.press("Enter");
+
+    await page.waitForTimeout(300);
+
+    // Verify bold mark is still present on the text
+    const boldText = page.locator("strong a, a strong");
+    await expect(boldText).toBeVisible();
+  });
+});


### PR DESCRIPTION
# Summary
This pull request fixes an issue where adding or editing a link on commented text removes the comment highlight and comment association. After this change, a link can be added or edited on commented text while preserving both the link underline and the existing comment behavior.

## Rationale
The issue was caused by `LinkToolbarExtension.editLink()` (from packages/core/src/extensions/LinkToolbar/LinkToolbar.ts) replacing the selected text with `insertText(...)` and then reapplying only the `link` mark. As a result, existing marks on that text, including the `comment` mark, were lost. Preserving existing non-link marks makes link editing behave correctly and keeps comment functionality intact.

## Changes
- Updated `LinkToolbarExtension.editLink()` to preserve existing marks on the selected text before replacing it
- Reapplied existing non-link marks after `insertText(...)`
- Reapplied the updated `link` mark after restoring the preserved marks

## Impact
This change affects the link editing flow for text that already contains other marks, especially comments. It should improve behavior by preserving comment highlighting and comment accessibility when links are added or edited. The intended behavior for normal link editing remains the same.

## Testing
- Manually verified: added a link on commented text preserves the comment highlight
- Manually verified: editing a link on bold text preserves the bold mark  
- Added Playwright e2e test in `tests/src/end-to-end/linktoolbar/linktoolbar.test.ts` 
  verifying that bold marks are preserved when editing a link
- Existing tests pass (pre-existing snapshot failures are unrelated platform differences)

## Screenshots/Video
Below is an image showing commented text retaining the comment, highlight, and link after the fix.
<img width="687" height="377" alt="image" src="https://github.com/user-attachments/assets/ad492afb-3781-4032-ae50-328e9adfffe0" />

## Checklist

- [x] Code follows the project's coding standards.
- [x] Unit tests covering the new feature have been added.
- [x] All existing tests pass.
- [ ] The documentation has been updated to reflect the new feature

## Additional Notes
Fixes #2573 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Link editing now preserves other text formatting (bold, italic, etc.) when updating a link and ensures editor focus happens after changes are applied.

* **Tests**
  * Added an end-to-end test that verifies link insertion, editing, and preservation of text formatting (e.g., bold) after updating a link.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->