### PR TITLE
feat: Drag hendle menu delete button removes all other blocks in selection (BLO-1007)

### DIFF
--- a/packages/react/src/components/SideMenu/DragHandleMenu/DefaultItems/RemoveBlockItem.tsx
+++ b/packages/react/src/components/SideMenu/DragHandleMenu/DefaultItems/RemoveBlockItem.tsx
@@ -22,7 +22,14 @@ export const RemoveBlockItem = (props: { children: ReactNode }) => {
   return (
     <Components.Generic.Menu.Item
       className={"bn-menu-item"}
-      onClick={() => editor.removeBlocks([block])}
+      onClick={() => {
+        const selectedBlocks = editor.getSelection()?.blocks;
+        const blocksToRemove =
+          selectedBlocks && selectedBlocks.some((b) => b.id === block.id)
+            ? selectedBlocks
+            : [block];
+        editor.removeBlocks(blocksToRemove);
+      }}
     >
       {props.children}
     </Components.Generic.Menu.Item>

--- a/tests/package.json
+++ b/tests/package.json
@@ -5,9 +5,9 @@
   "scripts": {
     "build": "tsc",
     "lint": "eslint src --max-warnings 0",
-    "playwright": "playwright test --ui",
+    "playwright": "playwright test",
     "test": "vitest --run",
-    "test:updateSnaps": "docker run --rm -e RUN_IN_DOCKER=true --network host -v $(pwd)/..:/work/ -w /work/tests -it mcr.microsoft.com/playwright:v1.51.1-noble npx playwright test draghandle -u",
+    "test:updateSnaps": "docker run --rm -e RUN_IN_DOCKER=true --network host -v $(pwd)/..:/work/ -w /work/tests -it mcr.microsoft.com/playwright:v1.51.1-noble npx playwright test -u",
     "test-ct": "playwright test -c playwright-ct.config.ts --headed",
     "test-ct:updateSnaps": "docker run --rm  -e RUN_IN_DOCKER=true --network host -v $(pwd)/..:/work/ -w /work/tests -it mcr.microsoft.com/playwright:v1.51.1-noble npx playwright test -c playwright-ct.config.ts -u",
     "clean": "rimraf dist"

--- a/tests/package.json
+++ b/tests/package.json
@@ -5,9 +5,9 @@
   "scripts": {
     "build": "tsc",
     "lint": "eslint src --max-warnings 0",
-    "playwright": "playwright test",
+    "playwright": "playwright test --ui",
     "test": "vitest --run",
-    "test:updateSnaps": "docker run --rm -e RUN_IN_DOCKER=true --network host -v $(pwd)/..:/work/ -w /work/tests -it mcr.microsoft.com/playwright:v1.51.1-noble npx playwright test -u",
+    "test:updateSnaps": "docker run --rm -e RUN_IN_DOCKER=true --network host -v $(pwd)/..:/work/ -w /work/tests -it mcr.microsoft.com/playwright:v1.51.1-noble npx playwright test draghandle -u",
     "test-ct": "playwright test -c playwright-ct.config.ts --headed",
     "test-ct:updateSnaps": "docker run --rm  -e RUN_IN_DOCKER=true --network host -v $(pwd)/..:/work/ -w /work/tests -it mcr.microsoft.com/playwright:v1.51.1-noble npx playwright test -c playwright-ct.config.ts -u",
     "clean": "rimraf dist"

--- a/tests/src/end-to-end/draghandle/draghandle.test.ts
+++ b/tests/src/end-to-end/draghandle/draghandle.test.ts
@@ -2,6 +2,7 @@ import { expect, Page } from "@playwright/test";
 import { test } from "../../setup/setupScript.js";
 import {
   BASE_URL,
+  BULLET_LIST_SELECTOR,
   DRAG_HANDLE_ADD_SELECTOR,
   DRAG_HANDLE_MENU_SELECTOR,
   DRAG_HANDLE_SELECTOR,
@@ -156,6 +157,64 @@ test.describe("Check Draghandle functionality", () => {
     await page.waitForSelector(H_THREE_BLOCK_SELECTOR);
 
     await compareDocToSnapshot(page, "dragHandleDocStructure");
+  });
+
+  test("Delete button should delete all blocks in multi-block selection when hovered block is in selection", async () => {
+    await executeSlashCommand(page, "h1");
+    await page.keyboard.type("Heading 1");
+    await page.keyboard.press("Enter", { delay: 10 });
+    await executeSlashCommand(page, "h2");
+    await page.keyboard.type("Heading 2");
+    await page.keyboard.press("Enter", { delay: 10 });
+    await executeSlashCommand(page, "h3");
+    await page.keyboard.type("Heading 3");
+    await page.keyboard.press("Enter", { delay: 10 });
+    await executeSlashCommand(page, "bullet");
+    await page.keyboard.type("Bullet List");
+
+    await page.keyboard.down("Shift");
+    await page.keyboard.press("ArrowUp");
+    await page.keyboard.press("ControlOrMeta+ArrowLeft");
+    await page.keyboard.up("Shift");
+
+    await page.hover(H_THREE_BLOCK_SELECTOR);
+    await page.click(DRAG_HANDLE_SELECTOR);
+    await page.click("text=Delete");
+    await page.waitForSelector(H_ONE_BLOCK_SELECTOR);
+    await page.waitForSelector(H_TWO_BLOCK_SELECTOR);
+    await page.waitForSelector(H_THREE_BLOCK_SELECTOR, { state: "detached" });
+    await page.waitForSelector(BULLET_LIST_SELECTOR, { state: "detached" });
+
+    await compareDocToSnapshot(page, "draghandledeletemultiselection");
+  });
+
+  test("Delete button should delete only hovered block when it is outside multi-block selection", async () => {
+    await executeSlashCommand(page, "h1");
+    await page.keyboard.type("Heading 1");
+    await page.keyboard.press("Enter", { delay: 10 });
+    await executeSlashCommand(page, "h2");
+    await page.keyboard.type("Heading 2");
+    await page.keyboard.press("Enter", { delay: 10 });
+    await executeSlashCommand(page, "h3");
+    await page.keyboard.type("Heading 3");
+    await page.keyboard.press("Enter", { delay: 10 });
+    await executeSlashCommand(page, "bullet");
+    await page.keyboard.type("Bullet List");
+
+    await page.keyboard.down("Shift");
+    await page.keyboard.press("ArrowUp");
+    await page.keyboard.press("ControlOrMeta+ArrowLeft");
+    await page.keyboard.up("Shift");
+
+    await page.hover(H_ONE_BLOCK_SELECTOR);
+    await page.click(DRAG_HANDLE_SELECTOR);
+    await page.click("text=Delete");
+    await page.waitForSelector(H_ONE_BLOCK_SELECTOR, { state: "detached" });
+    await page.waitForSelector(H_TWO_BLOCK_SELECTOR);
+    await page.waitForSelector(H_THREE_BLOCK_SELECTOR);
+    await page.waitForSelector(BULLET_LIST_SELECTOR);
+
+    await compareDocToSnapshot(page, "draghandledeletehoveroutsideselection");
   });
 
   test("Deleting block with children should delete all children", async () => {

--- a/tests/src/end-to-end/draghandle/draghandle.test.ts-snapshots/draghandledeletehoveroutsideselection-chromium-linux.json
+++ b/tests/src/end-to-end/draghandle/draghandle.test.ts-snapshots/draghandledeletehoveroutsideselection-chromium-linux.json
@@ -1,0 +1,96 @@
+{
+  "type": "doc",
+  "content": [
+    {
+      "type": "blockGroup",
+      "content": [
+        {
+          "type": "blockContainer",
+          "attrs": {
+            "id": "2"
+          },
+          "content": [
+            {
+              "type": "heading",
+              "attrs": {
+                "backgroundColor": "default",
+                "textColor": "default",
+                "textAlignment": "left",
+                "level": 2,
+                "isToggleable": false
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "Heading 2"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "blockContainer",
+          "attrs": {
+            "id": "3"
+          },
+          "content": [
+            {
+              "type": "heading",
+              "attrs": {
+                "backgroundColor": "default",
+                "textColor": "default",
+                "textAlignment": "left",
+                "level": 3,
+                "isToggleable": false
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "Heading 3"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "blockContainer",
+          "attrs": {
+            "id": "4"
+          },
+          "content": [
+            {
+              "type": "bulletListItem",
+              "attrs": {
+                "backgroundColor": "default",
+                "textColor": "default",
+                "textAlignment": "left"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "Bullet List"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "blockContainer",
+          "attrs": {
+            "id": "1"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "backgroundColor": "default",
+                "textColor": "default",
+                "textAlignment": "left"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/src/end-to-end/draghandle/draghandle.test.ts-snapshots/draghandledeletehoveroutsideselection-firefox-linux.json
+++ b/tests/src/end-to-end/draghandle/draghandle.test.ts-snapshots/draghandledeletehoveroutsideselection-firefox-linux.json
@@ -1,0 +1,96 @@
+{
+  "type": "doc",
+  "content": [
+    {
+      "type": "blockGroup",
+      "content": [
+        {
+          "type": "blockContainer",
+          "attrs": {
+            "id": "2"
+          },
+          "content": [
+            {
+              "type": "heading",
+              "attrs": {
+                "backgroundColor": "default",
+                "textColor": "default",
+                "textAlignment": "left",
+                "level": 2,
+                "isToggleable": false
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "Heading 2"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "blockContainer",
+          "attrs": {
+            "id": "3"
+          },
+          "content": [
+            {
+              "type": "heading",
+              "attrs": {
+                "backgroundColor": "default",
+                "textColor": "default",
+                "textAlignment": "left",
+                "level": 3,
+                "isToggleable": false
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "Heading 3"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "blockContainer",
+          "attrs": {
+            "id": "4"
+          },
+          "content": [
+            {
+              "type": "bulletListItem",
+              "attrs": {
+                "backgroundColor": "default",
+                "textColor": "default",
+                "textAlignment": "left"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "Bullet List"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "blockContainer",
+          "attrs": {
+            "id": "1"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "backgroundColor": "default",
+                "textColor": "default",
+                "textAlignment": "left"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/src/end-to-end/draghandle/draghandle.test.ts-snapshots/draghandledeletehoveroutsideselection-webkit-linux.json
+++ b/tests/src/end-to-end/draghandle/draghandle.test.ts-snapshots/draghandledeletehoveroutsideselection-webkit-linux.json
@@ -1,0 +1,96 @@
+{
+  "type": "doc",
+  "content": [
+    {
+      "type": "blockGroup",
+      "content": [
+        {
+          "type": "blockContainer",
+          "attrs": {
+            "id": "2"
+          },
+          "content": [
+            {
+              "type": "heading",
+              "attrs": {
+                "backgroundColor": "default",
+                "textColor": "default",
+                "textAlignment": "left",
+                "level": 2,
+                "isToggleable": false
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "Heading 2"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "blockContainer",
+          "attrs": {
+            "id": "3"
+          },
+          "content": [
+            {
+              "type": "heading",
+              "attrs": {
+                "backgroundColor": "default",
+                "textColor": "default",
+                "textAlignment": "left",
+                "level": 3,
+                "isToggleable": false
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "Heading 3"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "blockContainer",
+          "attrs": {
+            "id": "4"
+          },
+          "content": [
+            {
+              "type": "bulletListItem",
+              "attrs": {
+                "backgroundColor": "default",
+                "textColor": "default",
+                "textAlignment": "left"
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "Bullet List"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "blockContainer",
+          "attrs": {
+            "id": "1"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "backgroundColor": "default",
+                "textColor": "default",
+                "textAlignment": "left"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/src/end-to-end/draghandle/draghandle.test.ts-snapshots/draghandledeletemultiselection-chromium-linux.json
+++ b/tests/src/end-to-end/draghandle/draghandle.test.ts-snapshots/draghandledeletemultiselection-chromium-linux.json
@@ -1,0 +1,74 @@
+{
+  "type": "doc",
+  "content": [
+    {
+      "type": "blockGroup",
+      "content": [
+        {
+          "type": "blockContainer",
+          "attrs": {
+            "id": "0"
+          },
+          "content": [
+            {
+              "type": "heading",
+              "attrs": {
+                "backgroundColor": "default",
+                "textColor": "default",
+                "textAlignment": "left",
+                "level": 1,
+                "isToggleable": false
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "Heading 1"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "blockContainer",
+          "attrs": {
+            "id": "2"
+          },
+          "content": [
+            {
+              "type": "heading",
+              "attrs": {
+                "backgroundColor": "default",
+                "textColor": "default",
+                "textAlignment": "left",
+                "level": 2,
+                "isToggleable": false
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "Heading 2"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "blockContainer",
+          "attrs": {
+            "id": "1"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "backgroundColor": "default",
+                "textColor": "default",
+                "textAlignment": "left"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/src/end-to-end/draghandle/draghandle.test.ts-snapshots/draghandledeletemultiselection-firefox-linux.json
+++ b/tests/src/end-to-end/draghandle/draghandle.test.ts-snapshots/draghandledeletemultiselection-firefox-linux.json
@@ -1,0 +1,74 @@
+{
+  "type": "doc",
+  "content": [
+    {
+      "type": "blockGroup",
+      "content": [
+        {
+          "type": "blockContainer",
+          "attrs": {
+            "id": "0"
+          },
+          "content": [
+            {
+              "type": "heading",
+              "attrs": {
+                "backgroundColor": "default",
+                "textColor": "default",
+                "textAlignment": "left",
+                "level": 1,
+                "isToggleable": false
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "Heading 1"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "blockContainer",
+          "attrs": {
+            "id": "2"
+          },
+          "content": [
+            {
+              "type": "heading",
+              "attrs": {
+                "backgroundColor": "default",
+                "textColor": "default",
+                "textAlignment": "left",
+                "level": 2,
+                "isToggleable": false
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "Heading 2"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "blockContainer",
+          "attrs": {
+            "id": "1"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "backgroundColor": "default",
+                "textColor": "default",
+                "textAlignment": "left"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/src/end-to-end/draghandle/draghandle.test.ts-snapshots/draghandledeletemultiselection-webkit-linux.json
+++ b/tests/src/end-to-end/draghandle/draghandle.test.ts-snapshots/draghandledeletemultiselection-webkit-linux.json
@@ -1,0 +1,74 @@
+{
+  "type": "doc",
+  "content": [
+    {
+      "type": "blockGroup",
+      "content": [
+        {
+          "type": "blockContainer",
+          "attrs": {
+            "id": "0"
+          },
+          "content": [
+            {
+              "type": "heading",
+              "attrs": {
+                "backgroundColor": "default",
+                "textColor": "default",
+                "textAlignment": "left",
+                "level": 1,
+                "isToggleable": false
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "Heading 1"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "blockContainer",
+          "attrs": {
+            "id": "2"
+          },
+          "content": [
+            {
+              "type": "heading",
+              "attrs": {
+                "backgroundColor": "default",
+                "textColor": "default",
+                "textAlignment": "left",
+                "level": 2,
+                "isToggleable": false
+              },
+              "content": [
+                {
+                  "type": "text",
+                  "text": "Heading 2"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "blockContainer",
+          "attrs": {
+            "id": "1"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "backgroundColor": "default",
+                "textColor": "default",
+                "textAlignment": "left"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
# Summary

<!-- Briefly describe the feature being introduced. -->

This PR changes the drag handle menu's delete button to delete not just the block it's attached to, but all blocks spanned by the selection, if the attached block is also spanned by the selection. Otherwise, the same behaviour as before applies.

Closes #2411 

## Rationale

<!-- Explain the reasoning behind this feature and its benefits to the project. -->

This is more intuitive for users and makes it easier to delete many blocks at once.

## Changes

<!-- List the major changes made in this pull request. -->

- Updated click handler for `RemoveBlockItem`.

## Impact

<!-- Discuss any potential impacts this feature may have on existing functionalities. -->

N/A

## Testing

<!-- Describe how the feature has been tested, including both automated and manual testing strategies. -->

Added e2e tests.

## Screenshots/Video

<!-- Include screenshots or video demonstrating the new feature, if applicable. -->

N/A

## Checklist

- [X] Code follows the project's coding standards.
- [X] Unit tests covering the new feature have been added.
- [X] All existing tests pass.
- [X] The documentation has been updated to reflect the new feature

## Additional Notes

<!-- Any additional information or context relevant to this PR. -->

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved block deletion behavior: when multiple blocks are selected, deleting now removes all selected blocks instead of just the hovered one.

* **Tests**
  * Added end-to-end tests for draghandle deletion scenarios with multi-block selections and individual block deletion.
  * Updated test configuration and added cross-browser snapshot fixtures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->