### PR TITLE
fix: Code block PDF export (BLO-987)

### DIFF
--- a/packages/xl-pdf-exporter/src/pdf/__snapshots__/example.jsx
+++ b/packages/xl-pdf-exporter/src/pdf/__snapshots__/example.jsx
@@ -1085,8 +1085,7 @@
       >
         <VIEW
           style={{
-            backgroundColor: '#161616',
-            color: '#ffffff',
+            border: '1px solid #000000',
             fontFamily: 'GeistMono',
             fontSize: 12,
             lineHeight: 1.25,

--- a/packages/xl-pdf-exporter/src/pdf/__snapshots__/exampleWithHeaderAndFooter.jsx
+++ b/packages/xl-pdf-exporter/src/pdf/__snapshots__/exampleWithHeaderAndFooter.jsx
@@ -1093,8 +1093,7 @@
       >
         <VIEW
           style={{
-            backgroundColor: '#161616',
-            color: '#ffffff',
+            border: '1px solid #000000',
             fontFamily: 'GeistMono',
             fontSize: 12,
             lineHeight: 1.25,

--- a/packages/xl-pdf-exporter/src/pdf/defaultSchema/blocks.tsx
+++ b/packages/xl-pdf-exporter/src/pdf/defaultSchema/blocks.tsx
@@ -114,7 +114,12 @@ export const pdfBlockMappingForDefaultSchema: BlockMapping<
     );
   },
   codeBlock: (block) => {
-    const textContent = (block.content as StyledText<any>[])[0]?.text || "";
+    // Code blocks should always contain a single `StyledText` inline content.
+    // However, if this is not the case for whatever reason, we can merge the
+    // text content of all `StyledText` content in them.
+    const textContent = (block.content as StyledText<any>[])
+      .map((item) => item.text)
+      .join("");
     const lines = textContent.split("\n").map((line, index) => {
       const indent = line.match(/^\s*/)?.[0].length || 0;
 
@@ -135,8 +140,7 @@ export const pdfBlockMappingForDefaultSchema: BlockMapping<
         wrap={false}
         style={{
           padding: 24 * PIXELS_PER_POINT,
-          backgroundColor: "#161616",
-          color: "#ffffff",
+          border: "1px solid #000000",
           lineHeight: 1.25,
           fontSize: FONT_SIZE * PIXELS_PER_POINT,
           fontFamily: "GeistMono",


### PR DESCRIPTION
# Summary

<!-- Briefly describe the feature being introduced. -->

This PR mainly changes the styling of code blocks when exported to PDF, replacing the black background for just a black border. The idea of this is to make it more suitable for print, which is a fairly common use case of exporting PDFs.

Additionally, it fixes an issue referenced in #2324, where only the first content with matching syntax highlighting is exported. The root cause of said issue is uncertain as syntax highlighting is applied via decorations, so I have no idea how it would ever show up in the editor content, but the fix should work all the same.

Closes #2324

## Rationale

<!-- Explain the reasoning behind this feature and its benefits to the project. -->

See above.

## Changes

<!-- List the major changes made in this pull request. -->

- Updated code block styling in exported PDF.
- Made all `StyledText` inline content get merged into a single string before exporting code block to PDF, instead of only the first `StyledText` text string being used.

## Impact

<!-- Discuss any potential impacts this feature may have on existing functionalities. -->

N/A

## Testing

<!-- Describe how the feature has been tested, including both automated and manual testing strategies. -->

N/A

## Screenshots/Video

<!-- Include screenshots or video demonstrating the new feature, if applicable. -->

N/A

## Checklist

- [X] Code follows the project's coding standards.
- [ ] Unit tests covering the new feature have been added.
- [X] All existing tests pass.
- [ ] The documentation has been updated to reflect the new feature

## Additional Notes

<!-- Any additional information or context relevant to this PR. -->

N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed code block rendering in PDF exports to display complete text content.

* **Style**
  * Updated code block styling in PDF exports with a simplified border design.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->