### PR TITLE
feat: Code mark input rule edge case (BLO-938)

### DIFF
--- a/packages/core/src/blocks/defaultBlocks.ts
+++ b/packages/core/src/blocks/defaultBlocks.ts
@@ -1,3 +1,4 @@
+import { InputRule } from "@tiptap/core";
 import Bold from "@tiptap/extension-bold";
 import Code from "@tiptap/extension-code";
 import Italic from "@tiptap/extension-italic";
@@ -136,7 +137,32 @@ export const defaultStyleSpecs = {
   italic: createStyleSpecFromTipTapMark(Italic, "boolean"),
   underline: createStyleSpecFromTipTapMark(Underline, "boolean"),
   strike: createStyleSpecFromTipTapMark(Strike, "boolean"),
-  code: createStyleSpecFromTipTapMark(Code, "boolean"),
+  code: createStyleSpecFromTipTapMark(
+    Code.extend({
+      // Extends the Code mark with an extra input rule that fires when a space is
+      // typed after the closing backtick. The default rule only fires when typing
+      // the closing backtick itself, so it misses the case where the user opens
+      // both backticks first, then writes content between them.
+      addInputRules() {
+        return [
+          ...(this.parent?.() ?? []),
+          new InputRule({
+            find: /(^|[^`])`([^`]+)`(?!`) $/,
+            handler: ({ state, range, match }) => {
+              const { tr, schema } = state;
+              const leadingChar = match[1];
+              const content = match[2];
+              tr.replaceWith(range.from + leadingChar.length, range.to, [
+                schema.text(content, [this.type.create()]),
+                schema.text(" "),
+              ]);
+            },
+          }),
+        ];
+      },
+    }),
+    "boolean",
+  ),
   textColor: TextColor,
   backgroundColor: BackgroundColor,
 } satisfies StyleSpecs;

--- a/packages/core/src/blocks/defaultBlocks.ts
+++ b/packages/core/src/blocks/defaultBlocks.ts
@@ -1,4 +1,4 @@
-import { InputRule } from "@tiptap/core";
+import { InputRule, markInputRule } from "@tiptap/core";
 import Bold from "@tiptap/extension-bold";
 import Code from "@tiptap/extension-code";
 import Italic from "@tiptap/extension-italic";
@@ -139,13 +139,20 @@ export const defaultStyleSpecs = {
   strike: createStyleSpecFromTipTapMark(Strike, "boolean"),
   code: createStyleSpecFromTipTapMark(
     Code.extend({
-      // Extends the Code mark with an extra input rule that fires when a space is
-      // typed after the closing backtick. The default rule only fires when typing
-      // the closing backtick itself, so it misses the case where the user opens
-      // both backticks first, then writes content between them.
       addInputRules() {
         return [
-          ...(this.parent?.() ?? []),
+          // Matches any string that starts with a backtick, ends with a
+          // backtick, and has any non-backtick characters in between. Copied
+          // from original input rule:
+          // https://github.com/ueberdosis/tiptap/blob/c27661c148cdbea9e1c80107e10d0a9d1775c4ec/packages/extension-code/src/code.ts#L116
+          markInputRule({
+            find: /(^|[^`])`([^`]+)`(?!`)$/,
+            type: this.type,
+          }),
+          // Extends the Code mark with an extra input rule that fires when a space is
+          // typed after the closing backtick. The default rule only fires when typing
+          // the closing backtick itself, so it misses the case where the user adds
+          // both backticks first, then writes content between them.
           new InputRule({
             find: /(^|[^`])`([^`]+)`(?!`) $/,
             handler: ({ state, range, match }) => {


### PR DESCRIPTION
# Summary

<!-- Briefly describe the feature being introduced. -->

The code mark/style has an input rule which converts text wrapped in backticks into code. However, it misses an edge case where the user inputs 2 backticks, then enters text between them and adds a space after. This PR adds an additional input rule for this case.

Closes #1970

## Rationale

<!-- Explain the reasoning behind this feature and its benefits to the project. -->

While minor, this is a nice improvement to UX.

## Changes

<!-- List the major changes made in this pull request. -->

- Extended `Code` TipTap mark with additional input rule.

## Impact

<!-- Discuss any potential impacts this feature may have on existing functionalities. -->

N/A

## Testing

<!-- Describe how the feature has been tested, including both automated and manual testing strategies. -->

N/A

## Screenshots/Video

<!-- Include screenshots or video demonstrating the new feature, if applicable. -->

N/A

## Checklist

- [X] Code follows the project's coding standards.
- [X] Unit tests covering the new feature have been added.
- [X] All existing tests pass.
- [X] The documentation has been updated to reflect the new feature

## Additional Notes

<!-- Any additional information or context relevant to this PR. -->

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved inline code handling so backtick-wrapped text followed immediately by a space is reliably recognized and rendered as code, preserving the trailing space correctly for smoother typing and display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->