### PR TITLE
fix: Pasting plain text from VSCode (BLO-366)

### DIFF
--- a/packages/core/src/api/clipboard/fromClipboard/handleVSCodePaste.ts
+++ b/packages/core/src/api/clipboard/fromClipboard/handleVSCodePaste.ts
@@ -1,9 +1,6 @@
 import { EditorView } from "prosemirror-view";
 
-export async function handleVSCodePaste(
-  event: ClipboardEvent,
-  view: EditorView,
-) {
+export function handleVSCodePaste(event: ClipboardEvent, view: EditorView) {
   const { schema } = view.state;
 
   if (!event.clipboardData) {
@@ -17,8 +14,7 @@ export async function handleVSCodePaste(
   }
 
   if (!schema.nodes.codeBlock) {
-    view.pasteText(text);
-    return true;
+    return false;
   }
 
   const vscode = event.clipboardData!.getData("vscode-editor-data");

--- a/packages/core/src/api/clipboard/fromClipboard/pasteExtension.ts
+++ b/packages/core/src/api/clipboard/fromClipboard/pasteExtension.ts
@@ -57,8 +57,13 @@ function defaultPasteHandler({
   }
 
   if (format === "vscode-editor-data") {
-    handleVSCodePaste(event, editor.prosemirrorView);
-    return true;
+    // If VSCode clipboard data cannot be parsed as a code block, try parsing
+    // `text/plain` as a fallback.
+    if (handleVSCodePaste(event, editor.prosemirrorView)) {
+      return true;
+    }
+
+    format = "text/plain";
   }
 
   if (format === "Files") {


### PR DESCRIPTION
# Summary

<!-- Briefly describe the feature being introduced. -->

When VSCode content is on the clipboard, it stores content in the `plain/text` MIME type. It also contains a bunch of information about the source, like the language of the code being pasted, which depends on the source file type.

BlockNote always attempts to parse VSCode content as a code block. If this fails for whatever reason, e.g. code blocks are not in the schema, a language wasn't found, etc, it won't paste anything.

This PR makes it so that if `handleVSCodePaste` is unable to parse the `text/plain` content as a code block, we attempt to parse it the usual way.

## Rationale

<!-- Explain the reasoning behind this feature and its benefits to the project. -->

While minor, it's not that uncommon for people to have plain text files in VSCode, or files without an ending. Copy/pasting from these into BlockNote is totally broken right now, so this should be fixed.

## Changes

<!-- List the major changes made in this pull request. -->

- If `handleVSCodePaste` returns false, `format` is set to `text/plain` and the content is parsed normally.
- Made `handleVSCodePaste` for all branches where the content cannot be parsed as a code block.

## Impact

<!-- Discuss any potential impacts this feature may have on existing functionalities. -->

N/A

## Testing

<!-- Describe how the feature has been tested, including both automated and manual testing strategies. -->

Our unit testing setup doesn't support adding custom content types to the clipboard the way that VSCode does, so we can't really replicate VSCode clipboard content for testing.

## Screenshots/Video

<!-- Include screenshots or video demonstrating the new feature, if applicable. -->

N/A

## Checklist

- [X] Code follows the project's coding standards.
- [ ] Unit tests covering the new feature have been added.
- [X] All existing tests pass.
- [ ] The documentation has been updated to reflect the new feature

## Additional Notes

<!-- Any additional information or context relevant to this PR. -->

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved clipboard paste handling for VS Code formatted content. Code blocks now paste with proper formatting only when a code block node is available; otherwise, content falls back to plain text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->