### PR TITLE
Custom schema example demos: alert title input + macro block

### DIFF
--- a/examples/06-custom-schema/01-alert-block/src/Alert.tsx
+++ b/examples/06-custom-schema/01-alert-block/src/Alert.tsx
@@ -60,6 +60,11 @@ export const createAlert = createReactBlockSpec(
         default: "warning",
         values: ["warning", "error", "info", "success"],
       },
+      title: {
+        default: undefined,
+        type: "string",
+        optional: true,
+      } as const,
     },
     content: "inline",
   },
@@ -69,6 +74,19 @@ export const createAlert = createReactBlockSpec(
         (a) => a.value === props.block.props.type,
       )!;
       const Icon = alertType.icon;
+      const savedTitle = props.block.props.title ?? "";
+
+      const saveTitle = (value: string) => {
+        const next = value.trim();
+        if (next === savedTitle) {
+          return;
+        }
+        props.editor.updateBlock(props.block, {
+          type: "alert",
+          props: { title: next || undefined },
+        });
+      };
+
       return (
         <div className={"alert"} data-alert-type={props.block.props.type}>
           {/*Icon which opens a menu to choose the Alert type*/}
@@ -111,8 +129,25 @@ export const createAlert = createReactBlockSpec(
               })}
             </Menu.Dropdown>
           </Menu>
-          {/*Rich text field for user to type in*/}
-          <div className={"inline-content"} ref={props.contentRef} />
+          <div className={"alert-body"}>
+            <div className={"alert-title-wrapper"} contentEditable={false}>
+              {/* This input can live within the block, and control the title property of the block */}
+              <input
+                key={savedTitle}
+                className={"alert-title-input"}
+                defaultValue={savedTitle}
+                placeholder="Add title"
+                onBlur={(e) => saveTitle(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter") {
+                    e.currentTarget.blur();
+                  }
+                }}
+              />
+            </div>
+            {/*Rich text field for user to type in*/}
+            <div className={"inline-content"} ref={props.contentRef} />
+          </div>
         </div>
       );
     },

--- a/examples/06-custom-schema/01-alert-block/src/styles.css
+++ b/examples/06-custom-schema/01-alert-block/src/styles.css
@@ -72,3 +72,47 @@
 .inline-content {
   flex-grow: 1;
 }
+
+.alert-body {
+  display: flex;
+  flex-direction: column;
+  flex-grow: 1;
+  min-width: 0;
+}
+
+.alert-title-wrapper {
+  display: flex;
+  align-items: center;
+  min-height: 24px;
+}
+
+.alert-title-input {
+  background: transparent;
+  border: none;
+  border-radius: 3px;
+  color: inherit;
+  cursor: text;
+  font-family: inherit;
+  font-size: 0.9em;
+  font-weight: 600;
+  outline: none;
+  padding: 2px 4px;
+  width: 100%;
+}
+
+.alert-title-input::placeholder {
+  color: rgba(0, 0, 0, 0.35);
+  font-weight: 500;
+}
+
+[data-color-scheme="dark"] .alert-title-input::placeholder {
+  color: rgba(255, 255, 255, 0.4);
+}
+
+.alert-title-input:hover:not(:focus) {
+  background-color: rgba(0, 0, 0, 0.04);
+}
+
+[data-color-scheme="dark"] .alert-title-input:hover:not(:focus) {
+  background-color: rgba(255, 255, 255, 0.06);
+}

--- a/examples/06-custom-schema/09-macro-block/.bnexample.json
+++ b/examples/06-custom-schema/09-macro-block/.bnexample.json
@@ -1,0 +1,11 @@
+{
+  "playground": true,
+  "docs": true,
+  "author": "matthewlipski",
+  "tags": [
+    "Intermediate",
+    "Blocks",
+    "Custom Schemas"
+  ],
+  "dependencies": {}
+}

--- a/examples/06-custom-schema/09-macro-block/README.md
+++ b/examples/06-custom-schema/09-macro-block/README.md
@@ -1,0 +1,12 @@
+# Macro Block
+
+In this example, we create a custom `Macro` block using the vanilla `createBlockSpec` API from `@blocknote/core`. Each macro block stores an `id` prop, and the `id` is used to look up "before" and "after" HTML strings in a global map. Those strings are injected as html on either side of the editable inline content.
+
+This pattern is useful when you want a block whose decoration is driven by a runtime registry — for example, server-driven labels, citations, or templated wrappers.
+
+**Try it out:** Edit the inline text inside each macro block. Notice that the "before" and "after" decorations stay non-editable, and that swapping the `id` in `App.tsx` would change the surrounding HTML without touching the block's content.
+
+**Relevant Docs:**
+
+- [Custom Blocks](/docs/features/custom-schemas/custom-blocks)
+- [Editor Setup](/docs/getting-started/editor-setup)

--- a/examples/06-custom-schema/09-macro-block/index.html
+++ b/examples/06-custom-schema/09-macro-block/index.html
@@ -1,0 +1,14 @@
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Macro Block</title>
+    <script>
+      <!-- AUTO-GENERATED FILE, DO NOT EDIT DIRECTLY -->
+    </script>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="./main.tsx"></script>
+  </body>
+</html>

--- a/examples/06-custom-schema/09-macro-block/main.tsx
+++ b/examples/06-custom-schema/09-macro-block/main.tsx
@@ -1,0 +1,11 @@
+// AUTO-GENERATED FILE, DO NOT EDIT DIRECTLY
+import React from "react";
+import { createRoot } from "react-dom/client";
+import App from "./src/App.jsx";
+
+const root = createRoot(document.getElementById("root")!);
+root.render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/examples/06-custom-schema/09-macro-block/package.json
+++ b/examples/06-custom-schema/09-macro-block/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@blocknote/example-custom-schema-macro-block",
+  "description": "AUTO-GENERATED FILE, DO NOT EDIT DIRECTLY",
+  "type": "module",
+  "private": true,
+  "version": "0.12.4",
+  "scripts": {
+    "start": "vite",
+    "dev": "vite",
+    "build:prod": "tsc && vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@blocknote/ariakit": "latest",
+    "@blocknote/core": "latest",
+    "@blocknote/mantine": "latest",
+    "@blocknote/react": "latest",
+    "@blocknote/shadcn": "latest",
+    "@mantine/core": "^9.0.2",
+    "@mantine/hooks": "^9.0.2",
+    "react": "^19.2.3",
+    "react-dom": "^19.2.3"
+  },
+  "devDependencies": {
+    "@types/react": "^19.2.3",
+    "@types/react-dom": "^19.2.3",
+    "@vitejs/plugin-react": "^6.0.1",
+    "vite": "^8.0.8"
+  }
+}

--- a/examples/06-custom-schema/09-macro-block/src/App.tsx
+++ b/examples/06-custom-schema/09-macro-block/src/App.tsx
@@ -1,0 +1,44 @@
+import { BlockNoteSchema, defaultBlockSpecs } from "@blocknote/core";
+import "@blocknote/core/fonts/inter.css";
+import { BlockNoteView } from "@blocknote/mantine";
+import "@blocknote/mantine/style.css";
+import { useCreateBlockNote } from "@blocknote/react";
+
+import { macroBlock } from "./Macro";
+import "./styles.css";
+
+const schema = BlockNoteSchema.create({
+  blockSpecs: {
+    ...defaultBlockSpecs,
+    macro: macroBlock(),
+  },
+});
+
+export default function App() {
+  const editor = useCreateBlockNote({
+    schema,
+    initialContent: [
+      {
+        type: "paragraph",
+        content:
+          "Below are two macro blocks. Each looks up its before/after content from a global registry by id — the first uses HTML strings, the second uses a live <input> element:",
+      },
+      {
+        type: "macro",
+        props: { id: "warning" },
+        content: "Stay hydrated while editing",
+      },
+      {
+        type: "macro",
+        props: { id: "note" },
+        content: "Type a note here, then add a label on the left",
+      },
+      {
+        type: "paragraph",
+        content: "Edit the inline text inside each macro to see it stay live.",
+      },
+    ],
+  });
+
+  return <BlockNoteView editor={editor} />;
+}

--- a/examples/06-custom-schema/09-macro-block/src/Macro.ts
+++ b/examples/06-custom-schema/09-macro-block/src/Macro.ts
@@ -1,0 +1,63 @@
+import { createBlockSpec, defaultProps } from "@blocknote/core";
+
+import { macroRegistry } from "./macroRegistry.js";
+
+// The Macro block — built with the vanilla `createBlockSpec` API.
+//
+// It carries a single `id` prop that is used to look up the HTML that should
+// be rendered in the "before" and "after" slots around the block's editable
+// inline content. This can actually be in any structure, it is in your control
+export const macroBlock = createBlockSpec(
+  {
+    type: "macro",
+    propSchema: {
+      textAlignment: defaultProps.textAlignment,
+      textColor: defaultProps.textColor,
+      id: {
+        default: "" as const,
+      },
+    },
+    content: "inline",
+  },
+  {
+    render: (block) => {
+      const wrapper = document.createElement("div");
+      wrapper.className = "macro-block";
+
+      // We pull from the "registry" what this block should insert before and after
+      const definition = macroRegistry[block.props.id];
+
+      const before = document.createElement("div");
+      before.className = "macro-slot macro-slot-before";
+      before.contentEditable = "false";
+      const beforeContent = definition?.before ?? "";
+      if (typeof beforeContent === "string") {
+        before.innerHTML = beforeContent;
+      } else {
+        before.appendChild(beforeContent);
+      }
+
+      const content = document.createElement("div");
+      content.className = "macro-content";
+
+      const after = document.createElement("div");
+      after.className = "macro-slot macro-slot-after";
+      after.contentEditable = "false";
+      const afterContent = definition?.after ?? "";
+      if (typeof afterContent === "string") {
+        after.innerHTML = afterContent;
+      } else {
+        after.appendChild(afterContent);
+      }
+
+      // You have full control over this HTML structure
+      // and can inject the rich-text content wherever you want
+      wrapper.append(before, content, after);
+
+      return {
+        dom: wrapper,
+        contentDOM: content,
+      };
+    },
+  },
+);

--- a/examples/06-custom-schema/09-macro-block/src/Macro.ts
+++ b/examples/06-custom-schema/09-macro-block/src/Macro.ts
@@ -1,6 +1,6 @@
 import { createBlockSpec, defaultProps } from "@blocknote/core";
 
-import { macroRegistry } from "./macroRegistry.js";
+import { macroRegistry } from "./macroRegistry";
 
 // The Macro block — built with the vanilla `createBlockSpec` API.
 //

--- a/examples/06-custom-schema/09-macro-block/src/macroRegistry.ts
+++ b/examples/06-custom-schema/09-macro-block/src/macroRegistry.ts
@@ -1,0 +1,48 @@
+// A global, runtime-mutable registry that maps a macro id to the content that
+// should be injected before and after the block's editable inline content.
+//
+// Each slot can be either:
+//   - an HTML string  → injected via innerHTML
+//   - an HTMLElement  → injected via appendChild (lets you put live, stateful
+//                       DOM into the slot — e.g. an <input>)
+//
+// In a real application this could be populated from a server response, a
+// shared module, or any other side channel — the block render function only
+// reads from it.
+export type MacroDefinition = {
+  before: string | HTMLElement;
+  after: string | HTMLElement;
+};
+
+// An interactive "before" slot: a real <input> that lives in the registry and
+// gets appended into whichever macro block uses this id. This mirrors the
+// pattern from the Alert block's title input — but here it's authored as
+// vanilla DOM and managed by the registry rather than by React state.
+const labelInput = document.createElement("input");
+labelInput.className = "macro-label-input";
+labelInput.type = "text";
+labelInput.placeholder = "Label…";
+labelInput.setAttribute("aria-label", "Macro label");
+
+export const macroRegistry: Record<string, MacroDefinition> = {
+  warning: {
+    before: `
+      <span class="macro-badge macro-badge-warning">
+        <span class="macro-emoji">⚠️</span>
+        Heads up
+      </span>
+    `,
+    after: `
+      <a class="macro-link" href="https://www.blocknotejs.org/" target="_blank" rel="noreferrer">
+        Read the docs →
+      </a>
+    `,
+  },
+  note: {
+    // An HTMLElement instead of a string — the macro block will appendChild it.
+    before: labelInput,
+    after: `
+      <span class="macro-meta">— the input on the left is a live DOM node</span>
+    `,
+  },
+};

--- a/examples/06-custom-schema/09-macro-block/src/styles.css
+++ b/examples/06-custom-schema/09-macro-block/src/styles.css
@@ -1,0 +1,104 @@
+.macro-block {
+  align-items: stretch;
+  background: rgba(0, 0, 0, 0.03);
+  border: 1px solid rgba(0, 0, 0, 0.06);
+  border-radius: 6px;
+  display: flex;
+  flex-direction: column;
+  flex-grow: 1;
+  gap: 6px;
+  padding: 8px 12px;
+}
+
+[data-color-scheme="dark"] .macro-block {
+  background: rgba(255, 255, 255, 0.04);
+  border-color: rgba(255, 255, 255, 0.08);
+}
+
+.macro-content {
+  flex-grow: 1;
+  min-width: 0;
+}
+
+.macro-slot {
+  align-items: center;
+  align-self: flex-start;
+  display: inline-flex;
+  user-select: none;
+}
+
+.macro-badge {
+  align-items: center;
+  border-radius: 999px;
+  display: inline-flex;
+  font-size: 0.75em;
+  font-weight: 600;
+  gap: 4px;
+  padding: 2px 10px;
+}
+
+.macro-badge-greeting {
+  background: #e0e7ff;
+  color: #312e81;
+}
+
+.macro-badge-warning {
+  background: #fef3c7;
+  color: #78350f;
+}
+
+.macro-emoji {
+  font-size: 1em;
+}
+
+.macro-meta {
+  color: rgba(0, 0, 0, 0.45);
+  font-size: 0.8em;
+  font-style: italic;
+}
+
+[data-color-scheme="dark"] .macro-meta {
+  color: rgba(255, 255, 255, 0.5);
+}
+
+.macro-link {
+  color: #2563eb;
+  font-size: 0.8em;
+  font-weight: 500;
+  text-decoration: none;
+}
+
+.macro-link:hover {
+  text-decoration: underline;
+}
+
+.macro-label-input {
+  background: transparent;
+  border: none;
+  border-radius: 3px;
+  color: inherit;
+  cursor: text;
+  font-family: inherit;
+  font-size: 0.8em;
+  font-weight: 600;
+  outline: none;
+  padding: 2px 6px;
+  width: 140px;
+}
+
+.macro-label-input::placeholder {
+  color: rgba(0, 0, 0, 0.35);
+  font-weight: 500;
+}
+
+.macro-label-input:hover:not(:focus) {
+  background-color: rgba(0, 0, 0, 0.04);
+}
+
+[data-color-scheme="dark"] .macro-label-input::placeholder {
+  color: rgba(255, 255, 255, 0.4);
+}
+
+[data-color-scheme="dark"] .macro-label-input:hover:not(:focus) {
+  background-color: rgba(255, 255, 255, 0.06);
+}

--- a/examples/06-custom-schema/09-macro-block/tsconfig.json
+++ b/examples/06-custom-schema/09-macro-block/tsconfig.json
@@ -1,0 +1,36 @@
+{
+  "__comment": "AUTO-GENERATED FILE, DO NOT EDIT DIRECTLY",
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": [
+      "DOM",
+      "DOM.Iterable",
+      "ESNext"
+    ],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "composite": true
+  },
+  "include": [
+    "."
+  ],
+  "__ADD_FOR_LOCAL_DEV_references": [
+    {
+      "path": "../../../packages/core/"
+    },
+    {
+      "path": "../../../packages/react/"
+    }
+  ]
+}

--- a/examples/06-custom-schema/09-macro-block/vite.config.ts
+++ b/examples/06-custom-schema/09-macro-block/vite.config.ts
@@ -1,0 +1,32 @@
+// AUTO-GENERATED FILE, DO NOT EDIT DIRECTLY
+import react from "@vitejs/plugin-react";
+import * as fs from "fs";
+import * as path from "path";
+import { defineConfig } from "vite";
+// import eslintPlugin from "vite-plugin-eslint";
+// https://vitejs.dev/config/
+export default defineConfig((conf) => ({
+  plugins: [react()],
+  optimizeDeps: {},
+  build: {
+    sourcemap: true,
+  },
+  resolve: {
+    alias:
+      conf.command === "build" ||
+      !fs.existsSync(path.resolve(__dirname, "../../packages/core/src"))
+        ? {}
+        : ({
+            // Comment out the lines below to load a built version of blocknote
+            // or, keep as is to load live from sources with live reload working
+            "@blocknote/core": path.resolve(
+              __dirname,
+              "../../packages/core/src/"
+            ),
+            "@blocknote/react": path.resolve(
+              __dirname,
+              "../../packages/react/src/"
+            ),
+          } as any),
+  },
+}));

--- a/playground/src/examples.gen.tsx
+++ b/playground/src/examples.gen.tsx
@@ -1459,6 +1459,28 @@
         "readme": "In this example, we create a custom block which renders a simple HTML paragraph with placeholder text. The block has no editable content.\n\n**Relevant Docs:**\n\n- [Custom Blocks](/docs/features/custom-schemas/custom-blocks)\n- [Editor Setup](/docs/getting-started/editor-setup)"
       },
       {
+        "projectSlug": "macro-block",
+        "fullSlug": "custom-schema/macro-block",
+        "pathFromRoot": "examples/06-custom-schema/09-macro-block",
+        "config": {
+          "playground": true,
+          "docs": true,
+          "author": "matthewlipski",
+          "tags": [
+            "Intermediate",
+            "Blocks",
+            "Custom Schemas"
+          ],
+          "dependencies": {} as any
+        },
+        "title": "Macro Block",
+        "group": {
+          "pathFromRoot": "examples/06-custom-schema",
+          "slug": "custom-schema"
+        },
+        "readme": "In this example, we create a custom `Macro` block using the vanilla `createBlockSpec` API from `@blocknote/core`. Each macro block stores an `id` prop, and the `id` is used to look up \"before\" and \"after\" HTML strings in a global map. Those strings are injected as html on either side of the editable inline content.\n\nThis pattern is useful when you want a block whose decoration is driven by a runtime registry — for example, server-driven labels, citations, or templated wrappers.\n\n**Try it out:** Edit the inline text inside each macro block. Notice that the \"before\" and \"after\" decorations stay non-editable, and that swapping the `id` in `App.tsx` would change the surrounding HTML without touching the block's content.\n\n**Relevant Docs:**\n\n- [Custom Blocks](/docs/features/custom-schemas/custom-blocks)\n- [Editor Setup](/docs/getting-started/editor-setup)"
+      },
+      {
         "projectSlug": "draggable-inline-content",
         "fullSlug": "custom-schema/draggable-inline-content",
         "pathFromRoot": "examples/06-custom-schema/draggable-inline-content",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3289,6 +3289,49 @@ importers:
         specifier: ^8.0.8
         version: 8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3)
 
+  examples/06-custom-schema/09-macro-block:
+    dependencies:
+      '@blocknote/ariakit':
+        specifier: latest
+        version: link:../../../packages/ariakit
+      '@blocknote/core':
+        specifier: latest
+        version: link:../../../packages/core
+      '@blocknote/mantine':
+        specifier: latest
+        version: link:../../../packages/mantine
+      '@blocknote/react':
+        specifier: latest
+        version: link:../../../packages/react
+      '@blocknote/shadcn':
+        specifier: latest
+        version: link:../../../packages/shadcn
+      '@mantine/core':
+        specifier: ^9.0.2
+        version: 9.1.1(@mantine/hooks@9.1.1(react@19.2.5))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@mantine/hooks':
+        specifier: ^9.0.2
+        version: 9.1.1(react@19.2.5)
+      react:
+        specifier: ^19.2.3
+        version: 19.2.5
+      react-dom:
+        specifier: ^19.2.3
+        version: 19.2.5(react@19.2.5)
+    devDependencies:
+      '@types/react':
+        specifier: ^19.2.3
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.14)
+      '@vitejs/plugin-react':
+        specifier: ^6.0.1
+        version: 6.0.1(babel-plugin-react-compiler@1.0.0)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3))
+      vite:
+        specifier: ^8.0.8
+        version: 8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.8.3)
+
   examples/06-custom-schema/draggable-inline-content:
     dependencies:
       '@blocknote/ariakit':


### PR DESCRIPTION
## Summary

Two new patterns for working with custom blocks, both as runnable examples under `examples/06-custom-schema/`.

### 1. Alert block — multiple "fields" via props (`01-alert-block`)
By rendering an `<input>` inside the block's React view and storing its value in a block prop, a single block can expose multiple editable fields. The alert block now has both:

- a flat, click-to-edit **title input** (stored in the new `title` prop), styled to look like static document text until focused
- the existing **rich-text body** (the BlockNote inline content)

This is a clean way to fake "structured" blocks without splitting the content across multiple blocks or stepping outside the BlockNote document model.

Example here: https://blocknote-git-feat-example-demos-typecell.vercel.app/custom-schema/alert-block

### 2. Macro block — arbitrary HTML injection from outside the document (`09-macro-block`)
Built with the vanilla `createBlockSpec` API (no React). Each macro block stores an `id` prop that's used to look up arbitrary content in a **global registry**, which is injected as the "before" and "after" decoration around the block's editable inline content.

Each registry slot accepts either:
- an **HTML string** → injected via `innerHTML` (read-only templated decoration)
- a live **HTMLElement** → injected via `appendChild` (live, interactive DOM — e.g. an `<input>` or `<button>`)

Combined with pattern #1, this gives you read-only templated wrappers (citations, server-driven labels, etc.) and lightweight interactive controls (inputs, buttons) sitting next to BlockNote's editable inline content — without that decoration ever being part of the document JSON.

Example here: https://blocknote-git-feat-example-demos-typecell.vercel.app/custom-schema/macro-block