### PR TITLE
fix: Hardcoded strings in comment components (BLO-1033)

### DIFF
--- a/packages/core/src/i18n/locales/ar.ts
+++ b/packages/core/src/i18n/locales/ar.ts
@@ -369,9 +369,11 @@ export const ar: Dictionary = {
     edited: "تم التحرير",
     save_button_text: "حفظ",
     cancel_button_text: "إلغاء",
+    deleted_reference_text: "تم حذف المحتوى الأصلي",
     actions: {
       add_reaction: "أضف تفاعلًا",
       resolve: "حل",
+      reopen: "إعادة فتح",
       edit_comment: "تحرير التعليق",
       delete_comment: "حذف التعليق",
       more_actions: "المزيد من الإجراءات",

--- a/packages/core/src/i18n/locales/de.ts
+++ b/packages/core/src/i18n/locales/de.ts
@@ -403,9 +403,11 @@ export const de: Dictionary = {
     edited: "bearbeitet",
     save_button_text: "Speichern",
     cancel_button_text: "Abbrechen",
+    deleted_reference_text: "Originalinhalt gelöscht",
     actions: {
       add_reaction: "Reaktion hinzufügen",
       resolve: "Lösen",
+      reopen: "Wieder öffnen",
       edit_comment: "Kommentar bearbeiten",
       delete_comment: "Kommentar löschen",
       more_actions: "Weitere Aktionen",

--- a/packages/core/src/i18n/locales/en.ts
+++ b/packages/core/src/i18n/locales/en.ts
@@ -384,9 +384,11 @@ export const en = {
     edited: "edited",
     save_button_text: "Save",
     cancel_button_text: "Cancel",
+    deleted_reference_text: "Original content deleted",
     actions: {
       add_reaction: "Add reaction",
       resolve: "Resolve",
+      reopen: "Re-open",
       edit_comment: "Edit comment",
       delete_comment: "Delete comment",
       more_actions: "More actions",

--- a/packages/core/src/i18n/locales/es.ts
+++ b/packages/core/src/i18n/locales/es.ts
@@ -382,9 +382,11 @@ export const es: Dictionary = {
     edited: "editado",
     save_button_text: "Guardar",
     cancel_button_text: "Cancelar",
+    deleted_reference_text: "Contenido original eliminado",
     actions: {
       add_reaction: "Agregar reacción",
       resolve: "Resolver",
+      reopen: "Reabrir",
       edit_comment: "Editar comentario",
       delete_comment: "Eliminar comentario",
       more_actions: "Más acciones",

--- a/packages/core/src/i18n/locales/fa.ts
+++ b/packages/core/src/i18n/locales/fa.ts
@@ -352,9 +352,11 @@ export const fa = {
     edited: "ویرایش شده",
     save_button_text: "ذخیره",
     cancel_button_text: "لغو",
+    deleted_reference_text: "محتوای اصلی حذف شد",
     actions: {
       add_reaction: "افزودن واکنش",
       resolve: "حل کردن",
+      reopen: "باز کردن مجدد",
       edit_comment: "ویرایش دیدگاه",
       delete_comment: "حذف دیدگاه",
       more_actions: "اقدامات بیشتر",

--- a/packages/core/src/i18n/locales/fr.ts
+++ b/packages/core/src/i18n/locales/fr.ts
@@ -430,9 +430,11 @@ export const fr: Dictionary = {
     edited: "modifié",
     save_button_text: "Enregistrer",
     cancel_button_text: "Annuler",
+    deleted_reference_text: "Contenu d'origine supprimé",
     actions: {
       add_reaction: "Ajouter une réaction",
       resolve: "Résoudre",
+      reopen: "Rouvrir",
       edit_comment: "Modifier le commentaire",
       delete_comment: "Supprimer le commentaire",
       more_actions: "Plus d'actions",

--- a/packages/core/src/i18n/locales/he.ts
+++ b/packages/core/src/i18n/locales/he.ts
@@ -384,9 +384,11 @@ export const he: Dictionary = {
     edited: "נערך",
     save_button_text: "שמור",
     cancel_button_text: "בטל",
+    deleted_reference_text: "התוכן המקורי נמחק",
     actions: {
       add_reaction: "הוסף תגובה",
       resolve: "סמן כפתור",
+      reopen: "פתח מחדש",
       edit_comment: "ערוך תגובה",
       delete_comment: "מחק תגובה",
       more_actions: "פעולות נוספות",

--- a/packages/core/src/i18n/locales/hr.ts
+++ b/packages/core/src/i18n/locales/hr.ts
@@ -397,9 +397,11 @@ export const hr: Dictionary = {
     edited: "uredio",
     save_button_text: "Spremi",
     cancel_button_text: "Odustani",
+    deleted_reference_text: "Originalni sadržaj je obrisan",
     actions: {
       add_reaction: "Dodaj reakciju",
       resolve: "Riješi",
+      reopen: "Ponovno otvori",
       edit_comment: "Uredi komentar",
       delete_comment: "Obriši komentar",
       more_actions: "Više radnji",

--- a/packages/core/src/i18n/locales/is.ts
+++ b/packages/core/src/i18n/locales/is.ts
@@ -397,9 +397,11 @@ export const is: Dictionary = {
     edited: "breytt",
     save_button_text: "Vista",
     cancel_button_text: "Hætta",
+    deleted_reference_text: "Upprunalegu efni eytt",
     actions: {
       add_reaction: "Bæta við viðbrögðum",
       resolve: "Leysa",
+      reopen: "Opna aftur",
       edit_comment: "Breyta athugasemd",
       delete_comment: "Eyða athugasemd",
       more_actions: "Fleiri aðgerðir",

--- a/packages/core/src/i18n/locales/it.ts
+++ b/packages/core/src/i18n/locales/it.ts
@@ -406,9 +406,11 @@ export const it: Dictionary = {
     edited: "modificato",
     save_button_text: "Salva",
     cancel_button_text: "Annulla",
+    deleted_reference_text: "Contenuto originale eliminato",
     actions: {
       add_reaction: "Aggiungi reazione",
       resolve: "Risolvi",
+      reopen: "Riapri",
       edit_comment: "Modifica commento",
       delete_comment: "Elimina commento",
       more_actions: "Altre azioni",

--- a/packages/core/src/i18n/locales/ja.ts
+++ b/packages/core/src/i18n/locales/ja.ts
@@ -424,9 +424,11 @@ export const ja: Dictionary = {
     edited: "編集済み",
     save_button_text: "保存",
     cancel_button_text: "キャンセル",
+    deleted_reference_text: "元のコンテンツが削除されました",
     actions: {
       add_reaction: "リアクションを追加",
       resolve: "解決",
+      reopen: "再開",
       edit_comment: "コメントを編集",
       delete_comment: "コメントを削除",
       more_actions: "その他の操作",

--- a/packages/core/src/i18n/locales/ko.ts
+++ b/packages/core/src/i18n/locales/ko.ts
@@ -397,9 +397,11 @@ export const ko: Dictionary = {
     edited: "수정됨",
     save_button_text: "저장",
     cancel_button_text: "취소",
+    deleted_reference_text: "원본 콘텐츠 삭제됨",
     actions: {
       add_reaction: "반응 추가",
       resolve: "해결",
+      reopen: "다시 열기",
       edit_comment: "댓글 수정",
       delete_comment: "댓글 삭제",
       more_actions: "더 많은 작업",

--- a/packages/core/src/i18n/locales/nl.ts
+++ b/packages/core/src/i18n/locales/nl.ts
@@ -384,9 +384,11 @@ export const nl: Dictionary = {
     edited: "bewerkt",
     save_button_text: "Opslaan",
     cancel_button_text: "Annuleren",
+    deleted_reference_text: "Originele inhoud verwijderd",
     actions: {
       add_reaction: "Reactie toevoegen",
       resolve: "Oplossen",
+      reopen: "Heropenen",
       edit_comment: "Reactie bewerken",
       delete_comment: "Reactie verwijderen",
       more_actions: "Meer acties",

--- a/packages/core/src/i18n/locales/no.ts
+++ b/packages/core/src/i18n/locales/no.ts
@@ -401,9 +401,11 @@ export const no: Dictionary = {
     edited: "redigert",
     save_button_text: "Lagre",
     cancel_button_text: "Avbryt",
+    deleted_reference_text: "Originalt innhold slettet",
     actions: {
       add_reaction: "Legg til reaksjon",
       resolve: "Løs",
+      reopen: "Gjenåpne",
       edit_comment: "Rediger kommentar",
       delete_comment: "Slett kommentar",
       more_actions: "Flere handlinger",

--- a/packages/core/src/i18n/locales/pl.ts
+++ b/packages/core/src/i18n/locales/pl.ts
@@ -375,9 +375,11 @@ export const pl: Dictionary = {
     edited: "edytowany",
     save_button_text: "Zapisz",
     cancel_button_text: "Anuluj",
+    deleted_reference_text: "Oryginalna treść usunięta",
     actions: {
       add_reaction: "Dodaj reakcję",
       resolve: "Rozwiąż",
+      reopen: "Otwórz ponownie",
       edit_comment: "Edytuj komentarz",
       delete_comment: "Usuń komentarz",
       more_actions: "Więcej akcji",

--- a/packages/core/src/i18n/locales/pt.ts
+++ b/packages/core/src/i18n/locales/pt.ts
@@ -376,9 +376,11 @@ export const pt: Dictionary = {
     edited: "editado",
     save_button_text: "Salvar",
     cancel_button_text: "Cancelar",
+    deleted_reference_text: "Conteúdo original excluído",
     actions: {
       add_reaction: "Adicionar reação",
       resolve: "Resolver",
+      reopen: "Reabrir",
       edit_comment: "Editar comentário",
       delete_comment: "Excluir comentário",
       more_actions: "Mais ações",

--- a/packages/core/src/i18n/locales/ru.ts
+++ b/packages/core/src/i18n/locales/ru.ts
@@ -427,9 +427,11 @@ export const ru: Dictionary = {
     edited: "изменен",
     save_button_text: "Сохранить",
     cancel_button_text: "Отменить",
+    deleted_reference_text: "Исходный контент удалён",
     actions: {
       add_reaction: "Добавить реакцию",
       resolve: "Решить",
+      reopen: "Возобновить",
       edit_comment: "Редактировать комментарий",
       delete_comment: "Удалить комментарий",
       more_actions: "Другие действия",

--- a/packages/core/src/i18n/locales/sk.ts
+++ b/packages/core/src/i18n/locales/sk.ts
@@ -382,9 +382,11 @@ export const sk = {
     edited: "upravený",
     save_button_text: "Uložiť",
     cancel_button_text: "Zrušiť",
+    deleted_reference_text: "Pôvodný obsah odstránený",
     actions: {
       add_reaction: "Pridať reakciu",
       resolve: "Vyriešiť",
+      reopen: "Znovu otvoriť",
       edit_comment: "Upraviť komentár",
       delete_comment: "Vymazať komentár",
       more_actions: "Ďalšie akcie",

--- a/packages/core/src/i18n/locales/uk.ts
+++ b/packages/core/src/i18n/locales/uk.ts
@@ -408,9 +408,11 @@ export const uk: Dictionary = {
     edited: "відредаговано",
     save_button_text: "Зберегти",
     cancel_button_text: "Скасувати",
+    deleted_reference_text: "Оригінальний вміст видалено",
     actions: {
       add_reaction: "Додати реакцію",
       resolve: "Вирішити",
+      reopen: "Відкрити знову",
       edit_comment: "Редагувати коментар",
       delete_comment: "Видалити коментар",
       more_actions: "Більше дій",

--- a/packages/core/src/i18n/locales/uz.ts
+++ b/packages/core/src/i18n/locales/uz.ts
@@ -417,9 +417,11 @@ export const uz: Dictionary = {
     edited: "tahrirlangan",
     save_button_text: "Saqlash",
     cancel_button_text: "Bekor qilish",
+    deleted_reference_text: "Asl tarkib o‘chirildi",
     actions: {
       add_reaction: "Reaksiya qo‘shish",
       resolve: "Hal qilish",
+      reopen: "Qayta ochish",
       edit_comment: "Izohni tahrirlash",
       delete_comment: "Izohni o‘chirish",
       more_actions: "Boshqa amallar",

--- a/packages/core/src/i18n/locales/vi.ts
+++ b/packages/core/src/i18n/locales/vi.ts
@@ -383,9 +383,11 @@ export const vi: Dictionary = {
     edited: "đã chỉnh sửa",
     save_button_text: "Lưu",
     cancel_button_text: "Hủy",
+    deleted_reference_text: "Nội dung gốc đã bị xóa",
     actions: {
       add_reaction: "Thêm phản ứng",
       resolve: "Giải quyết",
+      reopen: "Mở lại",
       edit_comment: "Chỉnh sửa bình luận",
       delete_comment: "Xóa bình luận",
       more_actions: "Thêm hành động",

--- a/packages/core/src/i18n/locales/zh-tw.ts
+++ b/packages/core/src/i18n/locales/zh-tw.ts
@@ -425,9 +425,11 @@ export const zhTW: Dictionary = {
     edited: "已編輯",
     save_button_text: "儲存",
     cancel_button_text: "取消",
+    deleted_reference_text: "原始內容已刪除",
     actions: {
       add_reaction: "新增回應",
       resolve: "解決",
+      reopen: "重新開啟",
       edit_comment: "編輯評論",
       delete_comment: "刪除評論",
       more_actions: "更多操作",

--- a/packages/core/src/i18n/locales/zh.ts
+++ b/packages/core/src/i18n/locales/zh.ts
@@ -425,9 +425,11 @@ export const zh: Dictionary = {
     edited: "已编辑",
     save_button_text: "保存",
     cancel_button_text: "取消",
+    deleted_reference_text: "原始内容已删除",
     actions: {
       add_reaction: "添加反应",
       resolve: "解决",
+      reopen: "重新打开",
       edit_comment: "编辑评论",
       delete_comment: "删除评论",
       more_actions: "更多操作",

--- a/packages/react/src/components/Comments/Comment.tsx
+++ b/packages/react/src/components/Comments/Comment.tsx
@@ -171,7 +171,7 @@ export const Comment = ({
           (thread.resolved ? (
             <Components.Generic.Toolbar.Button
               key={"reopen"}
-              mainTooltip="Re-open"
+              mainTooltip={dict.comments.actions.reopen}
               variant="compact"
               onClick={onReopen}
             >

--- a/packages/react/src/components/Comments/FloatingComposer.tsx
+++ b/packages/react/src/components/Comments/FloatingComposer.tsx
@@ -62,7 +62,7 @@ export function FloatingComposer<
           >
             <Components.Generic.Toolbar.Button
               className={"bn-button"}
-              mainTooltip="Save"
+              mainTooltip={dict.comments.save_button_text}
               variant="compact"
               isDisabled={isEmpty}
               onClick={async () => {
@@ -81,7 +81,7 @@ export function FloatingComposer<
                 editor.focus();
               }}
             >
-              Save
+              {dict.comments.save_button_text}
             </Components.Generic.Toolbar.Button>
           </Components.Generic.Toolbar.Root>
         )}

--- a/packages/react/src/components/Comments/ThreadsSidebar.tsx
+++ b/packages/react/src/components/Comments/ThreadsSidebar.tsx
@@ -135,7 +135,7 @@ export function getReferenceText(
 ) {
   return editor.transact((tr) => {
     if (!threadPosition) {
-      return "Original content deleted";
+      return editor.dictionary.comments.deleted_reference_text;
     }
 
     // TODO: Handles an edge case where the editor is re-rendered and the document


### PR DESCRIPTION
# Summary

<!-- Briefly describe the feature being introduced. -->

This PR adds dictionary entries for any remaining hardcoded strings in comment-related components.

Closes #2530 

## Rationale

<!-- Explain the reasoning behind this feature and its benefits to the project. -->

This is an issue for internationalization.

## Changes

<!-- List the major changes made in this pull request. -->

See above.

## Impact

<!-- Discuss any potential impacts this feature may have on existing functionalities. -->

N/A

## Testing

<!-- Describe how the feature has been tested, including both automated and manual testing strategies. -->

N/A

## Screenshots/Video

<!-- Include screenshots or video demonstrating the new feature, if applicable. -->

N/A

## Checklist

- [X] Code follows the project's coding standards.
- [X] Unit tests covering the new feature have been added.
- [X] All existing tests pass.
- [X] The documentation has been updated to reflect the new feature

## Additional Notes

<!-- Any additional information or context relevant to this PR. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added multi-language support for reopening comments and displaying deleted reference messages throughout the app.

* **Localization**
  * Expanded translations to 24+ languages with new localized text for comment reopen actions and deleted content indicators.
  * Replaced hardcoded UI text with language-specific translations for improved user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->