### PR TITLE
docs: add yearly pricing option with discount

### DIFF
--- a/docs/app/pricing/PricingTiers.tsx
+++ b/docs/app/pricing/PricingTiers.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { cn } from "@/lib/fumadocs/cn";
+import { useState } from "react";
+import { Tier, Tiers } from "./tiers";
+
+type Frequency = "month" | "year";
+
+export function PricingTiers({ tiers }: { tiers: Tier[] }) {
+  const [frequency, setFrequency] = useState<Frequency>("year");
+
+  return (
+    <>
+      {/* Frequency Toggle */}
+      <div className="mb-10 flex items-center justify-center gap-3">
+        <span
+          className={cn(
+            "text-sm font-medium transition-colors",
+            frequency === "month" ? "text-stone-900" : "text-stone-400",
+          )}
+        >
+          Monthly
+        </span>
+        <button
+          type="button"
+          role="switch"
+          aria-checked={frequency === "year"}
+          onClick={() =>
+            setFrequency((f) => (f === "month" ? "year" : "month"))
+          }
+          className={cn(
+            "relative inline-flex h-7 w-12 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors",
+            frequency === "year" ? "bg-purple-600" : "bg-stone-300",
+          )}
+        >
+          <span
+            className={cn(
+              "pointer-events-none inline-block h-6 w-6 rounded-full bg-white shadow-sm ring-0 transition-transform",
+              frequency === "year" ? "translate-x-5" : "translate-x-0",
+            )}
+          />
+        </button>
+        <span
+          className={cn(
+            "text-sm font-medium transition-colors",
+            frequency === "year" ? "text-stone-900" : "text-stone-400",
+          )}
+        >
+          Yearly
+        </span>
+        <span className="rounded-full bg-green-100 px-2.5 py-0.5 text-xs font-semibold text-green-700">
+          Save 50%
+        </span>
+      </div>
+
+      <Tiers tiers={tiers} frequency={frequency} />
+    </>
+  );
+}

--- a/docs/app/pricing/page.tsx
+++ b/docs/app/pricing/page.tsx
@@ -1,5 +1,5 @@
 import { FAQ } from "@/app/pricing/faq";
-import { Tier, Tiers } from "@/app/pricing/tiers";
+import { Tier } from "@/app/pricing/tiers";
 import { InfiniteSlider } from "@/components/InfiniteSlider";
 import {
   Tooltip,
@@ -9,6 +9,7 @@ import {
 } from "@/components/ui/tooltip";
 import { getFullMetadata } from "@/lib/getFullMetadata";
 import Link from "next/link";
+import { PricingTiers } from "./PricingTiers";
 
 export const metadata = getFullMetadata({
   title: "Pricing",
@@ -80,7 +81,7 @@ const tiers: Tier[] = [
     badge: "Recommended",
     description:
       "Commercial license for access to advanced features and technical support.",
-    price: { month: 390, year: 48 },
+    price: { month: 390, year: 2340 },
     features: [
       <span key="commercial" className="font-semibold text-stone-900">
         Commercial license for XL packages:
@@ -162,8 +163,8 @@ export default function Pricing() {
           </p>
         </div>
 
-        {/* Pricing Tiers */}
-        <Tiers tiers={tiers} frequency="month" />
+        {/* Pricing Tiers with Toggle */}
+        <PricingTiers tiers={tiers} />
 
         {/* Social proof */}
         <div className="mt-24 w-full border-t border-stone-200 pt-16">

--- a/docs/app/pricing/tiers.tsx
+++ b/docs/app/pricing/tiers.tsx
@@ -23,7 +23,13 @@ export type Tier = {
   cta?: "get-started" | "buy" | "contact";
 };
 
-function TierCTAButton({ tier }: { tier: Tier }) {
+const BUSINESS_PLAN_TYPES = new Set(["business", "business-yearly"]);
+
+function isBusinessPlan(planType: string) {
+  return BUSINESS_PLAN_TYPES.has(planType);
+}
+
+function TierCTAButton({ tier, frequency }: { tier: Tier; frequency: Frequency }) {
   const { data: session } = useSession();
   let text =
     tier.cta === "get-started"
@@ -38,10 +44,11 @@ function TierCTAButton({ tier }: { tier: Tier }) {
     if (session.planType === "free") {
       text = "Buy now";
     } else {
-      text =
-        session.planType === tier.id
-          ? "Manage subscription"
-          : "Update subscription";
+      const isCurrentPlan =
+        tier.id === "business"
+          ? isBusinessPlan(session.planType ?? "")
+          : session.planType === tier.id;
+      text = isCurrentPlan ? "Manage subscription" : "Update subscription";
     }
   }
 
@@ -68,9 +75,6 @@ function TierCTAButton({ tier }: { tier: Tier }) {
         }
 
         track("Signup", { tier: tier.id });
-        // ... rest of analytic logic kept simple for brevity in replacement,
-        // in real implementation we keep the existing logic.
-        // Re-injecting existing analytics logic below to ensure no regression.
         if (!session) {
           Sentry.captureEvent({
             message: "click-pricing-signup",
@@ -90,9 +94,16 @@ function TierCTAButton({ tier }: { tier: Tier }) {
           track("click-pricing-buy-now", { tier: tier.id });
           e.preventDefault();
           e.stopPropagation();
-          await authClient.checkout({ slug: tier.id });
+          const checkoutSlug = frequency === "year" && tier.id === "business"
+            ? "business-yearly"
+            : tier.id;
+          await authClient.checkout({ slug: checkoutSlug });
         } else {
-          if (session.planType === tier.id) {
+          const isCurrentPlan =
+            tier.id === "business"
+              ? isBusinessPlan(session.planType ?? "")
+              : session.planType === tier.id;
+          if (isCurrentPlan) {
             Sentry.captureEvent({
               message: "click-pricing-manage-subscription",
               level: "info",
@@ -208,6 +219,28 @@ export function Tiers({
                 <span className="text-3xl font-bold text-stone-900">
                   {tier.price}
                 </span>
+              ) : frequency === "year" ? (
+                <div>
+                  <div className="flex items-baseline gap-2">
+                    <span className="text-4xl font-bold text-stone-900">
+                      ${Math.round(tier.price.year / 12)}
+                    </span>
+                    <span className="text-sm font-medium text-stone-400">
+                      /month
+                    </span>
+                  </div>
+                  <div className="mt-1.5 flex items-center gap-2">
+                    <span className="text-sm text-stone-400 line-through decoration-stone-400">
+                      ${tier.price.month}/mo
+                    </span>
+                    <span className="rounded-md bg-green-100 px-1.5 py-0.5 text-xs font-semibold text-green-700">
+                      now -50%
+                    </span>
+                  </div>
+                  <p className="mt-1 text-xs text-stone-400">
+                    ${tier.price.year.toLocaleString()} billed yearly
+                  </p>
+                </div>
               ) : (
                 <div className="flex items-baseline gap-1">
                   <span className="text-4xl font-bold text-stone-900">
@@ -227,7 +260,7 @@ export function Tiers({
 
             {/* CTA */}
             <div className="mb-6">
-              <TierCTAButton tier={tier} />
+              <TierCTAButton tier={tier} frequency={frequency} />
             </div>
 
             {/* Features */}

--- a/docs/lib/auth.ts
+++ b/docs/lib/auth.ts
@@ -208,6 +208,10 @@ export const auth = betterAuth({
               slug: PRODUCTS.business.slug, // Custom slug for easy reference in Checkout URL, e.g. /checkout/pro
             },
             {
+              productId: PRODUCTS["business-yearly"].id,
+              slug: PRODUCTS["business-yearly"].slug,
+            },
+            {
               productId: PRODUCTS.starter.id,
               slug: PRODUCTS.starter.slug,
             },

--- a/docs/lib/product-list.ts
+++ b/docs/lib/product-list.ts
@@ -7,6 +7,14 @@ export const PRODUCTS = {
     name: "Business",
     slug: "business",
   } as const,
+  "business-yearly": {
+    id:
+      process.env.NODE_ENV === "production"
+        ? "ba3965dc-e1ca-494e-b36a-62e2e41615d4"
+        : "NOT-CREATED",
+    name: "Business Yearly",
+    slug: "business-yearly",
+  } as const,
   starter: {
     id:
       process.env.NODE_ENV === "production"


### PR DESCRIPTION
## Summary
- Add monthly/yearly toggle to the pricing page (defaults to yearly)
- Yearly plan: $195/mo ($2,340/yr) — 50% off the $390/mo monthly price
- Wire up `business-yearly` Polar product for checkout
- Business monthly and yearly treated as the same tier for subscription management

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an interactive toggle to switch between monthly and yearly billing frequency on the pricing page
  * Yearly billing plans now display with calculated monthly cost equivalents, reference pricing, and a savings indicator badge
  
* **Updates**
  * Corrected the Business plan's yearly pricing calculation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->