### PR TITLE
fix: cannot copy image when it is the first/only block in editor (#2016)

### DIFF
--- a/packages/core/src/api/clipboard/toClipboard/copyExtension.ts
+++ b/packages/core/src/api/clipboard/toClipboard/copyExtension.ts
@@ -127,7 +127,12 @@ export function selectedFragmentToHTML<
     );
   }
 
-  let selectedFragment = view.state.selection.content().content;
+  const originalSlice = view.state.selection.content();
+
+  // When AllSelection is used, ProseMirror wraps contents in blockGroup node.
+  // Unwrap it to avoid nested blocks when pasting.
+
+  let selectedFragment = originalSlice.content;
 
   if (selectedFragment.childCount === 1 && 
     selectedFragment.firstChild?.type.name === "blockGroup") {
@@ -136,7 +141,7 @@ export function selectedFragmentToHTML<
 
   // Uses default ProseMirror clipboard serialization.
   const clipboardHTML: string = view.serializeForClipboard(
-    new Slice(selectedFragment, 0, 0)
+    new Slice(selectedFragment, originalSlice.openStart, originalSlice.openEnd)
   ).dom.innerHTML;
 
   const externalHTML = fragmentToExternalHTML<BSchema, I, S>(

--- a/packages/core/src/api/clipboard/toClipboard/copyExtension.ts
+++ b/packages/core/src/api/clipboard/toClipboard/copyExtension.ts
@@ -1,5 +1,5 @@
 import { Extension } from "@tiptap/core";
-import { Fragment, Node } from "prosemirror-model";
+import { Fragment, Node, Slice } from "prosemirror-model";
 import { NodeSelection, Plugin } from "prosemirror-state";
 import { CellSelection } from "prosemirror-tables";
 import type { EditorView } from "prosemirror-view";
@@ -127,12 +127,17 @@ export function selectedFragmentToHTML<
     );
   }
 
+  let selectedFragment = view.state.selection.content().content;
+
+  if (selectedFragment.childCount === 1 && 
+    selectedFragment.firstChild?.type.name === "blockGroup") {
+      selectedFragment = selectedFragment.firstChild.content;
+    }
+
   // Uses default ProseMirror clipboard serialization.
   const clipboardHTML: string = view.serializeForClipboard(
-    view.state.selection.content(),
+    new Slice(selectedFragment, 0, 0)
   ).dom.innerHTML;
-
-  const selectedFragment = view.state.selection.content().content;
 
   const externalHTML = fragmentToExternalHTML<BSchema, I, S>(
     view,

--- a/packages/core/src/extensions/tiptap-extensions/KeyboardShortcuts/KeyboardShortcutsExtension.ts
+++ b/packages/core/src/extensions/tiptap-extensions/KeyboardShortcuts/KeyboardShortcutsExtension.ts
@@ -1,6 +1,6 @@
 import { Extension } from "@tiptap/core";
 import { Fragment, Node } from "prosemirror-model";
-import { TextSelection } from "prosemirror-state";
+import { AllSelection, TextSelection } from "prosemirror-state";
 
 import {
   getBottomNestedBlockInfo,
@@ -953,6 +953,17 @@ export const KeyboardShortcutsExtension = Extension.create<{
       "Mod-z": () => this.options.editor.undo(),
       "Mod-y": () => this.options.editor.redo(),
       "Shift-Mod-z": () => this.options.editor.redo(),
+      // Forces AllSelection from pos 0 to include non-editable blocks (e.g. images) that
+      // TextSelection would skip.
+      "Mod-a": () => {
+        const { doc } = this.options.editor.prosemirrorState;
+        this.options.editor.prosemirrorView?.dispatch(
+          this.options.editor.prosemirrorState.tr.setSelection(
+            new AllSelection(doc)
+          )
+        );
+        return true;
+      },
     };
   },
 });

--- a/tests/src/end-to-end/copypaste/copypaste.test.ts
+++ b/tests/src/end-to-end/copypaste/copypaste.test.ts
@@ -187,4 +187,30 @@ test.describe("Check Copy/Paste Functionality", () => {
 
     await compareDocToSnapshot(page, "images.json");
   });
+
+  test("Image as first block should be able to be copied using Ctrl+A", async ({
+    page,
+    browserName,
+  }) => {
+    test.skip(
+      browserName === "firefox" || browserName === "webkit",
+      "Firefox doesn't yet support the async clipboard API. Webkit copy/paste stopped working after updating to Playwright 1.33.",
+    );
+  
+    await focusOnEditor(page);
+  
+    const IMAGE_EMBED_URL = "https://placehold.co/800x540.png";
+    await executeSlashCommand(page, "image");
+  
+    await page.click(`[data-test="embed-tab"]`);
+    await page.click(`[data-test="embed-input"]`);
+    await page.keyboard.type(IMAGE_EMBED_URL);
+    await page.click(`[data-test="embed-input-button"]`);
+    await page.waitForSelector(`img[src="${IMAGE_EMBED_URL}"]`);
+  
+    await copyPasteAll(page);
+  
+    await compareDocToSnapshot(page, "imageAsFirstBlock.json");
+  });
+
 });


### PR DESCRIPTION
# Summary

Fixes #2016. Image cannot be copied using `Ctrl+A` and `Ctrl+C` keyboard shortcuts when it is the first or only block in the editor.

## Rationale

A user should be able to copy an image using the appropriate keyboard commands. As this is a common user action, the unexpected behavior is disruptive to user workflows.

## Changes

- Added a `mod-a` keyboard shortcut handler in `KeyboardShortcutsExtension.ts` that forces an AllSelection covering the entire document from position 0. Without this, the `Ctrl+A` keyboard command created a TextSelection starting at position 6, skipping the first block when it was a non-editable node (e.g. image).
- Unwrapped `blockGroup` from the selected fragment before building clipboard data in `copyExtension.ts`, preventing nested blocks when pasting.

## Impact

- `Ctrl+A` now selects all blocks including non-editable ones at the start of the document.
- Normal copy and paste behavior is unaffected.

## Testing

- Manually tested fix on Chrome and Firefox.
- Added a Playwright end-to-end test for implementation in `copypaste.test.ts`.
- All existing copy/paste equality tests pass after fixing slice open depth preservation when unwrapping the `blockGroup` node.

## Screenshots/Video

https://github.com/user-attachments/assets/28f66ff0-3d45-46bf-823b-06f9689b73cb

## Checklist

- [x] Code follows the project's coding standards.
- [x] Unit tests covering the new feature have been added.
- [x] All existing tests pass.
- [ ] The documentation has been updated to reflect the new feature

## Additional Notes

- **Limitation:** Non-editable blocks (e.g. images) are not visually highlighted when selected via `Ctrl+A`.  Follow-up CSS work needed.
- The Playwright test requires a snapshot to be generated by running `pnpm playwright test copypaste` for the first time.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added select all keyboard shortcut (Ctrl+A/Cmd+A) to select entire document content.

* **Bug Fixes**
  * Improved clipboard handling for copy/paste operations with block-level content.

* **Tests**
  * Added test coverage for copying and pasting images positioned at the start of the document.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->