### PR TITLE
feat: add Unicode quotation mark input rule for quote blocks

### DIFF
--- a/packages/core/src/blocks/Quote/block.ts
+++ b/packages/core/src/blocks/Quote/block.ts
@@ -84,6 +84,15 @@ export const createQuoteBlockSpec = createBlockSpec(
             };
           },
         },
+        {
+          find: new RegExp(`^\\p{Quotation_Mark}\\s$`, "u"),
+          replace() {
+            return {
+              type: "quote",
+              props: {},
+            };
+          },
+        },
       ],
     }),
   ],


### PR DESCRIPTION
# Summary

Add an input rule that converts Unicode quotation mark characters (e.g. `"`, `"`, `«`, `»`, `„`) followed by a space into a quote block, complementing the existing `> ` shortcut.

Ref: https://github.com/suitenumerique/docs/issues/1955#issuecomment-4279439866

## Rationale

Many keyboard layouts (especially non-US ones) produce Unicode quotation marks by default rather than the ASCII `>` character. Users intuitively type a quotation mark followed by a space to start a quote, and this change makes that work by matching any character in the Unicode `Quotation_Mark` category via `\p{Quotation_Mark}`.

## Changes

- Added a new input rule in `packages/core/src/blocks/Quote/block.ts` using the regex `^\p{Quotation_Mark}\s$` (with the `u` flag) to trigger quote block conversion.

## Impact

No impact on existing functionality — the existing `> ` input rule is unchanged. This is purely additive.

## Testing

- Manual testing with various Unicode quotation characters.

## Checklist

- [x] Code follows the project's coding standards.
- [ ] Unit tests covering the new feature have been added.
- [x] All existing tests pass.
- [ ] The documentation has been updated to reflect the new feature

## Additional Notes

The `\p{Quotation_Mark}` Unicode property covers all quotation mark characters defined by Unicode, including but not limited to: `"`, `"`, `"`, `'`, `'`, `«`, `»`, `„`, `‟`, `‹`, `›`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added keyboard shortcut support for creating quote blocks using Unicode quotation marks. Users can now type a quotation mark followed by a space to create a quote block, providing an alternative to the existing `> ` shortcut.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->