### PR TITLE
fix(markdown): avoid autolink angle brackets when copying plain URL l…

### DIFF
--- a/packages/core/src/api/exporters/markdown/markdownExporter.ts
+++ b/packages/core/src/api/exporters/markdown/markdownExporter.ts
@@ -33,7 +33,22 @@ export function cleanHTMLToMarkdown(cleanHTMLString: string) {
     .use(deps.rehypeRemark.default)
     .use(deps.remarkGfm.default)
     .use(deps.remarkStringify.default, {
-      handlers: { text: (node) => node.value },
+      handlers: {
+        text: (node) => node.value,
+        // Prevent autolink format <url> output plain URL instead
+        link: (node, _parent, state) => {
+          const children = state.containerPhrasing(node, {
+            before: "[",
+            after: "]",
+            lineShift: 0,
+            now: { line: 1, column: 1, offset: 0 },
+          });
+          if (!children || children === node.url) {
+            return node.url;
+          }
+          return `[${children}](${node.url})`;
+        },
+      },
     })
     .processSync(cleanHTMLString);
 

--- a/packages/core/src/api/exporters/markdown/markdownExporter.ts
+++ b/packages/core/src/api/exporters/markdown/markdownExporter.ts
@@ -35,18 +35,18 @@ export function cleanHTMLToMarkdown(cleanHTMLString: string) {
     .use(deps.remarkStringify.default, {
       handlers: {
         text: (node) => node.value,
-        // Prevent autolink format <url> output plain URL instead
-        link: (node, _parent, state) => {
+        // Prevent autolink format <url>, output plain URL instead
+        link: (node, _parent, state, info) => {
           const children = state.containerPhrasing(node, {
+            ...info,
             before: "[",
             after: "]",
-            lineShift: 0,
-            now: { line: 1, column: 1, offset: 0 },
           });
           if (!children || children === node.url) {
             return node.url;
           }
-          return `[${children}](${node.url})`;
+          const url = state.safe(node.url, { before: "(", after: ")" });
+          return `[${children}](${url})`;
         },
       },
     })


### PR DESCRIPTION
## Purpose

Fix broken links when copying a URL from a BlockNote document and pasting it
into another input (link toolbar).

When copying content from the editor, BlockNote serializes links to
`text/plain` using Markdown. Plain URL links (where text = URL) were
serialized as Markdown autolinks (`<https://example.com>`), causing the angle
brackets to be included wherever the text was pasted, resulting in invalid
hrefs.

## Proposal

* [x] Add a custom `link` handler in `remarkStringify` inside
  `cleanHTMLToMarkdown` to output plain URLs instead of Markdown autolink
  format when the link text equals the URL
* [x] When the link has a distinct label, the standard Markdown format
  `[label](url)` is preserved

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Markdown export link handling to avoid autolink-style rendering when link text equals the URL.
  * Descriptive links continue to export as standard Markdown ([text](url)) for readability.
  * URLs are now escaped when needed to ensure links render correctly in parentheses and other contexts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->