### PR TITLE
fix: Non-editable link clicks opening duplicate tabs

### DIFF
--- a/packages/core/src/editor/managers/ExtensionManager/extensions.ts
+++ b/packages/core/src/editor/managers/ExtensionManager/extensions.ts
@@ -2,6 +2,7 @@ import {
   AnyExtension as AnyTiptapExtension,
   extensions,
   getAttributes,
+  mergeAttributes,
   Node,
   Extension as TiptapExtension,
 } from "@tiptap/core";
@@ -117,7 +118,13 @@ export function getDefaultTiptapExtensions(
 
                   let link: HTMLAnchorElement | null = null;
 
-                  if (event.target instanceof HTMLAnchorElement) {
+                  if (
+                    event.target instanceof HTMLAnchorElement &&
+                    // Differentiate between link inline content and read-only links.
+                    event.target.hasAttribute("data-inline-content-type") &&
+                    event.target.getAttribute("data-inline-content-type") ===
+                      "link"
+                  ) {
                     link = event.target;
                   } else {
                     const target = event.target as HTMLElement | null;
@@ -128,8 +135,10 @@ export function getDefaultTiptapExtensions(
                     const root = tiptapEditor.view.dom;
 
                     // Intentionally limit the lookup to the editor root.
-                    // Using tag names like DIV as boundaries breaks with custom NodeViews.
-                    link = target.closest<HTMLAnchorElement>("a");
+                    // Using tag names like DIV as boundaries breaks with custom NodeViews,
+                    link = target.closest<HTMLAnchorElement>(
+                      'a[data-inline-content-type="link"]',
+                    );
 
                     if (link && !root.contains(link)) {
                       link = null;
@@ -178,7 +187,13 @@ export function getDefaultTiptapExtensions(
         defaultProtocol: DEFAULT_LINK_PROTOCOL,
         // only call this once if we have multiple editors installed. Or fix https://github.com/ueberdosis/tiptap/issues/5450
         protocols: LINKIFY_INITIALIZED ? [] : VALID_LINK_PROTOCOLS,
-        HTMLAttributes: options.links?.HTMLAttributes ?? {},
+        HTMLAttributes: mergeAttributes(
+          {
+            className: "bn-inline-content-section",
+            "data-inline-content-type": "link",
+          },
+          options.links?.HTMLAttributes ?? {},
+        ),
         // Always false as we handle clicks ourselves above.
         openOnClick: false,
       }),

--- a/tests/src/unit/core/formatConversion/export/__snapshots__/blocknoteHTML/hardbreak/between-links.html
+++ b/tests/src/unit/core/formatConversion/export/__snapshots__/blocknoteHTML/hardbreak/between-links.html
@@ -6,12 +6,16 @@
           <a
             target="_blank"
             rel="noopener noreferrer nofollow"
+            classname="bn-inline-content-section"
+            data-inline-content-type="link"
             href="https://www.website.com"
           >Link1</a>
           <br />
           <a
             target="_blank"
             rel="noopener noreferrer nofollow"
+            classname="bn-inline-content-section"
+            data-inline-content-type="link"
             href="https://www.website2.com"
           >Link2</a>
         </p>

--- a/tests/src/unit/core/formatConversion/export/__snapshots__/blocknoteHTML/hardbreak/link.html
+++ b/tests/src/unit/core/formatConversion/export/__snapshots__/blocknoteHTML/hardbreak/link.html
@@ -6,12 +6,16 @@
           <a
             target="_blank"
             rel="noopener noreferrer nofollow"
+            classname="bn-inline-content-section"
+            data-inline-content-type="link"
             href="https://www.website.com"
           >Link1</a>
           <br />
           <a
             target="_blank"
             rel="noopener noreferrer nofollow"
+            classname="bn-inline-content-section"
+            data-inline-content-type="link"
             href="https://www.website.com"
           >Link1</a>
         </p>

--- a/tests/src/unit/core/formatConversion/export/__snapshots__/blocknoteHTML/link/adjacent.html
+++ b/tests/src/unit/core/formatConversion/export/__snapshots__/blocknoteHTML/link/adjacent.html
@@ -6,11 +6,15 @@
           <a
             target="_blank"
             rel="noopener noreferrer nofollow"
+            classname="bn-inline-content-section"
+            data-inline-content-type="link"
             href="https://www.website.com"
           >Website</a>
           <a
             target="_blank"
             rel="noopener noreferrer nofollow"
+            classname="bn-inline-content-section"
+            data-inline-content-type="link"
             href="https://www.website2.com"
           >Website2</a>
         </p>

--- a/tests/src/unit/core/formatConversion/export/__snapshots__/blocknoteHTML/link/basic.html
+++ b/tests/src/unit/core/formatConversion/export/__snapshots__/blocknoteHTML/link/basic.html
@@ -6,6 +6,8 @@
           <a
             target="_blank"
             rel="noopener noreferrer nofollow"
+            classname="bn-inline-content-section"
+            data-inline-content-type="link"
             href="https://www.website.com"
           >Website</a>
         </p>

--- a/tests/src/unit/core/formatConversion/export/__snapshots__/blocknoteHTML/link/styled.html
+++ b/tests/src/unit/core/formatConversion/export/__snapshots__/blocknoteHTML/link/styled.html
@@ -7,12 +7,16 @@
             <a
               target="_blank"
               rel="noopener noreferrer nofollow"
+              classname="bn-inline-content-section"
+              data-inline-content-type="link"
               href="https://www.website.com"
             >Web</a>
           </strong>
           <a
             target="_blank"
             rel="noopener noreferrer nofollow"
+            classname="bn-inline-content-section"
+            data-inline-content-type="link"
             href="https://www.website.com"
           >site</a>
         </p>

--- a/tests/src/unit/core/formatConversion/export/__snapshots__/html/hardbreak/between-links.html
+++ b/tests/src/unit/core/formatConversion/export/__snapshots__/html/hardbreak/between-links.html
@@ -2,12 +2,16 @@
   <a
     target="_blank"
     rel="noopener noreferrer nofollow"
+    classname="bn-inline-content-section"
+    data-inline-content-type="link"
     href="https://www.website.com"
   >Link1</a>
   <br />
   <a
     target="_blank"
     rel="noopener noreferrer nofollow"
+    classname="bn-inline-content-section"
+    data-inline-content-type="link"
     href="https://www.website2.com"
   >Link2</a>
 </p>

--- a/tests/src/unit/core/formatConversion/export/__snapshots__/html/hardbreak/link.html
+++ b/tests/src/unit/core/formatConversion/export/__snapshots__/html/hardbreak/link.html
@@ -2,12 +2,16 @@
   <a
     target="_blank"
     rel="noopener noreferrer nofollow"
+    classname="bn-inline-content-section"
+    data-inline-content-type="link"
     href="https://www.website.com"
   >Link1</a>
   <br />
   <a
     target="_blank"
     rel="noopener noreferrer nofollow"
+    classname="bn-inline-content-section"
+    data-inline-content-type="link"
     href="https://www.website.com"
   >Link1</a>
 </p>

--- a/tests/src/unit/core/formatConversion/export/__snapshots__/html/link/adjacent.html
+++ b/tests/src/unit/core/formatConversion/export/__snapshots__/html/link/adjacent.html
@@ -2,11 +2,15 @@
   <a
     target="_blank"
     rel="noopener noreferrer nofollow"
+    classname="bn-inline-content-section"
+    data-inline-content-type="link"
     href="https://www.website.com"
   >Website</a>
   <a
     target="_blank"
     rel="noopener noreferrer nofollow"
+    classname="bn-inline-content-section"
+    data-inline-content-type="link"
     href="https://www.website2.com"
   >Website2</a>
 </p>

--- a/tests/src/unit/core/formatConversion/export/__snapshots__/html/link/basic.html
+++ b/tests/src/unit/core/formatConversion/export/__snapshots__/html/link/basic.html
@@ -2,6 +2,8 @@
   <a
     target="_blank"
     rel="noopener noreferrer nofollow"
+    classname="bn-inline-content-section"
+    data-inline-content-type="link"
     href="https://www.website.com"
   >Website</a>
 </p>

--- a/tests/src/unit/core/formatConversion/export/__snapshots__/html/link/styled.html
+++ b/tests/src/unit/core/formatConversion/export/__snapshots__/html/link/styled.html
@@ -3,12 +3,16 @@
     <a
       target="_blank"
       rel="noopener noreferrer nofollow"
+      classname="bn-inline-content-section"
+      data-inline-content-type="link"
       href="https://www.website.com"
     >Web</a>
   </strong>
   <a
     target="_blank"
     rel="noopener noreferrer nofollow"
+    classname="bn-inline-content-section"
+    data-inline-content-type="link"
     href="https://www.website.com"
   >site</a>
 </p>


### PR DESCRIPTION
# Summary

<!-- Briefly describe the feature being introduced. -->

This PR fixes a bug causing the `Link` extension's click handler to also fire on links that were non-editable, causing duplicate tabs to open.

Closes #1040 

## Rationale

<!-- Explain the reasoning behind this feature and its benefits to the project. -->

This is a bug.

## Changes

<!-- List the major changes made in this pull request. -->

- Added CSS class and `data-inline-content-type` attribute to inline/rich-text links to differentiate them from links that may be rendered by e.g. custom blocks.
- Made click handler in `Link` extension ignore links without those.

## Impact

<!-- Discuss any potential impacts this feature may have on existing functionalities. -->

N/A

## Testing

<!-- Describe how the feature has been tested, including both automated and manual testing strategies. -->

N/A, Needed?

## Screenshots/Video

<!-- Include screenshots or video demonstrating the new feature, if applicable. -->

N/A

## Checklist

- [X] Code follows the project's coding standards.
- [X] Unit tests covering the new feature have been added.
- [X] All existing tests pass.
- [X] The documentation has been updated to reflect the new feature

## Additional Notes

<!-- Any additional information or context relevant to this PR. -->
