### PR TITLE
fix: guard hideMenuIfNotFrozen against undefined view state (#2694, BLO-1171) 

### DIFF
--- a/packages/core/src/extensions/SideMenu/SideMenu.ts
+++ b/packages/core/src/extensions/SideMenu/SideMenu.ts
@@ -785,8 +785,8 @@ export const SideMenuExtension = createExtension(({ editor }) => {
      * interfering with open submenus.
      */
     hideMenuIfNotFrozen() {
-      if (!view!.menuFrozen && view!.state!.show) {
-        view!.state!.show = false;
+      if (!view!.menuFrozen && view!.state?.show) {
+        view!.state.show = false;
         view!.emitUpdate(view!.state!);
       }
     },


### PR DESCRIPTION
# Summary

Fixes #2694. `SideMenuExtension.hideMenuIfNotFrozen` was throwing `TypeError: Cannot read properties of undefined (reading 'show')` when a queued floating-ui scroll callback fired after the underlying `EditorView` had been re-created (e.g. toggling `editable`).

## Rationale

The plugin's `view.state` may already have not been initialized while `hideMenuIfNotFrozen` is still called in some sort of race condition.

A larger revisit of the side menu is planned — this is the minimal fix to stop the production noise for now.

## Changes

- [SideMenu.ts:788](packages/core/src/extensions/SideMenu/SideMenu.ts#L788) — use `view.state?.show` instead of `view.state!.show` in the freshness guard.

## Impact

No behavior change on the happy path; only suppresses the error when the view has been torn down.

## Testing

x

## Checklist

- [x] Code follows the project's coding standards.
- [ ] Unit tests covering the new feature have been added.
- [x] All existing tests pass.
- [ ] The documentation has been updated to reflect the new feature _(n/a)_

## Additional Notes

Quick fix ahead of a broader side-menu revisit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved potential instability with the side menu display by adding defensive checks to handle edge cases safely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->