### PR TITLE
fix: Multi-column errors when moving the only block out of a column

### DIFF
--- a/packages/core/src/api/blockManipulation/commands/moveBlocks/moveBlocks.ts
+++ b/packages/core/src/api/blockManipulation/commands/moveBlocks/moveBlocks.ts
@@ -1,3 +1,4 @@
+import { Fragment, Slice } from "prosemirror-model";
 import {
   NodeSelection,
   Selection,
@@ -5,12 +6,15 @@ import {
   Transaction,
 } from "prosemirror-state";
 import { CellSelection } from "prosemirror-tables";
+import { ReplaceStep } from "prosemirror-transform";
 
 import { Block } from "../../../../blocks/defaultBlocks.js";
 import type { BlockNoteEditor } from "../../../../editor/BlockNoteEditor";
 import { BlockIdentifier } from "../../../../schema/index.js";
 import { getNearestBlockPos } from "../../../getBlockInfoFromPos.js";
+import { blockToNode } from "../../../nodeConversions/blockToNode.js";
 import { getNodeById } from "../../../nodeUtil.js";
+import { getPmSchema } from "../../../pmUtil.js";
 
 type BlockSelectionData = (
   | {
@@ -170,8 +174,39 @@ export function moveSelectedBlocksAndSelection(
     ];
     const selectionData = getBlockSelectionData(editor);
 
+    // Resolve the destination to a position upfront. `removeBlocks` can
+    // collapse a `columnList` (via `fixColumnList`) and destroy
+    // `referenceBlock`, so a later ID lookup would fail.
+    const referenceId =
+      typeof referenceBlock === "string" ? referenceBlock : referenceBlock.id;
+    const referenceInfo = getNodeById(referenceId, tr.doc);
+    if (!referenceInfo) {
+      throw new Error(`Block with ID ${referenceId} not found`);
+    }
+    const targetPos =
+      placement === "before"
+        ? referenceInfo.posBeforeNode
+        : referenceInfo.posBeforeNode + referenceInfo.node.nodeSize;
+    const stepsBeforeRemove = tr.steps.length;
+
     editor.removeBlocks(blocks);
-    editor.insertBlocks(flattenColumns(blocks), referenceBlock, placement);
+
+    let mappedTargetPos = targetPos;
+    for (let i = stepsBeforeRemove; i < tr.steps.length; i++) {
+      mappedTargetPos = tr.steps[i].getMap().map(mappedTargetPos);
+    }
+
+    const pmSchema = getPmSchema(tr);
+    const nodesToInsert = flattenColumns(blocks).map((block) =>
+      blockToNode(block, pmSchema),
+    );
+    tr.step(
+      new ReplaceStep(
+        mappedTargetPos,
+        mappedTargetPos,
+        new Slice(Fragment.from(nodesToInsert), 0, 0),
+      ),
+    );
 
     updateBlockSelectionFromData(tr, selectionData);
   });

--- a/packages/xl-multi-column/src/test/commands/moveBlocks.test.ts
+++ b/packages/xl-multi-column/src/test/commands/moveBlocks.test.ts
@@ -55,3 +55,85 @@ describe("Test moveBlocksDown", () => {
     expect(getEditor().document).toMatchSnapshot();
   });
 });
+
+// Regression tests for https://github.com/TypeCellOS/BlockNote/issues/2594:
+// when a column contains only a single block, moving that block out of the
+// column triggers `fixColumnList` to collapse the columnList, which used to
+// invalidate the destination `referenceBlock`.
+describe("Test moveBlocks with single-block columns", () => {
+  it("Move out of a single-block column does not throw", () => {
+    const editor = getEditor();
+    editor.replaceBlocks(editor.document, [
+      {
+        id: "column-list-single",
+        type: "columnList",
+        children: [
+          {
+            id: "column-a",
+            type: "column",
+            children: [
+              {
+                id: "only-paragraph-a",
+                type: "paragraph",
+                content: "A",
+              },
+            ],
+          },
+          {
+            id: "column-b",
+            type: "column",
+            children: [
+              {
+                id: "only-paragraph-b",
+                type: "paragraph",
+                content: "B",
+              },
+            ],
+          },
+        ],
+      },
+      { id: "below", type: "paragraph", content: "below" },
+    ]);
+    editor.setTextCursorPosition("only-paragraph-a");
+
+    expect(() => editor.moveBlocksUp()).not.toThrow();
+  });
+
+  it("Move out of a single-block column when columnList is preceded by a sibling", () => {
+    const editor = getEditor();
+    editor.replaceBlocks(editor.document, [
+      { id: "above", type: "paragraph", content: "above" },
+      {
+        id: "column-list-single-2",
+        type: "columnList",
+        children: [
+          {
+            id: "column-c",
+            type: "column",
+            children: [
+              {
+                id: "only-paragraph-c",
+                type: "paragraph",
+                content: "C",
+              },
+            ],
+          },
+          {
+            id: "column-d",
+            type: "column",
+            children: [
+              {
+                id: "only-paragraph-d",
+                type: "paragraph",
+                content: "D",
+              },
+            ],
+          },
+        ],
+      },
+    ]);
+    editor.setTextCursorPosition("only-paragraph-c");
+
+    expect(() => editor.moveBlocksUp()).not.toThrow();
+  });
+});


### PR DESCRIPTION
# Summary

Fixes the `Uncaught Error: Block with ID … not found` thrown by `moveBlocksUp`/`moveBlocksDown` when the block being moved is the only block in its column. The throw happens inside `editor.transact`, so the transaction is rolled back and the block does not move.

Closes #2594

## Rationale

When a column contains only a single block, removing that block from the column makes the column empty. `removeAndInsertBlocks` then runs `fixColumnList`, which removes the empty column. ProseMirror's schema requires at least two columns, so it auto-fills an empty one, and `fixColumnList` then replaces the entire `columnList` with the contents of the remaining non-empty column. The `columnList`'s ID no longer exists in the document.

`moveSelectedBlocksAndSelection` was caching `referenceBlock` (the `columnList` itself, in the move-out-of-column case) and calling `editor.insertBlocks(..., referenceBlock, placement)` after `removeBlocks`. The subsequent `getNodeById` lookup failed and threw.

## Changes

- `packages/core/src/api/blockManipulation/commands/moveBlocks/moveBlocks.ts`: in `moveSelectedBlocksAndSelection`, resolve the destination to a ProseMirror position before `removeBlocks`, map it through any steps the removal adds, and insert at the mapped position via a direct `ReplaceStep` instead of re-resolving the `referenceBlock` ID.
- `packages/xl-multi-column/src/test/commands/moveBlocks.test.ts`: two regression tests that fail without the fix and pass with it. Covers both the case from the issue (columnList followed by a paragraph) and the variant where the columnList is preceded by a sibling.

## Impact

No behavioral change for existing scenarios. All existing `moveBlocks` snapshot tests still pass. Removing the ID-based re-lookup also slightly hardens the function against any future side effect that might destroy the destination block.

## Testing

- New regression tests in `packages/xl-multi-column/src/test/commands/moveBlocks.test.ts`.
- Manually verified in the playground at `/basic/multi-column/`: add a multi-column block, type text under it, `Cmd+Shift+Up`. No console error; the block moves out cleanly.

## Screenshots/Video

https://github.com/user-attachments/assets/1044083d-2bac-4b4d-b7fc-59810ae640dc



## Checklist

- [x] Code follows the project's coding standards.
- [x] Unit tests covering the new feature have been added.
- [x] All existing tests pass.
- [ ] The documentation has been updated to reflect the new feature

(No documentation change applicable; this is an internal bug fix.)

## Additional Notes

N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced block movement operations to improve reliability and provide faster error detection when moving blocks to invalid destinations.

* **Tests**
  * Added regression tests to ensure block movement works correctly in complex document layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->