### PR TITLE
feat: upgrade shiki to v4 and prosemirror-highlight to v0.15.1

### DIFF
--- a/examples/04-theming/07-custom-code-block/src/shiki.bundle.ts
+++ b/examples/04-theming/07-custom-code-block/src/shiki.bundle.ts
@@ -4,7 +4,7 @@ import type {
   DynamicImportThemeRegistration,
   HighlighterGeneric,
 } from "@shikijs/types";
-import { createdBundledHighlighter } from "@shikijs/core";
+import { createBundledHighlighter } from "@shikijs/core";
 import { createJavaScriptRegexEngine } from "@shikijs/engine-javascript";
 
 type BundledLanguage = "typescript" | "ts" | "javascript" | "js" | "vue";
@@ -24,7 +24,7 @@ const bundledThemes = {
   "dark-plus": () => import("@shikijs/themes/dark-plus"),
 } as Record<BundledTheme, DynamicImportThemeRegistration>;
 
-const createHighlighter = /* @__PURE__ */ createdBundledHighlighter<
+const createHighlighter = /* @__PURE__ */ createBundledHighlighter<
   BundledLanguage,
   BundledTheme
 >({

--- a/packages/code-block/package.json
+++ b/packages/code-block/package.json
@@ -50,12 +50,11 @@
   },
   "dependencies": {
     "@blocknote/core": "0.47.3",
-    "@shikijs/core": "^3",
-    "@shikijs/engine-javascript": "^3",
-    "@shikijs/langs": "^3",
-    "@shikijs/langs-precompiled": "^3",
-    "@shikijs/themes": "^3",
-    "@shikijs/types": "^3"
+    "@shikijs/core": "^4",
+    "@shikijs/engine-javascript": "^4",
+    "@shikijs/langs-precompiled": "^4",
+    "@shikijs/themes": "^4",
+    "@shikijs/types": "^4"
   },
   "devDependencies": {
     "eslint": "^8.57.1",

--- a/packages/code-block/src/shiki.bundle.ts
+++ b/packages/code-block/src/shiki.bundle.ts
@@ -4,7 +4,7 @@ import type {
   DynamicImportThemeRegistration,
   HighlighterGeneric,
 } from "@shikijs/types";
-import { createdBundledHighlighter } from "@shikijs/core";
+import { createBundledHighlighter } from "@shikijs/core";
 import { createJavaScriptRegexEngine } from "@shikijs/engine-javascript";
 
 type BundledLanguage = "typescript" | "ts" | "javascript" | "js" | "vue";
@@ -77,8 +77,7 @@ const bundledLanguages = {
   rust: () => import("@shikijs/langs-precompiled/rust"),
   rs: () => import("@shikijs/langs-precompiled/rust"),
   scala: () => import("@shikijs/langs-precompiled/scala"),
-  // Swift does not support pre-compilation right now
-  swift: () => import("@shikijs/langs/swift"),
+  swift: () => import("@shikijs/langs-precompiled/swift"),
   kotlin: () => import("@shikijs/langs-precompiled/kotlin"),
   kt: () => import("@shikijs/langs-precompiled/kotlin"),
   kts: () => import("@shikijs/langs-precompiled/kotlin"),
@@ -91,7 +90,7 @@ const bundledThemes = {
   "github-light": () => import("@shikijs/themes/github-light"),
 } as Record<BundledTheme, DynamicImportThemeRegistration>;
 
-const createHighlighter = /* @__PURE__ */ createdBundledHighlighter<
+const createHighlighter = /* @__PURE__ */ createBundledHighlighter<
   BundledLanguage,
   BundledTheme
 >({

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -91,7 +91,7 @@
   "dependencies": {
     "@emoji-mart/data": "^1.2.1",
     "@handlewithcare/prosemirror-inputrules": "^0.1.4",
-    "@shikijs/types": "^3",
+    "@shikijs/types": "^4",
     "@tanstack/store": "^0.7.7",
     "@tiptap/core": "^3.13.0",
     "@tiptap/extension-bold": "^3.13.0",
@@ -108,7 +108,7 @@
     "emoji-mart": "^5.6.0",
     "fast-deep-equal": "^3.1.3",
     "hast-util-from-dom": "^5.0.1",
-    "prosemirror-highlight": "^0.13.0",
+    "prosemirror-highlight": "^0.15.1",
     "prosemirror-model": "^1.25.4",
     "prosemirror-state": "^1.4.4",
     "prosemirror-tables": "^1.8.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4628,23 +4628,20 @@ importers:
         specifier: 0.47.3
         version: link:../core
       '@shikijs/core':
-        specifier: ^3
-        version: 3.23.0
+        specifier: ^4
+        version: 4.0.2
       '@shikijs/engine-javascript':
-        specifier: ^3
-        version: 3.23.0
-      '@shikijs/langs':
-        specifier: ^3
-        version: 3.23.0
+        specifier: ^4
+        version: 4.0.2
       '@shikijs/langs-precompiled':
-        specifier: ^3
-        version: 3.23.0
+        specifier: ^4
+        version: 4.0.2
       '@shikijs/themes':
-        specifier: ^3
-        version: 3.23.0
+        specifier: ^4
+        version: 4.0.2
       '@shikijs/types':
-        specifier: ^3
-        version: 3.23.0
+        specifier: ^4
+        version: 4.0.2
     devDependencies:
       eslint:
         specifier: ^8.57.1
@@ -4674,8 +4671,8 @@ importers:
         specifier: ^0.1.4
         version: 0.1.4(prosemirror-model@1.25.4)(prosemirror-state@1.4.4)(prosemirror-view@1.41.8)
       '@shikijs/types':
-        specifier: ^3
-        version: 3.23.0
+        specifier: ^4
+        version: 4.0.2
       '@tanstack/store':
         specifier: ^0.7.7
         version: 0.7.7
@@ -4725,8 +4722,8 @@ importers:
         specifier: ^5.0.1
         version: 5.0.1
       prosemirror-highlight:
-        specifier: ^0.13.0
-        version: 0.13.0(@shikijs/types@3.23.0)(@types/hast@3.0.4)(prosemirror-model@1.25.4)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.41.8)
+        specifier: ^0.15.1
+        version: 0.15.1(@shikijs/types@4.0.2)(@types/hast@3.0.4)(prosemirror-model@1.25.4)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.41.8)
       prosemirror-model:
         specifier: ^1.25.4
         version: 1.25.4
@@ -9764,6 +9761,10 @@ packages:
     resolution: {integrity: sha512-NVFZ+aosM+a90oUmlM8pRZkVZPFgMabCPicOaP0xklM7Lo6U6J9JqKs+ld1Z9K85k1mfQITc6r7VfZiifitPDA==}
     engines: {node: '>=20'}
 
+  '@shikijs/langs-precompiled@4.0.2':
+    resolution: {integrity: sha512-I7uqbU58tSTgChNtu7dTnJWOo0lAsZMyv1RT9DCb+qlcQu5fkp2lAeISo+2qxunYSX+l81nI83lYp75OoqYzqg==}
+    engines: {node: '>=20'}
+
   '@shikijs/langs@3.23.0':
     resolution: {integrity: sha512-2Ep4W3Re5aB1/62RSYQInK9mM3HsLeB91cHqznAJMuylqjzNVAVCMnNWRHFtcNHXsoNRayP9z1qj4Sq3nMqYXg==}
 
@@ -14611,10 +14612,12 @@ packages:
   prosemirror-gapcursor@1.4.0:
     resolution: {integrity: sha512-z00qvurSdCEWUIulij/isHaqu4uLS8r/Fi61IbjdIPJEonQgggbJsLnstW7Lgdk4zQ68/yr6B6bf7sJXowIgdQ==}
 
-  prosemirror-highlight@0.13.0:
-    resolution: {integrity: sha512-GIC2VCTUnukNdsEGLQWWOVpYPl/7/KrVp4xs7XMB48/4rhUrHK8hp8TEog4Irmv+2kmjx24RLnaisGOCP6U8jw==}
+  prosemirror-highlight@0.15.1:
+    resolution: {integrity: sha512-KcJUGNgqLED+eK/cisNtY3M+eDNLkZyWCdyi7B3RoW3rKHnhkKawnJAcr9p1F/e3q+oDB5Y5OiIrC11bxP7tFA==}
     peerDependencies:
-      '@shikijs/types': ^1.29.2 || ^2.0.0 || ^3.0.0
+      '@lezer/common': ^1.0.0
+      '@lezer/highlight': ^1.0.0
+      '@shikijs/types': ^1.29.2 || ^2.0.0 || ^3.0.0 || ^4.0.0
       '@types/hast': ^3.0.0
       highlight.js: ^11.9.0
       lowlight: ^3.1.0
@@ -14623,8 +14626,12 @@ packages:
       prosemirror-transform: ^1.8.0
       prosemirror-view: ^1.32.4
       refractor: ^5.0.0
-      sugar-high: ^0.6.1 || ^0.7.0 || ^0.8.0 || ^0.9.0
+      sugar-high: ^0.6.1 || ^0.7.0 || ^0.8.0 || ^0.9.0 || ^1.0.0
     peerDependenciesMeta:
+      '@lezer/common':
+        optional: true
+      '@lezer/highlight':
+        optional: true
       '@shikijs/types':
         optional: true
       '@types/hast':
@@ -20676,6 +20683,11 @@ snapshots:
       '@shikijs/types': 3.23.0
       oniguruma-to-es: 4.3.5
 
+  '@shikijs/langs-precompiled@4.0.2':
+    dependencies:
+      '@shikijs/types': 4.0.2
+      oniguruma-to-es: 4.3.5
+
   '@shikijs/langs@3.23.0':
     dependencies:
       '@shikijs/types': 3.23.0
@@ -26519,9 +26531,9 @@ snapshots:
       prosemirror-state: 1.4.4
       prosemirror-view: 1.41.8
 
-  prosemirror-highlight@0.13.0(@shikijs/types@3.23.0)(@types/hast@3.0.4)(prosemirror-model@1.25.4)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.41.8):
+  prosemirror-highlight@0.15.1(@shikijs/types@4.0.2)(@types/hast@3.0.4)(prosemirror-model@1.25.4)(prosemirror-state@1.4.4)(prosemirror-transform@1.12.0)(prosemirror-view@1.41.8):
     optionalDependencies:
-      '@shikijs/types': 3.23.0
+      '@shikijs/types': 4.0.2
       '@types/hast': 3.0.4
       prosemirror-model: 1.25.4
       prosemirror-state: 1.4.4


### PR DESCRIPTION
# Summary

Upgrade shiki from v3 to v4 and prosemirror-highlight from v0.13.0 to v0.15.1 across the core and code-block packages.

## Rationale

Shiki v4 includes a fix for the `createdBundledHighlighter` typo, Swift precompilation support, and requires Node.js >= 20. prosemirror-highlight v0.15.1 adds explicit shiki v4 compatibility.

## Changes

- Bumped all `@shikijs/*` dependencies from `^3` to `^4` in `@blocknote/code-block` and `@blocknote/core`
- Bumped `prosemirror-highlight` from `^0.13.0` to `^0.15.1` in `@blocknote/core`
- Removed `@shikijs/langs` dependency (no longer needed)
- Renamed `createdBundledHighlighter` → `createBundledHighlighter` (typo fixed in shiki v4) in `packages/code-block/src/shiki.bundle.ts` and `examples/04-theming/07-custom-code-block/src/shiki.bundle.ts`
- Switched Swift from runtime JS regex conversion (`@shikijs/langs/swift`) to precompiled (`@shikijs/langs-precompiled/swift`), now supported in v4

## Impact

No breaking API changes for BlockNote consumers. All language highlighting continues to work identically. Swift highlighting now uses precompiled grammars instead of runtime conversion, which is slightly more efficient.

## Testing

- `@blocknote/code-block`: 4/4 tests pass
- `@blocknote/core`: 309 passed, 3 skipped (all pre-existing skips)
- Both packages build successfully

## Checklist

- [x] Code follows the project's coding standards.
- [x] All existing tests pass.

## Additional Notes

Swift was the only language still relying on non-precompiled grammars from `@shikijs/langs`. Shiki v4 added precompilation support for Swift, so all 50 supported languages now use `@shikijs/langs-precompiled` with the JavaScript regex engine (no WASM).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Shiki syntax highlighting library to version 4, replacing the previous v3 with improved highlighting capabilities and performance.
  * Bumped prosemirror-highlight dependency to the latest version for enhanced text processing.
  * Updated related Shiki modules and language packs to maintain compatibility with v4.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->