### PR TITLE
fix: add .js extension to fast-deep-equal ESM import

### DIFF
--- a/packages/react/src/hooks/useEditorState.ts
+++ b/packages/react/src/hooks/useEditorState.ts
@@ -1,5 +1,5 @@
 import type { BlockNoteEditor } from "@blocknote/core";
-import deepEqual from "fast-deep-equal/es6/react";
+import deepEqual from "fast-deep-equal/es6/react.js";
 import { useDebugValue, useEffect, useLayoutEffect, useState } from "react";
 import { useSyncExternalStoreWithSelector } from "use-sync-external-store/shim/with-selector";
 import { useBlockNoteContext } from "../editor/BlockNoteContext.js";


### PR DESCRIPTION
# Summary

Fixes the CI failure introduced by d8fb6c2a1 (Next.js server-util integration test) by adding the `.js` extension to the `fast-deep-equal/es6/react` import in `@blocknote/react`.

## Rationale

The `fast-deep-equal` package has no `exports` field in its `package.json`, so Node.js ESM strictly requires the `.js` file extension to resolve subpath imports. The Next.js test app runs under ESM, causing `ERR_MODULE_NOT_FOUND` at runtime.

## Changes

- Added `.js` extension to `fast-deep-equal/es6/react` import in `packages/react/src/hooks/useEditorState.ts`

## Impact

No impact on existing bundler-based consumers (Webpack, Vite, etc.) since they already resolve extensionless imports. This change only affects Node.js ESM resolution, fixing the server-util test.

## Testing

- Rebuilt `@blocknote/react` and verified the dist output contains the corrected import path with `.js` extension.

## Checklist

- [x] Code follows the project's coding standards.
- [x] All existing tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Internal dependency path adjustment to ensure proper module resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->