### PR TITLE
fix: Drag preview blocking drops when overlapping the editor (BLO-996)

### DIFF
--- a/packages/core/src/editor/editor.css
+++ b/packages/core/src/editor/editor.css
@@ -80,6 +80,11 @@
    hidden. So setting it to an extremely low value instead makes the element
    functionally invisible while not affecting the drag preview itself. */
   opacity: 0.001;
+  /* The element is kept in the DOM after setDragImage captures its snapshot,
+   so it can overlap the editor and block drops in that area. Disabling
+   pointer-events lets drag/drop events pass through to the editor while
+   leaving the captured preview unaffected. */
+  pointer-events: none;
 }
 
 .bn-editor .bn-collaboration-cursor__base {


### PR DESCRIPTION
# Summary

<!-- Briefly describe the feature being introduced. -->

When dragging & dropping a block, an invisible HTML element is added to the DOM to set as the drag preview image.

Depending on the size of the dragged block and the position of the editor, this element may overlap with the editor HTML element, blocking the user from dropping the block anywhere covered by the preview element.

This PR fixes that by adding `pointer-events: none;` to the preview element CSS.

Closes #2369

## Rationale

<!-- Explain the reasoning behind this feature and its benefits to the project. -->

This is a bug, and it's especially unclear to the user why they cannot drop blocks in certain places.

## Changes

<!-- List the major changes made in this pull request. -->

See above.

## Impact

<!-- Discuss any potential impacts this feature may have on existing functionalities. -->

N/A

## Testing

<!-- Describe how the feature has been tested, including both automated and manual testing strategies. -->

N/A

## Screenshots/Video

<!-- Include screenshots or video demonstrating the new feature, if applicable. -->

N/A

## Checklist

- [X] Code follows the project's coding standards.
- [X] Unit tests covering the new feature have been added.
- [X] All existing tests pass.
- [X] The documentation has been updated to reflect the new feature

## Additional Notes

<!-- Any additional information or context relevant to this PR. -->

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated drag preview styling to ensure drag and drop interactions pass through to the underlying editor UI while maintaining visual transparency. This improves interaction handling during drag operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->