### PR TITLE
feat: Enter moves selection to cell below in tables (BLO-1006)

### DIFF
--- a/packages/core/src/blocks/Table/TableExtension.ts
+++ b/packages/core/src/blocks/Table/TableExtension.ts
@@ -50,7 +50,11 @@ export const TableExtension = Extension.create({
           const $cell = selectionCell(state);
           const $nextCell = nextCell($cell, "vert", 1);
 
-          if ($nextCell && dispatch) {
+          if (!$nextCell) {
+            return false;
+          }
+
+          if (dispatch) {
             dispatch(
               state.tr
                 .setSelection(

--- a/packages/core/src/blocks/Table/TableExtension.ts
+++ b/packages/core/src/blocks/Table/TableExtension.ts
@@ -1,5 +1,14 @@
 import { callOrReturn, Extension, getExtensionField } from "@tiptap/core";
-import { columnResizing, goToNextCell, tableEditing } from "prosemirror-tables";
+import { TextSelection } from "prosemirror-state";
+import {
+  columnResizing,
+  goToNextCell,
+  isInTable,
+  moveCellForward,
+  nextCell,
+  selectionCell,
+  tableEditing,
+} from "prosemirror-tables";
 
 export const RESIZE_MIN_WIDTH = 35;
 export const EMPTY_CELL_WIDTH = 120;
@@ -24,19 +33,35 @@ export const TableExtension = Extension.create({
 
   addKeyboardShortcuts() {
     return {
-      // Makes enter create a new line within the cell.
+      // Moves the selection to the cell below.
       Enter: () => {
         if (
-          this.editor.state.selection.empty &&
-          this.editor.state.selection.$head.parent.type.name ===
-            "tableParagraph"
+          this.editor.state.selection.$head.parent.type.name !==
+          "tableParagraph"
         ) {
-          this.editor.commands.insertContent({ type: "hardBreak" });
-
-          return true;
+          return false;
         }
 
-        return false;
+        return this.editor.commands.command(({ state, dispatch }) => {
+          if (!isInTable(state)) {
+            return false;
+          }
+
+          const $cell = selectionCell(state);
+          const $nextCell = nextCell($cell, "vert", 1);
+
+          if ($nextCell && dispatch) {
+            dispatch(
+              state.tr
+                .setSelection(
+                  TextSelection.between($nextCell, moveCellForward($nextCell)),
+                )
+                .scrollIntoView(),
+            );
+          }
+
+          return true;
+        });
       },
       // Ensures that backspace won't delete the table if the text cursor is at
       // the start of a cell and the selection is empty.

--- a/tests/src/end-to-end/tables/tables.test.ts
+++ b/tests/src/end-to-end/tables/tables.test.ts
@@ -49,4 +49,22 @@ test.describe("Check Table interactions", () => {
 
     await compareDocToSnapshot(page, "arrowKeyCells.json");
   });
+  test("Enter should move to cell below", async ({ page }) => {
+    await focusOnEditor(page);
+    await executeSlashCommand(page, "table");
+    await page.keyboard.type("Top");
+    await page.keyboard.press("Enter");
+    await page.keyboard.type("Bottom");
+
+    await compareDocToSnapshot(page, "enterMovesToCellBelow.json");
+  });
+  test("Shift+Enter should create a new line within cell", async ({ page }) => {
+    await focusOnEditor(page);
+    await executeSlashCommand(page, "table");
+    await page.keyboard.type("Line 1");
+    await page.keyboard.press("Shift+Enter");
+    await page.keyboard.type("Line 2");
+
+    await compareDocToSnapshot(page, "shiftEnterNewLineInCell.json");
+  });
 });

--- a/tests/src/end-to-end/tables/tables.test.ts-snapshots/enterMovesToCellBelow-json-chromium-linux.json
+++ b/tests/src/end-to-end/tables/tables.test.ts-snapshots/enterMovesToCellBelow-json-chromium-linux.json
@@ -1,0 +1,160 @@
+{
+  "type": "doc",
+  "content": [
+    {
+      "type": "blockGroup",
+      "content": [
+        {
+          "type": "blockContainer",
+          "attrs": {
+            "id": "0"
+          },
+          "content": [
+            {
+              "type": "table",
+              "attrs": {
+                "textColor": "default"
+              },
+              "content": [
+                {
+                  "type": "tableRow",
+                  "content": [
+                    {
+                      "type": "tableCell",
+                      "attrs": {
+                        "textColor": "default",
+                        "backgroundColor": "default",
+                        "textAlignment": "left",
+                        "colspan": 1,
+                        "rowspan": 1,
+                        "colwidth": null
+                      },
+                      "content": [
+                        {
+                          "type": "tableParagraph",
+                          "content": [
+                            {
+                              "type": "text",
+                              "text": "Top"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "tableCell",
+                      "attrs": {
+                        "textColor": "default",
+                        "backgroundColor": "default",
+                        "textAlignment": "left",
+                        "colspan": 1,
+                        "rowspan": 1,
+                        "colwidth": null
+                      },
+                      "content": [
+                        {
+                          "type": "tableParagraph"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "tableCell",
+                      "attrs": {
+                        "textColor": "default",
+                        "backgroundColor": "default",
+                        "textAlignment": "left",
+                        "colspan": 1,
+                        "rowspan": 1,
+                        "colwidth": null
+                      },
+                      "content": [
+                        {
+                          "type": "tableParagraph"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "tableRow",
+                  "content": [
+                    {
+                      "type": "tableCell",
+                      "attrs": {
+                        "textColor": "default",
+                        "backgroundColor": "default",
+                        "textAlignment": "left",
+                        "colspan": 1,
+                        "rowspan": 1,
+                        "colwidth": null
+                      },
+                      "content": [
+                        {
+                          "type": "tableParagraph",
+                          "content": [
+                            {
+                              "type": "text",
+                              "text": "Bottom"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "tableCell",
+                      "attrs": {
+                        "textColor": "default",
+                        "backgroundColor": "default",
+                        "textAlignment": "left",
+                        "colspan": 1,
+                        "rowspan": 1,
+                        "colwidth": null
+                      },
+                      "content": [
+                        {
+                          "type": "tableParagraph"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "tableCell",
+                      "attrs": {
+                        "textColor": "default",
+                        "backgroundColor": "default",
+                        "textAlignment": "left",
+                        "colspan": 1,
+                        "rowspan": 1,
+                        "colwidth": null
+                      },
+                      "content": [
+                        {
+                          "type": "tableParagraph"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "blockContainer",
+          "attrs": {
+            "id": "1"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "backgroundColor": "default",
+                "textColor": "default",
+                "textAlignment": "left"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/src/end-to-end/tables/tables.test.ts-snapshots/enterMovesToCellBelow-json-firefox-linux.json
+++ b/tests/src/end-to-end/tables/tables.test.ts-snapshots/enterMovesToCellBelow-json-firefox-linux.json
@@ -1,0 +1,160 @@
+{
+  "type": "doc",
+  "content": [
+    {
+      "type": "blockGroup",
+      "content": [
+        {
+          "type": "blockContainer",
+          "attrs": {
+            "id": "0"
+          },
+          "content": [
+            {
+              "type": "table",
+              "attrs": {
+                "textColor": "default"
+              },
+              "content": [
+                {
+                  "type": "tableRow",
+                  "content": [
+                    {
+                      "type": "tableCell",
+                      "attrs": {
+                        "textColor": "default",
+                        "backgroundColor": "default",
+                        "textAlignment": "left",
+                        "colspan": 1,
+                        "rowspan": 1,
+                        "colwidth": null
+                      },
+                      "content": [
+                        {
+                          "type": "tableParagraph",
+                          "content": [
+                            {
+                              "type": "text",
+                              "text": "Top"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "tableCell",
+                      "attrs": {
+                        "textColor": "default",
+                        "backgroundColor": "default",
+                        "textAlignment": "left",
+                        "colspan": 1,
+                        "rowspan": 1,
+                        "colwidth": null
+                      },
+                      "content": [
+                        {
+                          "type": "tableParagraph"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "tableCell",
+                      "attrs": {
+                        "textColor": "default",
+                        "backgroundColor": "default",
+                        "textAlignment": "left",
+                        "colspan": 1,
+                        "rowspan": 1,
+                        "colwidth": null
+                      },
+                      "content": [
+                        {
+                          "type": "tableParagraph"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "tableRow",
+                  "content": [
+                    {
+                      "type": "tableCell",
+                      "attrs": {
+                        "textColor": "default",
+                        "backgroundColor": "default",
+                        "textAlignment": "left",
+                        "colspan": 1,
+                        "rowspan": 1,
+                        "colwidth": null
+                      },
+                      "content": [
+                        {
+                          "type": "tableParagraph",
+                          "content": [
+                            {
+                              "type": "text",
+                              "text": "Bottom"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "tableCell",
+                      "attrs": {
+                        "textColor": "default",
+                        "backgroundColor": "default",
+                        "textAlignment": "left",
+                        "colspan": 1,
+                        "rowspan": 1,
+                        "colwidth": null
+                      },
+                      "content": [
+                        {
+                          "type": "tableParagraph"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "tableCell",
+                      "attrs": {
+                        "textColor": "default",
+                        "backgroundColor": "default",
+                        "textAlignment": "left",
+                        "colspan": 1,
+                        "rowspan": 1,
+                        "colwidth": null
+                      },
+                      "content": [
+                        {
+                          "type": "tableParagraph"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "blockContainer",
+          "attrs": {
+            "id": "1"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "backgroundColor": "default",
+                "textColor": "default",
+                "textAlignment": "left"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/src/end-to-end/tables/tables.test.ts-snapshots/enterMovesToCellBelow-json-webkit-linux.json
+++ b/tests/src/end-to-end/tables/tables.test.ts-snapshots/enterMovesToCellBelow-json-webkit-linux.json
@@ -1,0 +1,160 @@
+{
+  "type": "doc",
+  "content": [
+    {
+      "type": "blockGroup",
+      "content": [
+        {
+          "type": "blockContainer",
+          "attrs": {
+            "id": "0"
+          },
+          "content": [
+            {
+              "type": "table",
+              "attrs": {
+                "textColor": "default"
+              },
+              "content": [
+                {
+                  "type": "tableRow",
+                  "content": [
+                    {
+                      "type": "tableCell",
+                      "attrs": {
+                        "textColor": "default",
+                        "backgroundColor": "default",
+                        "textAlignment": "left",
+                        "colspan": 1,
+                        "rowspan": 1,
+                        "colwidth": null
+                      },
+                      "content": [
+                        {
+                          "type": "tableParagraph",
+                          "content": [
+                            {
+                              "type": "text",
+                              "text": "Top"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "tableCell",
+                      "attrs": {
+                        "textColor": "default",
+                        "backgroundColor": "default",
+                        "textAlignment": "left",
+                        "colspan": 1,
+                        "rowspan": 1,
+                        "colwidth": null
+                      },
+                      "content": [
+                        {
+                          "type": "tableParagraph"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "tableCell",
+                      "attrs": {
+                        "textColor": "default",
+                        "backgroundColor": "default",
+                        "textAlignment": "left",
+                        "colspan": 1,
+                        "rowspan": 1,
+                        "colwidth": null
+                      },
+                      "content": [
+                        {
+                          "type": "tableParagraph"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "tableRow",
+                  "content": [
+                    {
+                      "type": "tableCell",
+                      "attrs": {
+                        "textColor": "default",
+                        "backgroundColor": "default",
+                        "textAlignment": "left",
+                        "colspan": 1,
+                        "rowspan": 1,
+                        "colwidth": null
+                      },
+                      "content": [
+                        {
+                          "type": "tableParagraph",
+                          "content": [
+                            {
+                              "type": "text",
+                              "text": "Bottom"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "tableCell",
+                      "attrs": {
+                        "textColor": "default",
+                        "backgroundColor": "default",
+                        "textAlignment": "left",
+                        "colspan": 1,
+                        "rowspan": 1,
+                        "colwidth": null
+                      },
+                      "content": [
+                        {
+                          "type": "tableParagraph"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "tableCell",
+                      "attrs": {
+                        "textColor": "default",
+                        "backgroundColor": "default",
+                        "textAlignment": "left",
+                        "colspan": 1,
+                        "rowspan": 1,
+                        "colwidth": null
+                      },
+                      "content": [
+                        {
+                          "type": "tableParagraph"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "blockContainer",
+          "attrs": {
+            "id": "1"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "backgroundColor": "default",
+                "textColor": "default",
+                "textAlignment": "left"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/src/end-to-end/tables/tables.test.ts-snapshots/shiftEnterNewLineInCell-json-chromium-linux.json
+++ b/tests/src/end-to-end/tables/tables.test.ts-snapshots/shiftEnterNewLineInCell-json-chromium-linux.json
@@ -1,0 +1,161 @@
+{
+  "type": "doc",
+  "content": [
+    {
+      "type": "blockGroup",
+      "content": [
+        {
+          "type": "blockContainer",
+          "attrs": {
+            "id": "0"
+          },
+          "content": [
+            {
+              "type": "table",
+              "attrs": {
+                "textColor": "default"
+              },
+              "content": [
+                {
+                  "type": "tableRow",
+                  "content": [
+                    {
+                      "type": "tableCell",
+                      "attrs": {
+                        "textColor": "default",
+                        "backgroundColor": "default",
+                        "textAlignment": "left",
+                        "colspan": 1,
+                        "rowspan": 1,
+                        "colwidth": null
+                      },
+                      "content": [
+                        {
+                          "type": "tableParagraph",
+                          "content": [
+                            {
+                              "type": "text",
+                              "text": "Line 1"
+                            },
+                            {
+                              "type": "hardBreak"
+                            },
+                            {
+                              "type": "text",
+                              "text": "Line 2"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "tableCell",
+                      "attrs": {
+                        "textColor": "default",
+                        "backgroundColor": "default",
+                        "textAlignment": "left",
+                        "colspan": 1,
+                        "rowspan": 1,
+                        "colwidth": null
+                      },
+                      "content": [
+                        {
+                          "type": "tableParagraph"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "tableCell",
+                      "attrs": {
+                        "textColor": "default",
+                        "backgroundColor": "default",
+                        "textAlignment": "left",
+                        "colspan": 1,
+                        "rowspan": 1,
+                        "colwidth": null
+                      },
+                      "content": [
+                        {
+                          "type": "tableParagraph"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "tableRow",
+                  "content": [
+                    {
+                      "type": "tableCell",
+                      "attrs": {
+                        "textColor": "default",
+                        "backgroundColor": "default",
+                        "textAlignment": "left",
+                        "colspan": 1,
+                        "rowspan": 1,
+                        "colwidth": null
+                      },
+                      "content": [
+                        {
+                          "type": "tableParagraph"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "tableCell",
+                      "attrs": {
+                        "textColor": "default",
+                        "backgroundColor": "default",
+                        "textAlignment": "left",
+                        "colspan": 1,
+                        "rowspan": 1,
+                        "colwidth": null
+                      },
+                      "content": [
+                        {
+                          "type": "tableParagraph"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "tableCell",
+                      "attrs": {
+                        "textColor": "default",
+                        "backgroundColor": "default",
+                        "textAlignment": "left",
+                        "colspan": 1,
+                        "rowspan": 1,
+                        "colwidth": null
+                      },
+                      "content": [
+                        {
+                          "type": "tableParagraph"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "blockContainer",
+          "attrs": {
+            "id": "1"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "backgroundColor": "default",
+                "textColor": "default",
+                "textAlignment": "left"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/src/end-to-end/tables/tables.test.ts-snapshots/shiftEnterNewLineInCell-json-firefox-linux.json
+++ b/tests/src/end-to-end/tables/tables.test.ts-snapshots/shiftEnterNewLineInCell-json-firefox-linux.json
@@ -1,0 +1,161 @@
+{
+  "type": "doc",
+  "content": [
+    {
+      "type": "blockGroup",
+      "content": [
+        {
+          "type": "blockContainer",
+          "attrs": {
+            "id": "0"
+          },
+          "content": [
+            {
+              "type": "table",
+              "attrs": {
+                "textColor": "default"
+              },
+              "content": [
+                {
+                  "type": "tableRow",
+                  "content": [
+                    {
+                      "type": "tableCell",
+                      "attrs": {
+                        "textColor": "default",
+                        "backgroundColor": "default",
+                        "textAlignment": "left",
+                        "colspan": 1,
+                        "rowspan": 1,
+                        "colwidth": null
+                      },
+                      "content": [
+                        {
+                          "type": "tableParagraph",
+                          "content": [
+                            {
+                              "type": "text",
+                              "text": "Line 1"
+                            },
+                            {
+                              "type": "hardBreak"
+                            },
+                            {
+                              "type": "text",
+                              "text": "Line 2"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "tableCell",
+                      "attrs": {
+                        "textColor": "default",
+                        "backgroundColor": "default",
+                        "textAlignment": "left",
+                        "colspan": 1,
+                        "rowspan": 1,
+                        "colwidth": null
+                      },
+                      "content": [
+                        {
+                          "type": "tableParagraph"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "tableCell",
+                      "attrs": {
+                        "textColor": "default",
+                        "backgroundColor": "default",
+                        "textAlignment": "left",
+                        "colspan": 1,
+                        "rowspan": 1,
+                        "colwidth": null
+                      },
+                      "content": [
+                        {
+                          "type": "tableParagraph"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "tableRow",
+                  "content": [
+                    {
+                      "type": "tableCell",
+                      "attrs": {
+                        "textColor": "default",
+                        "backgroundColor": "default",
+                        "textAlignment": "left",
+                        "colspan": 1,
+                        "rowspan": 1,
+                        "colwidth": null
+                      },
+                      "content": [
+                        {
+                          "type": "tableParagraph"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "tableCell",
+                      "attrs": {
+                        "textColor": "default",
+                        "backgroundColor": "default",
+                        "textAlignment": "left",
+                        "colspan": 1,
+                        "rowspan": 1,
+                        "colwidth": null
+                      },
+                      "content": [
+                        {
+                          "type": "tableParagraph"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "tableCell",
+                      "attrs": {
+                        "textColor": "default",
+                        "backgroundColor": "default",
+                        "textAlignment": "left",
+                        "colspan": 1,
+                        "rowspan": 1,
+                        "colwidth": null
+                      },
+                      "content": [
+                        {
+                          "type": "tableParagraph"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "blockContainer",
+          "attrs": {
+            "id": "1"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "backgroundColor": "default",
+                "textColor": "default",
+                "textAlignment": "left"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/src/end-to-end/tables/tables.test.ts-snapshots/shiftEnterNewLineInCell-json-webkit-linux.json
+++ b/tests/src/end-to-end/tables/tables.test.ts-snapshots/shiftEnterNewLineInCell-json-webkit-linux.json
@@ -1,0 +1,161 @@
+{
+  "type": "doc",
+  "content": [
+    {
+      "type": "blockGroup",
+      "content": [
+        {
+          "type": "blockContainer",
+          "attrs": {
+            "id": "0"
+          },
+          "content": [
+            {
+              "type": "table",
+              "attrs": {
+                "textColor": "default"
+              },
+              "content": [
+                {
+                  "type": "tableRow",
+                  "content": [
+                    {
+                      "type": "tableCell",
+                      "attrs": {
+                        "textColor": "default",
+                        "backgroundColor": "default",
+                        "textAlignment": "left",
+                        "colspan": 1,
+                        "rowspan": 1,
+                        "colwidth": null
+                      },
+                      "content": [
+                        {
+                          "type": "tableParagraph",
+                          "content": [
+                            {
+                              "type": "text",
+                              "text": "Line 1"
+                            },
+                            {
+                              "type": "hardBreak"
+                            },
+                            {
+                              "type": "text",
+                              "text": "Line 2"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "tableCell",
+                      "attrs": {
+                        "textColor": "default",
+                        "backgroundColor": "default",
+                        "textAlignment": "left",
+                        "colspan": 1,
+                        "rowspan": 1,
+                        "colwidth": null
+                      },
+                      "content": [
+                        {
+                          "type": "tableParagraph"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "tableCell",
+                      "attrs": {
+                        "textColor": "default",
+                        "backgroundColor": "default",
+                        "textAlignment": "left",
+                        "colspan": 1,
+                        "rowspan": 1,
+                        "colwidth": null
+                      },
+                      "content": [
+                        {
+                          "type": "tableParagraph"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "tableRow",
+                  "content": [
+                    {
+                      "type": "tableCell",
+                      "attrs": {
+                        "textColor": "default",
+                        "backgroundColor": "default",
+                        "textAlignment": "left",
+                        "colspan": 1,
+                        "rowspan": 1,
+                        "colwidth": null
+                      },
+                      "content": [
+                        {
+                          "type": "tableParagraph"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "tableCell",
+                      "attrs": {
+                        "textColor": "default",
+                        "backgroundColor": "default",
+                        "textAlignment": "left",
+                        "colspan": 1,
+                        "rowspan": 1,
+                        "colwidth": null
+                      },
+                      "content": [
+                        {
+                          "type": "tableParagraph"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "tableCell",
+                      "attrs": {
+                        "textColor": "default",
+                        "backgroundColor": "default",
+                        "textAlignment": "left",
+                        "colspan": 1,
+                        "rowspan": 1,
+                        "colwidth": null
+                      },
+                      "content": [
+                        {
+                          "type": "tableParagraph"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "blockContainer",
+          "attrs": {
+            "id": "1"
+          },
+          "content": [
+            {
+              "type": "paragraph",
+              "attrs": {
+                "backgroundColor": "default",
+                "textColor": "default",
+                "textAlignment": "left"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
# Summary

<!-- Briefly describe the feature being introduced. -->

This PR makes Enter move the selection to the cell below in a table much as Tab moves it to the cell right. Shift+Enter still creates a hard break as before.

Closes #2409

## Rationale

<!-- Explain the reasoning behind this feature and its benefits to the project. -->

This is more similar to how table keyboard navigation typically works in other apps.

## Changes

<!-- List the major changes made in this pull request. -->

See above.

## Impact

<!-- Discuss any potential impacts this feature may have on existing functionalities. -->

N/A

## Testing

<!-- Describe how the feature has been tested, including both automated and manual testing strategies. -->

Added e2e tests.

## Screenshots/Video

<!-- Include screenshots or video demonstrating the new feature, if applicable. -->

N/A

## Checklist

- [X] Code follows the project's coding standards.
- [X] Unit tests covering the new feature have been added.
- [X] All existing tests pass.
- [X] The documentation has been updated to reflect the new feature

## Additional Notes

<!-- Any additional information or context relevant to this PR. -->

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enter now moves focus to the cell below when editing tables.
  * Shift+Enter inserts a new line inside the current table cell without moving focus.

* **Tests**
  * Added end-to-end tests covering Enter and Shift+Enter table behavior.
  * Added cross-browser snapshot fixtures validating expected table document states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->