### PR TITLE
fix: disable default UI when no components context is found

### DIFF
--- a/packages/react/src/editor/BlockNoteView.tsx
+++ b/packages/react/src/editor/BlockNoteView.tsx
@@ -143,15 +143,14 @@ function BlockNoteViewComponent<
   const componentsContext = useComponentsContext();
   const defaultUIProps: BlockNoteDefaultUIProps = useMemo(
     () => ({
-      formattingToolbar:
-        formattingToolbar ?? (componentsContext ? undefined : false),
-      linkToolbar: linkToolbar ?? (componentsContext ? undefined : false),
-      sideMenu: sideMenu ?? (componentsContext ? undefined : false),
-      slashMenu: slashMenu ?? (componentsContext ? undefined : false),
-      filePanel: filePanel ?? (componentsContext ? undefined : false),
-      tableHandles: tableHandles ?? (componentsContext ? undefined : false),
-      emojiPicker: emojiPicker ?? (componentsContext ? undefined : false),
-      comments: comments ?? (componentsContext ? undefined : false),
+      formattingToolbar: componentsContext ? formattingToolbar : false,
+      linkToolbar: componentsContext ? linkToolbar : false,
+      sideMenu: componentsContext ? sideMenu : false,
+      slashMenu: componentsContext ? slashMenu : false,
+      filePanel: componentsContext ? filePanel : false,
+      tableHandles: componentsContext ? tableHandles : false,
+      emojiPicker: componentsContext ? emojiPicker : false,
+      comments: componentsContext ? comments : false,
     }),
     [
       comments,

--- a/packages/react/src/editor/BlockNoteView.tsx
+++ b/packages/react/src/editor/BlockNoteView.tsx
@@ -31,6 +31,7 @@ import {
   BlockNoteViewContext,
   useBlockNoteViewContext,
 } from "./BlockNoteViewContext.js";
+import { useComponentsContext } from "./ComponentsContext.js";
 import { Portals, getContentComponent } from "./EditorContent.js";
 import { ElementRenderer } from "./ElementRenderer.js";
 
@@ -138,6 +139,33 @@ function BlockNoteViewComponent<
   const editorColorScheme =
     theme || (defaultColorScheme === "dark" ? "dark" : "light");
 
+  // Disable default UI components if no components context is found.
+  const componentsContext = useComponentsContext();
+  const defaultUIProps: BlockNoteDefaultUIProps = useMemo(
+    () => ({
+      formattingToolbar:
+        formattingToolbar ?? (componentsContext ? undefined : false),
+      linkToolbar: linkToolbar ?? (componentsContext ? undefined : false),
+      sideMenu: sideMenu ?? (componentsContext ? undefined : false),
+      slashMenu: slashMenu ?? (componentsContext ? undefined : false),
+      filePanel: filePanel ?? (componentsContext ? undefined : false),
+      tableHandles: tableHandles ?? (componentsContext ? undefined : false),
+      emojiPicker: emojiPicker ?? (componentsContext ? undefined : false),
+      comments: comments ?? (componentsContext ? undefined : false),
+    }),
+    [
+      comments,
+      componentsContext,
+      emojiPicker,
+      filePanel,
+      formattingToolbar,
+      linkToolbar,
+      sideMenu,
+      slashMenu,
+      tableHandles,
+    ],
+  );
+
   useEditorChange(onChange || emptyFn, editor);
   useEditorSelectionChange(onSelectionChange || emptyFn, editor);
 
@@ -180,30 +208,9 @@ function BlockNoteViewComponent<
         contentEditableProps,
         editable,
       },
-      defaultUIProps: {
-        formattingToolbar,
-        linkToolbar,
-        slashMenu,
-        emojiPicker,
-        sideMenu,
-        filePanel,
-        tableHandles,
-        comments,
-      },
+      defaultUIProps,
     };
-  }, [
-    autoFocus,
-    contentEditableProps,
-    editable,
-    formattingToolbar,
-    linkToolbar,
-    slashMenu,
-    emojiPicker,
-    sideMenu,
-    filePanel,
-    tableHandles,
-    comments,
-  ]);
+  }, [autoFocus, contentEditableProps, editable, defaultUIProps]);
 
   return (
     <BlockNoteContext.Provider value={blockNoteContext}>


### PR DESCRIPTION
# Summary

<!-- Briefly describe the feature being introduced. -->

When using `BlockNoteViewRaw` to create a minimal editor, errors are thrown when the editor attempts to render default UI elements as there is no components context to create them from. This PR makes it so that if no component context is found when rendering the editor, all default UI elements are disabled.

Note however that this is not a supported use case and we do not expect `BlockNoteViewRaw` to be used on its own.

Closes #889

## Rationale

<!-- Explain the reasoning behind this feature and its benefits to the project. -->

While this use case is not officially supported, `BlockNoteViewRaw` is exported and may be useful to some.

## Changes

<!-- List the major changes made in this pull request. -->

See above.

## Impact

<!-- Discuss any potential impacts this feature may have on existing functionalities. -->

N/A

## Testing

<!-- Describe how the feature has been tested, including both automated and manual testing strategies. -->

Because this is not something we officially support, no tests have been added.

## Screenshots/Video

<!-- Include screenshots or video demonstrating the new feature, if applicable. -->

N/A

## Checklist

- [X] Code follows the project's coding standards.
- [X] Unit tests covering the new feature have been added.
- [X] All existing tests pass.
- [X] The documentation has been updated to reflect the new feature

## Additional Notes

<!-- Any additional information or context relevant to this PR. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * UI feature defaults now respect surrounding component context instead of being forcibly applied, ensuring feature toggles align with host environment.
  * Default UI settings are memoized with simplified dependencies to reduce unnecessary re-renders and improve performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->