### PR TITLE
fix: hide side menu on scroll instead of overflow hacks

### DIFF
--- a/docs/app/styles.css
+++ b/docs/app/styles.css
@@ -53,14 +53,6 @@ body {
   box-shadow: unset !important;
 }
 
-.demo {
-  overflow: none;
-}
-
-.demo .bn-container {
-  position: relative;
-}
-
 .demo .bn-container:not(.bn-comment-editor),
 .demo .bn-editor {
   height: 100%;

--- a/packages/core/src/extensions/SideMenu/SideMenu.ts
+++ b/packages/core/src/extensions/SideMenu/SideMenu.ts
@@ -784,5 +784,17 @@ export const SideMenuExtension = createExtension(({ editor }) => {
       view!.state!.show = false;
       view!.emitUpdate(view!.state!);
     },
+
+    /**
+     * Hides the side menu unless it is currently frozen (e.g. the drag
+     * handle menu is open). Used to dismiss the menu on scroll without
+     * interfering with open submenus.
+     */
+    hideMenuIfNotFrozen() {
+      if (!view!.menuFrozen) {
+        view!.state!.show = false;
+        view!.emitUpdate(view!.state!);
+      }
+    },
   } as const;
 });

--- a/packages/core/src/extensions/SideMenu/SideMenu.ts
+++ b/packages/core/src/extensions/SideMenu/SideMenu.ts
@@ -791,7 +791,7 @@ export const SideMenuExtension = createExtension(({ editor }) => {
      * interfering with open submenus.
      */
     hideMenuIfNotFrozen() {
-      if (!view!.menuFrozen) {
+      if (!view!.menuFrozen && view!.state!.show) {
         view!.state!.show = false;
         view!.emitUpdate(view!.state!);
       }

--- a/packages/core/src/extensions/TableHandles/TableHandles.ts
+++ b/packages/core/src/extensions/TableHandles/TableHandles.ts
@@ -908,6 +908,20 @@ export const TableHandlesExtension = createExtension(({ editor }) => {
       view!.menuFrozen = false;
     },
 
+    /**
+     * Hides the table handles unless they are currently frozen (e.g. a
+     * handle menu is open). Used to dismiss the handles on scroll without
+     * interfering with open submenus.
+     */
+    hideHandlesIfNotFrozen() {
+      if (!view!.menuFrozen && view!.state?.show) {
+        view!.state.show = false;
+        view!.state.showAddOrRemoveRowsButton = false;
+        view!.state.showAddOrRemoveColumnsButton = false;
+        view!.emitUpdate();
+      }
+    },
+
     getCellsAtRowHandle(
       block: BlockFromConfigNoChildren<DefaultBlockSchema["table"], any, any>,
       relativeRowIndex: RelativeCellIndices["row"],

--- a/packages/react/src/components/Popovers/GenericPopover.tsx
+++ b/packages/react/src/components/Popovers/GenericPopover.tsx
@@ -3,6 +3,7 @@ import {
   FloatingFocusManager,
   useDismiss,
   useFloating,
+  UseFloatingOptions,
   useHover,
   useInteractions,
   useMergeRefs,
@@ -77,15 +78,48 @@ export function getMountedBoundingClientRectCache(
   };
 }
 
+/**
+ * Merges two `whileElementsMounted` handlers into one. Both run when elements
+ * mount, and both cleanup functions are called on unmount.
+ */
+function mergeWhileElementsMounted(
+  a: UseFloatingOptions["whileElementsMounted"],
+  b: UseFloatingOptions["whileElementsMounted"],
+): UseFloatingOptions["whileElementsMounted"] {
+  if (!a) {
+    return b;
+  }
+  if (!b) {
+    return a;
+  }
+
+  return (reference, floating, update) => {
+    const cleanupA = a(reference, floating, update);
+    const cleanupB = b(reference, floating, update);
+    return () => {
+      cleanupA?.();
+      cleanupB?.();
+    };
+  };
+}
+
 export const GenericPopover = (
   props: FloatingUIOptions & {
     reference?: GenericPopoverReference;
     children: ReactNode;
   },
 ) => {
+  const {
+    whileElementsMounted: _whileElementsMounted,
+    ...restFloatingOptions
+  } = props.useFloatingOptions ?? {};
+
   const { refs, floatingStyles, context } = useFloating<HTMLDivElement>({
-    whileElementsMounted: autoUpdate,
-    ...props.useFloatingOptions,
+    whileElementsMounted: mergeWhileElementsMounted(
+      autoUpdate,
+      props.useFloatingOptions?.whileElementsMounted,
+    ),
+    ...restFloatingOptions,
   });
 
   const { isMounted, styles } = useTransitionStyles(

--- a/packages/react/src/components/SideMenu/SideMenuController.tsx
+++ b/packages/react/src/components/SideMenu/SideMenuController.tsx
@@ -41,6 +41,8 @@ export const SideMenuController = (props: {
         floating,
         () => {
           if (!initialized) {
+            // autoUpdate calls this function once when the floating element is mounted
+            // we don't want to hide the menu in that case
             initialized = true;
             return;
           }

--- a/packages/react/src/components/SideMenu/SideMenuController.tsx
+++ b/packages/react/src/components/SideMenu/SideMenuController.tsx
@@ -1,6 +1,8 @@
 import { SideMenuExtension } from "@blocknote/core/extensions";
-import { FC, useMemo } from "react";
+import { autoUpdate, ReferenceElement } from "@floating-ui/react";
+import { FC, useCallback, useMemo } from "react";
 
+import { useBlockNoteEditor } from "../../hooks/useBlockNoteEditor.js";
 import { useExtensionState } from "../../hooks/useExtension.js";
 import { BlockPopover } from "../Popovers/BlockPopover.js";
 import { FloatingUIOptions } from "../Popovers/FloatingUIOptions.js";
@@ -11,6 +13,7 @@ export const SideMenuController = (props: {
   sideMenu?: FC<SideMenuProps>;
   floatingUIOptions?: Partial<FloatingUIOptions>;
 }) => {
+  const editor = useBlockNoteEditor();
   const state = useExtensionState(SideMenuExtension, {
     selector: (state) => {
       return state !== undefined
@@ -24,12 +27,43 @@ export const SideMenuController = (props: {
 
   const { show, block } = state || {};
 
+  // Hides the side menu on ancestor scroll so it doesn't overflow outside
+  // the editor's scroll container.
+  const whileElementsMounted = useCallback(
+    (
+      reference: ReferenceElement,
+      floating: HTMLElement,
+      _update: () => void,
+    ) => {
+      let initialized = false;
+      return autoUpdate(
+        reference,
+        floating,
+        () => {
+          if (!initialized) {
+            initialized = true;
+            return;
+          }
+          editor.getExtension(SideMenuExtension)?.hideMenuIfNotFrozen();
+        },
+        {
+          ancestorScroll: true,
+          ancestorResize: false,
+          elementResize: false,
+          layoutShift: false,
+        },
+      );
+    },
+    [editor],
+  );
+
   const floatingUIOptions = useMemo<FloatingUIOptions>(
     () => ({
       ...props.floatingUIOptions,
       useFloatingOptions: {
         open: show,
         placement: "left-start",
+        whileElementsMounted,
         ...props.floatingUIOptions?.useFloatingOptions,
       },
       useDismissProps: {
@@ -47,7 +81,7 @@ export const SideMenuController = (props: {
         ...props.floatingUIOptions?.elementProps,
       },
     }),
-    [props.floatingUIOptions, show],
+    [props.floatingUIOptions, show, whileElementsMounted],
   );
 
   const Component = props.sideMenu || SideMenu;

--- a/packages/react/src/components/TableHandles/TableHandlesController.tsx
+++ b/packages/react/src/components/TableHandles/TableHandlesController.tsx
@@ -7,9 +7,9 @@ import {
   StyleSchema,
 } from "@blocknote/core";
 import { TableHandlesExtension } from "@blocknote/core/extensions";
-import { FC, useMemo, useState } from "react";
+import { FC, useCallback, useMemo, useState } from "react";
 
-import { offset, size } from "@floating-ui/react";
+import { autoUpdate, offset, ReferenceElement, size } from "@floating-ui/react";
 import { useBlockNoteEditor } from "../../hooks/useBlockNoteEditor.js";
 import { useExtensionState } from "../../hooks/useExtension.js";
 import { FloatingUIOptions } from "../Popovers/FloatingUIOptions.js";
@@ -137,6 +137,36 @@ export const TableHandlesController = <
     return references;
   }, [editor, state]);
 
+  // Hides the table handles on ancestor scroll so they don't overflow
+  // outside the editor's scroll container.
+  const whileElementsMounted = useCallback(
+    (
+      reference: ReferenceElement,
+      floating: HTMLElement,
+      _update: () => void,
+    ) => {
+      let initialized = false;
+      return autoUpdate(
+        reference,
+        floating,
+        () => {
+          if (!initialized) {
+            initialized = true;
+            return;
+          }
+          editor.getExtension(TableHandlesExtension)?.hideHandlesIfNotFrozen();
+        },
+        {
+          ancestorScroll: true,
+          ancestorResize: false,
+          elementResize: false,
+          layoutShift: false,
+        },
+      );
+    },
+    [editor],
+  );
+
   const floatingUIOptions = useMemo<
     | {
         rowTableHandle: FloatingUIOptions;
@@ -158,6 +188,7 @@ export const TableHandlesController = <
                   (!onlyShownElement || onlyShownElement === "rowTableHandle"),
                 placement: "left",
                 middleware: [offset(-10)],
+                whileElementsMounted,
               },
               focusManagerProps: {
                 disabled: true,
@@ -177,6 +208,7 @@ export const TableHandlesController = <
                     onlyShownElement === "columnTableHandle"),
                 placement: "top",
                 middleware: [offset(-12)],
+                whileElementsMounted,
               },
               focusManagerProps: {
                 disabled: true,
@@ -196,6 +228,7 @@ export const TableHandlesController = <
                   (!onlyShownElement || onlyShownElement === "tableCellHandle"),
                 placement: "top-end",
                 middleware: [offset({ mainAxis: -15, crossAxis: -1 })],
+                whileElementsMounted,
               },
               focusManagerProps: {
                 disabled: true,
@@ -214,6 +247,7 @@ export const TableHandlesController = <
                   (!onlyShownElement ||
                     onlyShownElement === "extendRowsButton"),
                 placement: "bottom",
+                whileElementsMounted,
                 middleware: [
                   size({
                     apply({ rects, elements }) {
@@ -241,6 +275,7 @@ export const TableHandlesController = <
                   (!onlyShownElement ||
                     onlyShownElement === "extendColumnsButton"),
                 placement: "right",
+                whileElementsMounted,
                 middleware: [
                   size({
                     apply({ rects, elements }) {
@@ -262,7 +297,7 @@ export const TableHandlesController = <
             },
           }
         : undefined,
-    [onlyShownElement, state],
+    [onlyShownElement, state, whileElementsMounted],
   );
 
   if (!state) {


### PR DESCRIPTION
# Summary

Hide the side menu when the user scrolls, preventing it from overflowing outside the editor's scroll container (e.g. in docs demos). This reverts the CSS workarounds introduced in #2043 in favor of a proper floating-ui–based solution.

## Rationale

PR #2043 added `overflow: none` and `position: relative` hacks to the docs demo containers to prevent the side menu from visually escaping the demo box. This approach was fragile and didn't address the root cause. The proper fix is to hide the side menu on scroll — the same UX pattern used for keyboard input.

We prefer to handle this on the floating-ui layer instead of adding additional event listeners in the SideMenu extension, as we're trying to refactor more logic out of our custom extensions and into standard floating-ui patterns.

## Changes

- **`docs/app/styles.css`** — Removed `.demo { overflow: none }` and `.demo .bn-container { position: relative }` from #2043
- **`GenericPopover.tsx`** — Added `mergeWhileElementsMounted` helper that composes the default `autoUpdate` with any additional `whileElementsMounted` handler provided via props
- **`SideMenuController.tsx`** — Added a `whileElementsMounted` handler using `autoUpdate` with `ancestorScroll: true` to detect scroll and call `hideMenuIfNotFrozen()`
- **`SideMenu.ts`** — Added `hideMenuIfNotFrozen()` extension method that hides the menu only when it's not frozen (i.e. drag handle submenu is not open)

## Impact

- Side menu now hides on scroll in any context (not just docs demos)
- No impact on drag handle submenu — `hideMenuIfNotFrozen` respects the frozen state
- `GenericPopover`'s new merge behavior is backwards-compatible: when no `whileElementsMounted` is passed, behavior is identical to before

## Testing

- Manual testing: verified side menu hides on scroll in docs demos and playground
- Verified drag handle submenu stays open during scroll (frozen state respected)

## Checklist

- [x] Code follows the project's coding standards.
- [ ] Unit tests covering the new feature have been added.
- [x] All existing tests pass.
- [ ] The documentation has been updated to reflect the new feature

## Additional Notes

Reverts CSS changes from https://github.com/TypeCellOS/BlockNote/pull/2043.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Side menu now automatically hides when not frozen during interactions.
  * Table handles (and related controls) now auto-hide when not frozen during interactions.

* **Refactor**
  * Improved Floating UI lifecycle integration for more stable popovers and handle positioning.

* **Style**
  * Simplified demo container styling (removed certain overflow/position rules), which may affect demo layout/stacking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->