### PR TITLE
fix(i18): improve french translation for empty toggle list

### DIFF
--- a/packages/core/src/i18n/locales/fr.ts
+++ b/packages/core/src/i18n/locales/fr.ts
@@ -244,7 +244,7 @@ export const fr: Dictionary = {
     } as Record<string, string>,
   },
   toggle_blocks: {
-    add_block_button: "Toggle vide. Cliquez pour ajouter un bloc.",
+    add_block_button: "Liste repliable vide. Cliquez pour ajouter un bloc.",
   },
   // from react package:
   side_menu: {


### PR DESCRIPTION
# Summary

## Changes

When a toggle list is empty, the display message in French is not accurate. Translating toggle by `liste repliable` in this context makes more sense and helps the understanding of what action can be made by the user.


## Testing

No test was modified; I didn't find other occurrences of `Toggle vide` in the project.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Localization**
  * Refined French localization. The label text for empty collapsible sections has been updated with more descriptive wording. French-language users will now encounter clearer messaging that provides better description of these expandable interface elements. This localization enhancement improves overall user experience and comprehension throughout the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->