### PR TITLE
fix(clipboard): use ProseMirror selection state to fix copy/cut inside Shadow DOM

### DIFF
--- a/packages/core/src/api/clipboard/toClipboard/copyExtension.ts
+++ b/packages/core/src/api/clipboard/toClipboard/copyExtension.ts
@@ -145,11 +145,13 @@ export function selectedFragmentToHTML<
   return { clipboardHTML, externalHTML, markdown };
 }
 
-const checkIfSelectionInNonEditableBlock = () => {
-  // Let browser handle event if selection is empty (nothing
-  // happens).
-  const selection = window.getSelection();
-  if (!selection || selection.isCollapsed) {
+const checkIfSelectionInNonEditableBlock = (view: EditorView) => {
+  // Use ProseMirror's internal selection state to check for empty selection.
+  // window.getSelection() returns null or a collapsed selection inside Shadow
+  // DOM (Firefox, Safari, and Chromium edge cases), causing this guard to
+  // misfire and silently skip clipboard writes. view.state.selection is always
+  // accurate regardless of DOM mode.
+  if (view.state.selection.empty) {
     return true;
   }
 
@@ -158,16 +160,19 @@ const checkIfSelectionInNonEditableBlock = () => {
   // non-editable block. We only need to check one node as it's
   // not possible for the browser selection to start in an
   // editable block and end in a non-editable one.
-  let node = selection.focusNode;
-  while (node) {
-    if (
-      node instanceof HTMLElement &&
-      node.getAttribute("contenteditable") === "false"
-    ) {
-      return true;
-    }
+  const selection = window.getSelection();
+  if (selection && !selection.isCollapsed) {
+    let node = selection.focusNode;
+    while (node) {
+      if (
+        node instanceof HTMLElement &&
+        node.getAttribute("contenteditable") === "false"
+      ) {
+        return true;
+      }
 
-    node = node.parentElement;
+      node = node.parentElement;
+    }
   }
 
   return false;
@@ -213,7 +218,7 @@ export const createCopyToClipboardExtension = <
           props: {
             handleDOMEvents: {
               copy(view, event) {
-                if (checkIfSelectionInNonEditableBlock()) {
+                if (checkIfSelectionInNonEditableBlock(view)) {
                   return true;
                 }
 
@@ -222,7 +227,7 @@ export const createCopyToClipboardExtension = <
                 return true;
               },
               cut(view, event) {
-                if (checkIfSelectionInNonEditableBlock()) {
+                if (checkIfSelectionInNonEditableBlock(view)) {
                   return true;
                 }
 


### PR DESCRIPTION
## Problem

`window.getSelection()` returns `null` or a collapsed selection when a BlockNote editor is mounted inside a **Shadow DOM** (`attachShadow({ mode: 'open' })`). This causes `checkIfSelectionInNonEditableBlock` to always return `true`, which silently skips `copyToClipboard`. The browser's default copy handler then fires instead, which uses ProseMirror's `DOMSerializer` — producing `<div class="bn-block-content">` wrappers with no `<ul>`/`<ol>` — so list bullets, heading levels, bold, and italic are **all lost** when pasting into external apps (Google Docs, LibreOffice Writer, Gmail, etc.).

**Affected browsers:** Firefox (all versions), Safari ≤ 16.3, Chromium edge cases.

**Reproduction:** mount a BlockNote editor inside `attachShadow({ mode: 'open' })`, select a bullet list, copy, and paste into any external app — formatting is gone.

This is not a theoretical concern: [OpenProject](https://www.openproject.org/) embeds BlockNote inside a Shadow DOM to isolate it from the host Angular application. This bug breaks clipboard formatting for all their users.

## Root cause

```typescript
// Before — copyExtension.ts
const checkIfSelectionInNonEditableBlock = () => {
  const selection = window.getSelection();
  if (!selection || selection.isCollapsed) {
    return true; // <-- always fires inside Shadow DOM → clipboard write skipped
  }
  // ...
};
```

`window.getSelection()` is not Shadow-DOM-aware and cannot see selections that live inside a shadow root.

## Fix

Use `view.state.selection.empty` as the primary empty-selection guard. ProseMirror's internal state is always accurate regardless of DOM mode. The DOM-level non-editable-island traversal is retained as a secondary check, but only runs when `window.getSelection()` actually returns a non-collapsed selection (i.e. in non-Shadow-DOM contexts where it still works).

```typescript
// After
const checkIfSelectionInNonEditableBlock = (view: EditorView) => {
  // ProseMirror's internal state is Shadow DOM-safe; window.getSelection() is not.
  if (view.state.selection.empty) {
    return true;
  }

  // Keep the non-editable-island check for standard DOM contexts.
  const selection = window.getSelection();
  if (selection && !selection.isCollapsed) {
    let node = selection.focusNode;
    while (node) {
      if (node instanceof HTMLElement && node.getAttribute("contenteditable") === "false")
        return true;
      node = node.parentElement;
    }
  }

  return false;
};
```

Both `copy` and `cut` call sites are updated to pass `view`.

## Checklist

- [x] `view.state.selection.empty` replaces `window.getSelection()` for the empty-selection guard
- [x] Non-editable-island DOM traversal is preserved (secondary, only when DOM selection is available)
- [x] Both `copy` and `cut` handlers updated
- [x] No behaviour change in standard (non-Shadow-DOM) contexts
- [ ] Manual test: Shadow DOM mount → select bullet list → copy → paste into Google Docs/LibreOffice
- [ ] Manual test: cut removes source content after writing clipboard