### PR TITLE
feat: Hide trailing block when editor is read-only (BLO-843)

### DIFF
--- a/packages/core/src/editor/editor.css
+++ b/packages/core/src/editor/editor.css
@@ -195,3 +195,8 @@ For the ShowSelectionPlugin
   background-color: highlight;
   padding: 2px 0;
 }
+
+/* Hide trailing block when editor is not editable. */
+.bn-editor[contenteditable="false"] .bn-trailing-block {
+  display: none;
+}

--- a/packages/core/src/extensions/TrailingNode/TrailingNode.ts
+++ b/packages/core/src/extensions/TrailingNode/TrailingNode.ts
@@ -1,4 +1,5 @@
 import { Plugin, PluginKey } from "prosemirror-state";
+import { Decoration, DecorationSet } from "prosemirror-view";
 import { createExtension } from "../../editor/BlockNoteExtension.js";
 
 // based on https://github.com/ueberdosis/tiptap/blob/40a9404c94c7fef7900610c195536384781ae101/demos/src/Experiments/TrailingNode/Vue/trailing-node.ts
@@ -19,6 +20,41 @@ export const TrailingNodeExtension = createExtension(() => {
     prosemirrorPlugins: [
       new Plugin({
         key: plugin,
+        props: {
+          decorations: (state) => {
+            const { doc } = state;
+
+            const lastBlockGroup = doc.lastChild;
+            if (!lastBlockGroup || lastBlockGroup.type.name !== "blockGroup") {
+              return;
+            }
+
+            const lastBlockContainer = lastBlockGroup.lastChild;
+            if (
+              !lastBlockContainer ||
+              lastBlockContainer.type.name !== "blockContainer"
+            ) {
+              return;
+            }
+
+            const lastBlockContent = lastBlockContainer.firstChild;
+            if (
+              !lastBlockContent ||
+              lastBlockContent.type.spec.content !== "inline*" ||
+              lastBlockContent.content.size > 0
+            ) {
+              return;
+            }
+
+            const from = doc.content.size - 1 - lastBlockContainer.nodeSize;
+
+            return DecorationSet.create(doc, [
+              Decoration.node(from, from + lastBlockContainer.nodeSize, {
+                class: "bn-trailing-block",
+              }),
+            ]);
+          },
+        },
         appendTransaction: (_, __, state) => {
           const { doc, tr, schema } = state;
           const shouldInsertNodeAtEnd = plugin.getState(state);


### PR DESCRIPTION
# Summary

<!-- Briefly describe the feature being introduced. -->

This PR hides the extra block created if the editor `trailingBlock` option is set to true or left undefined, when the edidor is read-only.

The block is hidden as opposed to being outright removed to avoid triggering content changes, which is a concern especially in the context of collaboration.

Closes #462

## Rationale

<!-- Explain the reasoning behind this feature and its benefits to the project. -->

The trailing block is pretty useless when read-only - it's whole point is to improve UX when the editor is interactive.

## Changes

<!-- List the major changes made in this pull request. -->

- Added decoration to `TrailingNodeExtension` to set `.bn-trailing-block` CSS class on trailing block.
- Added CSS rule to hide trailing block.

## Impact

<!-- Discuss any potential impacts this feature may have on existing functionalities. -->

N/A

## Testing

<!-- Describe how the feature has been tested, including both automated and manual testing strategies. -->

N/A

## Screenshots/Video

<!-- Include screenshots or video demonstrating the new feature, if applicable. -->

## Checklist

- [X] Code follows the project's coding standards.
- [ ] Unit tests covering the new feature have been added.
- [X] All existing tests pass.
- [ ] The documentation has been updated to reflect the new feature

## Additional Notes

<!-- Any additional information or context relevant to this PR. -->

N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed trailing placeholder block visibility in read-only editor mode—it now properly hides when the editor is not editable, providing a cleaner interface for document viewing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->