### PR TITLE
fix(clipboard): use ProseMirror selection state for Shadow DOM compatibility

### DIFF
--- a/packages/core/src/api/clipboard/toClipboard/copyExtension.ts
+++ b/packages/core/src/api/clipboard/toClipboard/copyExtension.ts
@@ -145,11 +145,13 @@ export function selectedFragmentToHTML<
   return { clipboardHTML, externalHTML, markdown };
 }
 
-const checkIfSelectionInNonEditableBlock = () => {
-  // Let browser handle event if selection is empty (nothing
-  // happens).
-  const selection = window.getSelection();
-  if (!selection || selection.isCollapsed) {
+const checkIfSelectionInNonEditableBlock = (view: EditorView) => {
+  // Use ProseMirror's internal selection state to check for empty selection.
+  // window.getSelection() returns null or a collapsed selection inside Shadow
+  // DOM (Firefox, Safari, and Chromium edge cases), causing this guard to
+  // misfire and silently skip clipboard writes. view.state.selection is always
+  // accurate regardless of DOM mode.
+  if (view.state.selection.empty) {
     return true;
   }
 
@@ -158,16 +160,19 @@ const checkIfSelectionInNonEditableBlock = () => {
   // non-editable block. We only need to check one node as it's
   // not possible for the browser selection to start in an
   // editable block and end in a non-editable one.
-  let node = selection.focusNode;
-  while (node) {
-    if (
-      node instanceof HTMLElement &&
-      node.getAttribute("contenteditable") === "false"
-    ) {
-      return true;
-    }
+  const selection = window.getSelection();
+  if (selection && !selection.isCollapsed) {
+    let node = selection.focusNode;
+    while (node) {
+      if (
+        node instanceof HTMLElement &&
+        node.getAttribute("contenteditable") === "false"
+      ) {
+        return true;
+      }
 
-    node = node.parentElement;
+      node = node.parentElement;
+    }
   }
 
   return false;
@@ -213,7 +218,7 @@ export const createCopyToClipboardExtension = <
           props: {
             handleDOMEvents: {
               copy(view, event) {
-                if (checkIfSelectionInNonEditableBlock()) {
+                if (checkIfSelectionInNonEditableBlock(view)) {
                   return true;
                 }
 
@@ -222,7 +227,7 @@ export const createCopyToClipboardExtension = <
                 return true;
               },
               cut(view, event) {
-                if (checkIfSelectionInNonEditableBlock()) {
+                if (checkIfSelectionInNonEditableBlock(view)) {
                   return true;
                 }
 


### PR DESCRIPTION
## Problem

BlockNote embeds ProseMirror inside editors that may be mounted in a Shadow DOM (e.g. OpenProject uses `attachShadow({ mode: 'open' })` to isolate the editor from its Angular host). In this setup, `window.getSelection()` returns `null` or a collapsed selection even when text is visually selected — this affects Firefox (all versions), Safari ≤16.3, and Chromium edge cases.

`checkIfSelectionInNonEditableBlock` used `window.getSelection()` as its primary empty-selection guard. Because `getSelection()` misfires in Shadow DOM, the guard always returned `true`, causing both the `copy` and `cut` handlers to bail out early without writing to the clipboard. The browser's default copy then ran, which uses ProseMirror's `DOMSerializer` without BlockNote's semantic wrappers — losing list formatting, headings, and bold/italic on paste into external apps.

## Fix

Use `view.state.selection.empty` as the primary guard. ProseMirror's internal selection state is updated via its own reconciliation loop and is always accurate regardless of DOM mode.

The non-editable-block DOM walk (which does need `window.getSelection()`) is kept as a secondary guard, but only runs when `getSelection()` actually returns a non-collapsed selection — so it's a no-op in Shadow DOM environments where `getSelection()` is unreliable.

## Test

Verified in OpenProject (Shadow DOM setup) with a bullet list: the clipboard now contains all three expected types — `blocknote/html`, `text/html` (with `<ul>/<li>`), and `text/plain` (markdown `* item`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved clipboard handling for copy and cut operations in non-editable sections and shadow DOM scenarios, ensuring more reliable selection detection across different browser conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->