### PR TITLE
fix: prevent table row drag from moving an extra adjacent row

### DIFF
--- a/packages/core/src/extensions/TableHandles/TableHandles.ts
+++ b/packages/core/src/extensions/TableHandles/TableHandles.ts
@@ -466,6 +466,8 @@ export class TableHandlesView implements PluginView {
     event.preventDefault();
 
     const { draggingState, colIndex, rowIndex } = this.state;
+    // Clear so a re-dispatched drop short-circuits above (issue #2691).
+    this.state.draggingState = undefined;
 
     const columnWidths = this.state.block.content.columnWidths;
 

--- a/tests/src/end-to-end/tables/tables.test.ts
+++ b/tests/src/end-to-end/tables/tables.test.ts
@@ -1,5 +1,6 @@
+import { expect } from "@playwright/test";
 import { test } from "../../setup/setupScript.js";
-import { BASE_URL } from "../../utils/const.js";
+import { BASE_URL, TABLE_SELECTOR } from "../../utils/const.js";
 import { compareDocToSnapshot, focusOnEditor } from "../../utils/editor.js";
 import { executeSlashCommand } from "../../utils/slashmenu.js";
 
@@ -66,5 +67,121 @@ test.describe("Check Table interactions", () => {
     await page.keyboard.type("Line 2");
 
     await compareDocToSnapshot(page, "shiftEnterNewLineInCell.json");
+  });
+  // Regression test for https://github.com/TypeCellOS/BlockNote/issues/2691.
+  // Drops the dragged row to the LEFT of `.bn-block-group` (where the side
+  // menu sits). SideMenuView re-dispatches drops outside `.bn-block-group`
+  // (within 250px) as synthetic events; without the guard in
+  // TableHandles.dropHandler, the synthetic drop AND the original drop both
+  // run the row-move logic, dragging an adjacent row along with the target.
+  test("Row drag should move only the dragged row", async ({
+    page,
+    browserName,
+  }) => {
+    test.skip(
+      browserName === "firefox",
+      "Playwright doesn't correctly simulate drag events in Firefox.",
+    );
+
+    await focusOnEditor(page);
+    await executeSlashCommand(page, "table");
+
+    // Replace the default table with a deterministic 5-row × 1-col table.
+    await page.evaluate(() => {
+      const cellAttrs = {
+        textColor: "default",
+        backgroundColor: "default",
+        textAlignment: "left",
+        colspan: 1,
+        rowspan: 1,
+        colwidth: null,
+      };
+      const rows = ["R1", "R2", "R3", "R4", "R5"].map((label) => ({
+        type: "tableRow",
+        content: [
+          {
+            type: "tableCell",
+            attrs: cellAttrs,
+            content: [
+              {
+                type: "tableParagraph",
+                content: [{ type: "text", text: label }],
+              },
+            ],
+          },
+        ],
+      }));
+      (
+        window as unknown as {
+          ProseMirror: {
+            commands: { setContent: (doc: unknown) => void };
+          };
+        }
+      ).ProseMirror.commands.setContent({
+        type: "doc",
+        content: [
+          {
+            type: "blockGroup",
+            content: [
+              {
+                type: "blockContainer",
+                attrs: { id: "0" },
+                content: [
+                  {
+                    type: "table",
+                    attrs: { textColor: "default" },
+                    content: rows,
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      });
+    });
+    await page.waitForFunction(
+      () => document.querySelectorAll(".bn-editor tbody tr").length === 5,
+    );
+
+    // Hover R2's first cell so its row drag handle becomes visible. The
+    // row handle has no rotate transform (the column handle does).
+    const rows = page.locator(`${TABLE_SELECTOR} tbody tr`);
+    await rows.nth(1).locator("td").first().hover();
+    const handle = page
+      .locator(".bn-table-handle")
+      .filter({ hasNot: page.locator(`[style*="rotate"]`) })
+      .first();
+    await handle.waitFor({ state: "visible" });
+    const handleBox = (await handle.boundingBox())!;
+
+    // Drop into the side-menu area: LEFT of `.bn-block-group`, vertically
+    // aligned with the last row. This is outside the block-group rect but
+    // well within the 250px range that triggers SideMenuView's synthetic
+    // drop re-dispatch — the same condition that surfaces the bug for
+    // real users dragging onto the side gutter.
+    const blockGroup = (await page
+      .locator(".bn-block-group")
+      .first()
+      .boundingBox())!;
+    const lastRowBox = (await rows.nth(4).locator("td").first().boundingBox())!;
+    const dropX = blockGroup.x - 50;
+    const dropY = lastRowBox.y + lastRowBox.height / 2;
+
+    await page.mouse.move(
+      handleBox.x + handleBox.width / 2,
+      handleBox.y + handleBox.height / 2,
+      { steps: 5 },
+    );
+    await page.mouse.down();
+    await page.mouse.move(dropX, dropY, { steps: 10 });
+    await page.mouse.up();
+
+    const order = (
+      await page
+        .locator(`${TABLE_SELECTOR} tbody tr td:first-child`)
+        .allInnerTexts()
+    ).map((t) => t.trim());
+    // Expected: only R2 moved. Buggy (#2691): R3 follows along.
+    expect(order).toEqual(["R1", "R3", "R4", "R5", "R2"]);
   });
 });


### PR DESCRIPTION
# Summary

Fixes a bug where dragging a single table row could move an extra adjacent row when the drop lands outside `.bn-block-group` (e.g. into the side menu gutter). Closes #2691.

## Rationale

`SideMenuView.dispatchSyntheticEvent` re-dispatches `drop` events as `synthetic` so ProseMirror can handle drops that fall outside the editor bounds. Both `SideMenuView` and `TableHandlesView` listen for `drop` on `pmView.root`. `SideMenuView`'s handlers already guard against the synthetic  event, but `TableHandlesView.dropHandler` does not — so a single user gesture invokes `dropHandler` twice (once for the synthetic, once for the original). Between the two calls, ProseMirror commits the row move and refreshes `state.block`, causing the second call to drag the now-shifted neighbor along with the original target.

The fix clears `state.draggingState` once `dropHandler` has the values it needs, making the handler idempotent. This avoids leaking knowledge of `SideMenuView`'s synthetic-event convention into `TableHandlesView` and protects against any future path that re-enters `dropHandler` for the same gesture.

## Changes

- `packages/core/src/extensions/TableHandles/TableHandles.ts`: After destructuring `draggingState` from `this.state`, clear `this.state.draggingState = undefined`. The re-dispatched drop now short-circuits at the existing `draggingState === undefined` early return.
- `tests/src/end-to-end/tables/tables.test.ts`: Added a Playwright regression test that drags row 2 of a 5-row table onto the side-menu gutter (`blockGroup.x - 50`) and asserts the resulting row order.

## Impact

- **TableHandles row/column drag**: Behavior unchanged for normal in-bounds drops. Out-of-bounds drops (side gutter, below table padding) now move only the dragged row instead of also dragging an adjacent one.
- **`dragEnd`** still sets `draggingState = undefined`, which is now a no-op  after `dropHandler` ran but stays correct for drag cancellations that never reach `dropHandler`.


## Testing

- **Regression test**: New Playwright test drags row 2 of a 5-row table onto the side-menu gutter and asserts the row order is `["R1", "R3", "R4", "R5",  "R2"]`. Fails without the fix with `["R1", "R4", "R5", "R2", "R3"]` (the exact bug pattern from #2691). Passes on chromium and webkit; firefox is skipped following the existing dragdrop test convention.
- **Manual**: Verified the original repro in the BlockNote demo no longer triggers after the fix.

## Screenshots/Video

**Before**
<img width="2144" height="1624" alt="duplicateRows" src="https://github.com/user-attachments/assets/39815646-edfa-4c56-b8c3-41a0f7157987" />

**After**
<img width="2144" height="1624" alt="화면 기록 2026-05-04 오후 3 43 22" src="https://github.com/user-attachments/assets/06c47ecc-0288-4895-81f4-52ee2ab37537" />

## Checklist

- [x] Code follows the project's coding standards.
- [x] Unit tests covering the new feature have been added.
- [x] All existing tests pass.
- [ ] The documentation has been updated to reflect the new feature

## Additional Notes

the bug is intermittent in real use because it only triggers when the drop coordinate falls outside `.bn-block-group`. The regression test pins the drop to the side gutter to make this deterministic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
- Fixed table row drag-and-drop behavior to prevent unintended row movements during drag operations, ensuring only the selected row is repositioned as intended.
- Added regression test coverage to verify correct row drag behavior and confirm that only the intended row moves during drag operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->