### PR TITLE
ci(fresh-install): bump examples & playground in lockstep with packages

### DIFF
--- a/.github/workflows/fresh-install-tests.yml
+++ b/.github/workflows/fresh-install-tests.yml
@@ -11,9 +11,6 @@ name: Fresh Install Tests
 # so test tooling churn doesn't cause false positives.
 
 on:
-  push:
-    branches:
-      - main
   schedule:
     - cron: "0 2 * * *" # Daily at 02:00 UTC
   workflow_dispatch: # Allow manual runs

--- a/.github/workflows/fresh-install-tests.yml
+++ b/.github/workflows/fresh-install-tests.yml
@@ -14,6 +14,7 @@ on:
   push:
     branches:
       - package-upgrades
+      - feat/fresh-install-debug
   schedule:
     - cron: "0 2 * * *" # Daily at 02:00 UTC
   workflow_dispatch: # Allow manual runs
@@ -47,25 +48,26 @@ jobs:
         run: pnpm install
 
       - id: update_prod_deps
-        name: Update prod deps of published packages
-        # Resolves production dependencies of every published (non-private)
-        # workspace package to the latest version within their declared semver
-        # ranges. This simulates what a user gets when running
-        # `npm install @blocknote/react` in a fresh project.
+        name: Update prod deps of packages, examples, and playground
+        # Resolves production dependencies to the latest versions within declared
+        # semver ranges for:
+        #   - packages/*    – the published @blocknote/* packages
+        #   - examples/*/*  – the individual example apps
+        #   - playground    – the example-editor app that bundles the examples
+        # Examples and playground are included so shared peer-dep'd libs
+        # (e.g. @tiptap/core + @tiptap/pm) resolve to the same version across
+        # publishable packages and the apps consuming them; otherwise pnpm ends
+        # up with two virtual-store copies keyed on different peer versions and
+        # TypeScript treats their exports as unrelated types.
+        # docs/, shared/, tests/, fumadocs/ are deliberately excluded — they're
+        # not part of the "fresh npm install @blocknote/react" user experience
+        # this workflow simulates.
         # DevDependencies are left at their lockfile versions.
-        run: |
-          FILTERS=$(node -e "
-            const fs = require('fs');
-            const path = require('path');
-            fs.readdirSync('packages').forEach(dir => {
-              try {
-                const pkg = JSON.parse(fs.readFileSync(path.join('packages', dir, 'package.json'), 'utf8'));
-                if (!pkg.private && pkg.name) process.stdout.write('--filter ' + pkg.name + ' ');
-              } catch {}
-            });
-          ")
-          echo "Updating prod deps for: $FILTERS"
-          eval pnpm update --prod $FILTERS
+        run: >-
+          pnpm update --prod
+          --filter "./packages/*"
+          --filter "./examples/*/*"
+          --filter "./playground"
 
       - id: build_packages
         name: Build packages

--- a/.github/workflows/fresh-install-tests.yml
+++ b/.github/workflows/fresh-install-tests.yml
@@ -13,8 +13,7 @@ name: Fresh Install Tests
 on:
   push:
     branches:
-      - package-upgrades
-      - feat/fresh-install-debug
+      - main
   schedule:
     - cron: "0 2 * * *" # Daily at 02:00 UTC
   workflow_dispatch: # Allow manual runs

--- a/.github/workflows/fresh-install-tests.yml
+++ b/.github/workflows/fresh-install-tests.yml
@@ -48,26 +48,38 @@ jobs:
         run: pnpm install
 
       - id: update_prod_deps
-        name: Update prod deps of packages, examples, and playground
-        # Resolves production dependencies to the latest versions within declared
-        # semver ranges for:
-        #   - packages/*    – the published @blocknote/* packages
-        #   - examples/*/*  – the individual example apps
-        #   - playground    – the example-editor app that bundles the examples
-        # Examples and playground are included so shared peer-dep'd libs
-        # (e.g. @tiptap/core + @tiptap/pm) resolve to the same version across
-        # publishable packages and the apps consuming them; otherwise pnpm ends
-        # up with two virtual-store copies keyed on different peer versions and
-        # TypeScript treats their exports as unrelated types.
-        # docs/, shared/, tests/, fumadocs/ are deliberately excluded — they're
-        # not part of the "fresh npm install @blocknote/react" user experience
-        # this workflow simulates.
+        name: Update prod deps of published packages
+        # Resolves production dependencies of every published (non-private)
+        # workspace package to the latest version within their declared semver
+        # ranges. This simulates what a user gets when running
+        # `npm install @blocknote/react` in a fresh project.
         # DevDependencies are left at their lockfile versions.
-        run: >-
-          pnpm update --prod
-          --filter "./packages/*"
-          --filter "./examples/*/*"
-          --filter "./playground"
+        run: |
+          FILTERS=$(node -e "
+            const fs = require('fs');
+            const path = require('path');
+            fs.readdirSync('packages').forEach(dir => {
+              try {
+                const pkg = JSON.parse(fs.readFileSync(path.join('packages', dir, 'package.json'), 'utf8'));
+                if (!pkg.private && pkg.name) process.stdout.write('--filter ' + pkg.name + ' ');
+              } catch {}
+            });
+          ")
+          echo "Updating prod deps for: $FILTERS"
+          eval pnpm update --prod $FILTERS
+
+      - id: dedupe_deps
+        name: Dedupe transitive dependencies
+        # After bumping the publishable packages' prod deps, collapse any
+        # duplicate transitive resolutions (e.g. @tiptap/core + @tiptap/pm)
+        # that would otherwise differ between the updated publishable packages
+        # and the un-updated examples/playground. Without this, TypeScript
+        # treats the two copies' exports as unrelated types and example-editor
+        # fails to build (TS2322 on Extension<any, any> vs AnyExtension).
+        # Dedupe only rewrites the lockfile — it does NOT modify package.json,
+        # so the examples' "@blocknote/*": "latest" specs (which is what
+        # CodeSandbox users see) stay intact.
+        run: pnpm dedupe
 
       - id: build_packages
         name: Build packages
@@ -108,6 +120,8 @@ jobs:
             failed_step="Install dependencies"
           elif [ "${{ steps.update_prod_deps.outcome }}" = "failure" ]; then
             failed_step="Update prod deps of published packages"
+          elif [ "${{ steps.dedupe_deps.outcome }}" = "failure" ]; then
+            failed_step="Dedupe transitive dependencies"
           elif [ "${{ steps.build_packages.outcome }}" = "failure" ]; then
             failed_step="Build packages"
           elif [ "${{ steps.run_unit_tests.outcome }}" = "failure" ]; then

--- a/packages/core/src/blocks/ListItem/NumberedListItem/IndexingPlugin.test.ts
+++ b/packages/core/src/blocks/ListItem/NumberedListItem/IndexingPlugin.test.ts
@@ -1,5 +1,5 @@
 import { Selection } from "prosemirror-state";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 
 import { BlockNoteEditor } from "../../../editor/BlockNoteEditor.js";
 
@@ -9,9 +9,22 @@ import { BlockNoteEditor } from "../../../editor/BlockNoteEditor.js";
 
 const PLUGIN_KEY = "numbered-list-indexing-decorations$";
 
+// Track editors created in each test so we can destroy them in afterEach —
+// otherwise prosemirror-view's DOMObserver leaves a setTimeout alive that
+// fires after vitest tears down jsdom, throwing
+// `ReferenceError: document is not defined` and failing the run.
+const activeEditors: BlockNoteEditor<any, any, any>[] = [];
+
+afterEach(() => {
+  while (activeEditors.length) {
+    activeEditors.pop()!._tiptapEditor.destroy();
+  }
+});
+
 function createEditor() {
   const editor = BlockNoteEditor.create();
   editor.mount(document.createElement("div"));
+  activeEditors.push(editor);
   return editor;
 }
 

--- a/packages/core/src/blocks/ListItem/NumberedListItem/IndexingPlugin.test.ts
+++ b/packages/core/src/blocks/ListItem/NumberedListItem/IndexingPlugin.test.ts
@@ -9,7 +9,7 @@ import { BlockNoteEditor } from "../../../editor/BlockNoteEditor.js";
 
 const PLUGIN_KEY = "numbered-list-indexing-decorations$";
 
-// Track editors created in each test so we can destroy them in afterEach —
+// Track editors created in each test so we can unmount them in afterEach —
 // otherwise prosemirror-view's DOMObserver leaves a setTimeout alive that
 // fires after vitest tears down jsdom, throwing
 // `ReferenceError: document is not defined` and failing the run.
@@ -17,7 +17,7 @@ const activeEditors: BlockNoteEditor<any, any, any>[] = [];
 
 afterEach(() => {
   while (activeEditors.length) {
-    activeEditors.pop()!._tiptapEditor.destroy();
+    activeEditors.pop()!.unmount();
   }
 });
 


### PR DESCRIPTION
## Summary

- **Problem**: The **Fresh Install Tests** workflow has been failing at the *Build packages* step. Root cause is a TS2322 in `@blocknote/example-editor`: `Extension<any, any>` not assignable to `AnyExtension`. The workflow's `pnpm update --prod --filter <publishable @blocknote/* only>` upgraded `@tiptap/react`/`@tiptap/pm` to `3.22.4` in the publishable packages, but `examples/*` and `playground` stayed at `3.22.3`. Since `@tiptap/core` has `@tiptap/pm` as a peer dep, pnpm created two virtual-store copies (`...@pm@3.22.3` and `...@pm@3.22.4`) and TypeScript treated their `Extension` exports as unrelated types.
- **Fix**: Extend the update filter to also cover `./examples/*/*` and `./playground`. `docs/`, `shared/`, `tests/`, `fumadocs/` stay excluded — they're not part of the "fresh `npm install @blocknote/react`" user experience this workflow simulates. DevDependencies still stay pinned to the lockfile via `--prod`.
- Also adds `feat/fresh-install-debug` to the workflow's `push` triggers so this PR exercises the workflow.

Verified locally: clean `pnpm install` + targeted update + `nx run @blocknote/example-editor:build` all pass (was failing before).

## Test plan

- [ ] Fresh Install Tests workflow succeeds on this branch (triggered by the push)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI workflow now runs fresh-install tests on an additional branch.
  * Added a dependency deduplication step to reduce duplicate transitive installs and produce a cleaner lockfile.
  * Improved CI failure notifications to surface failures from the new dedupe step.

* **Tests**
  * Enhanced test teardown to properly dispose editor instances after each test, reducing resource leaks and flakiness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->