### PR TITLE
feat: Link customization options (BLO-913)

### DIFF
--- a/docs/content/docs/features/blocks/inline-content.mdx
+++ b/docs/content/docs/features/blocks/inline-content.mdx
@@ -116,6 +116,8 @@ const editor = BlockNoteEditor.create({
 
 Custom handler invoked when a link is clicked. If left `undefined`, links are opened in a new window on click (the default behavior). If provided, that default behavior is disabled and this function is called instead.
 
+Returning `false` will let BlockNote run other click handlers after this one. Returning `true` or nothing (the default) marks the event as handled.
+
 ```ts
 const editor = BlockNoteEditor.create({
   links: {

--- a/docs/content/docs/features/blocks/inline-content.mdx
+++ b/docs/content/docs/features/blocks/inline-content.mdx
@@ -79,6 +79,53 @@ type Link = {
 };
 ```
 
+### Customizing Links
+
+You can customize how links are rendered and how they respond to clicks with the `links` editor option.
+
+```ts
+const editor = BlockNoteEditor.create({
+  links: {
+    HTMLAttributes: {
+      class: "my-link-class",
+      target: "_blank",
+    },
+    onClick: (event) => {
+      // Custom click logic, e.g. routing without a page reload.
+    },
+  },
+});
+```
+
+#### `HTMLAttributes`
+
+Additional HTML attributes that should be added to rendered link elements.
+
+```ts
+const editor = BlockNoteEditor.create({
+  links: {
+    HTMLAttributes: {
+      class: "my-link-class",
+      target: "_blank",
+    },
+  },
+});
+```
+
+#### `onClick`
+
+Custom handler invoked when a link is clicked. If left `undefined`, links are opened in a new window on click (the default behavior). If provided, that default behavior is disabled and this function is called instead.
+
+```ts
+const editor = BlockNoteEditor.create({
+  links: {
+    onClick: (event) => {
+      // Do something when a link is clicked.
+    },
+  },
+});
+```
+
 ## Default Styles
 
 The default text formatting options in BlockNote are represented by the `Styles` in the default schema:

--- a/packages/core/src/editor/BlockNoteEditor.ts
+++ b/packages/core/src/editor/BlockNoteEditor.ts
@@ -141,6 +141,25 @@ export interface BlockNoteEditorOptions<
   >[];
 
   /**
+   * Options for configuring how links behave in the editor.
+   */
+  links?: {
+    /**
+     * HTML attributes to add to rendered link elements.
+     *
+     * @default {}
+     * @example { class: "my-link-class", target: "_blank" }
+     */
+    HTMLAttributes?: Record<string, any>;
+    /**
+     * Custom handler invoked when a link is clicked. If left `undefined`,
+     * links are opened in a new window on click. If provided, the default
+     * open-on-click behavior is disabled and this function is called instead.
+     */
+    onClick?: (event: MouseEvent) => void;
+  };
+
+  /**
    * @deprecated, provide placeholders via dictionary instead
    * @internal
    */

--- a/packages/core/src/editor/BlockNoteEditor.ts
+++ b/packages/core/src/editor/BlockNoteEditor.ts
@@ -155,8 +155,11 @@ export interface BlockNoteEditorOptions<
      * Custom handler invoked when a link is clicked. If left `undefined`,
      * links are opened in a new window on click. If provided, the default
      * open-on-click behavior is disabled and this function is called instead.
+     *
+     * Return `false` to let ProseMirror continue handling the click event.
+     * Returning `true` or nothing (the default) marks the event as handled.
      */
-    onClick?: (event: MouseEvent) => void;
+    onClick?: (event: MouseEvent) => boolean | void;
   };
 
   /**

--- a/packages/core/src/editor/managers/ExtensionManager/extensions.ts
+++ b/packages/core/src/editor/managers/ExtensionManager/extensions.ts
@@ -73,7 +73,10 @@ export function getDefaultTiptapExtensions(
     SuggestionAddMark,
     SuggestionDeleteMark,
     SuggestionModificationMark,
-    Link,
+    Link.configure({
+      HTMLAttributes: options.links?.HTMLAttributes ?? {},
+      onClick: options.links?.onClick,
+    }),
     ...(Object.values(editor.schema.styleSpecs).map((styleSpec) => {
       return styleSpec.implementation.mark.configure({
         editor: editor,

--- a/packages/core/src/extensions/tiptap-extensions/Link/helpers/clickHandler.ts
+++ b/packages/core/src/extensions/tiptap-extensions/Link/helpers/clickHandler.ts
@@ -6,7 +6,7 @@ import { Plugin, PluginKey } from "@tiptap/pm/state";
 type ClickHandlerOptions = {
   type: MarkType;
   editor: Editor;
-  onClick?: (event: MouseEvent) => void;
+  onClick?: (event: MouseEvent) => boolean | void;
 };
 
 export function clickHandler(options: ClickHandlerOptions): Plugin {
@@ -48,8 +48,8 @@ export function clickHandler(options: ClickHandlerOptions): Plugin {
         }
 
         if (options.onClick) {
-          options.onClick(event);
-          return true;
+          const result = options.onClick(event);
+          return result ?? true;
         }
 
         const attrs = getAttributes(view.state, options.type.name);

--- a/packages/core/src/extensions/tiptap-extensions/Link/helpers/clickHandler.ts
+++ b/packages/core/src/extensions/tiptap-extensions/Link/helpers/clickHandler.ts
@@ -6,6 +6,7 @@ import { Plugin, PluginKey } from "@tiptap/pm/state";
 type ClickHandlerOptions = {
   type: MarkType;
   editor: Editor;
+  onClick?: (event: MouseEvent) => void;
 };
 
 export function clickHandler(options: ClickHandlerOptions): Plugin {
@@ -44,6 +45,11 @@ export function clickHandler(options: ClickHandlerOptions): Plugin {
 
         if (!link) {
           return false;
+        }
+
+        if (options.onClick) {
+          options.onClick(event);
+          return true;
         }
 
         const attrs = getAttributes(view.state, options.type.name);

--- a/packages/core/src/extensions/tiptap-extensions/Link/link.ts
+++ b/packages/core/src/extensions/tiptap-extensions/Link/link.ts
@@ -57,7 +57,7 @@ function shouldAutoLink(url: string): boolean {
 
 export type LinkOptions = {
   HTMLAttributes: Record<string, any>;
-  onClick?: (event: MouseEvent) => void;
+  onClick?: (event: MouseEvent) => boolean | void;
 };
 
 /**

--- a/packages/core/src/extensions/tiptap-extensions/Link/link.ts
+++ b/packages/core/src/extensions/tiptap-extensions/Link/link.ts
@@ -55,10 +55,15 @@ function shouldAutoLink(url: string): boolean {
   return true;
 }
 
+export type LinkOptions = {
+  HTMLAttributes: Record<string, any>;
+  onClick?: (event: MouseEvent) => void;
+};
+
 /**
  * BlockNote Link mark extension.
  */
-export const Link = Mark.create({
+export const Link = Mark.create<LinkOptions>({
   name: "link",
 
   priority: 1000,
@@ -68,6 +73,13 @@ export const Link = Mark.create({
   exitable: true,
 
   inclusive: false,
+
+  addOptions() {
+    return {
+      HTMLAttributes: {},
+      onClick: undefined,
+    };
+  },
 
   addAttributes() {
     return {
@@ -156,14 +168,14 @@ export const Link = Mark.create({
         defaultProtocol: DEFAULT_PROTOCOL,
         validate: isAllowedUri,
         shouldAutoLink,
-      })
+      }),
     );
 
     plugins.push(
       clickHandler({
         type: this.type,
         editor: this.editor,
-      })
+      }),
     );
 
     plugins.push(
@@ -172,7 +184,7 @@ export const Link = Mark.create({
         defaultProtocol: DEFAULT_PROTOCOL,
         type: this.type,
         shouldAutoLink,
-      })
+      }),
     );
 
     return plugins;


### PR DESCRIPTION
# Summary

<!-- Briefly describe the feature being introduced. -->

This PR adds a new editor option:

```
links: Partial<{
  HTMLAttributes: Record<string, any>;
  onClick?: (event: MouseEvent) => void;
}>
```

These do basically what they say - `HTMLAttributes` adds HTML attributes to rendered link elements and `onClick` replaces the default click behaviour (which opens the link in a new tab).

Closes #1539 

## Rationale

<!-- Explain the reasoning behind this feature and its benefits to the project. -->

Some users are finding it annoying that links open a new tab on click when they're just trying to move the selection. 

HTML attributes allow for slight customization for link rendering. It's the best we can do atm, but really more of a stopgap solution as consumers should ideally be able to override the default link rendering with whatever they want.

## Changes

<!-- List the major changes made in this pull request. -->

See above.

## Impact

<!-- Discuss any potential impacts this feature may have on existing functionalities. -->

N/A

## Testing

<!-- Describe how the feature has been tested, including both automated and manual testing strategies. -->

N/A (example needed?)

## Screenshots/Video

<!-- Include screenshots or video demonstrating the new feature, if applicable. -->

N/A

## Checklist

- [X] Code follows the project's coding standards.
- [X] Unit tests covering the new feature have been added.
- [X] All existing tests pass.
- [X] The documentation has been updated to reflect the new feature

## Additional Notes

<!-- Any additional information or context relevant to this PR. -->

N/A