### PR TITLE
feat(react): Added select component for text align feature

### DIFF
--- a/docs/content/docs/react/components/formatting-toolbar.mdx
+++ b/docs/content/docs/react/components/formatting-toolbar.mdx
@@ -38,3 +38,29 @@ The first element in the default Formatting Toolbar is the Block Type Select, an
 <Example name="ui-components/formatting-toolbar-block-type-items" />
 
 Here, we use the `FormattingToolbar` component but keep the default buttons (we don't pass any children). Instead, we pass our customized Block Type Select items using the `blockTypeSelectItems` prop.
+
+## Adding a Text Align Select
+
+You can replace the default text alignment buttons with a `TextAlignSelect` dropdown, which groups all four alignment options (Left, Center, Right, Justify) into a single compact select.
+
+To use it, pass `<TextAlignSelect>` as a child of `FormattingToolbar` in a custom toolbar:
+
+```tsx
+import {
+  BlockTypeSelect,
+  FormattingToolbar,
+  FormattingToolbarController,
+  TextAlignSelect,
+} from "@blocknote/react";
+
+const CustomFormattingToolbar = () => (
+  <FormattingToolbar>
+    <BlockTypeSelect key="blockTypeSelect" />
+    {/* ... other toolbar items ... */}
+    <TextAlignSelect key="textAlignSelect" />
+    {/* ... other toolbar items ... */}
+  </FormattingToolbar>
+);
+```
+
+The select is only rendered when the cursor or selection is on a block that supports the `textAlignment` prop (e.g. paragraphs and headings). For table blocks, it applies the chosen alignment to the individual cells covered by the current cell selection.

--- a/packages/core/src/i18n/locales/ar.ts
+++ b/packages/core/src/i18n/locales/ar.ts
@@ -310,15 +310,19 @@ export const ar: Dictionary = {
     },
     align_left: {
       tooltip: "محاذاة النص إلى اليسار",
+      label: "يسار",
     },
     align_center: {
       tooltip: "محاذاة النص في المنتصف",
+      label: "وسط",
     },
     align_right: {
       tooltip: "محاذاة النص إلى اليمين",
+      label: "يمين",
     },
     align_justify: {
       tooltip: "ضبط النص",
+      label: "ضبط",
     },
     table_cell_merge: {
       tooltip: "جمع الخلايا",

--- a/packages/core/src/i18n/locales/de.ts
+++ b/packages/core/src/i18n/locales/de.ts
@@ -344,15 +344,19 @@ export const de: Dictionary = {
     },
     align_left: {
       tooltip: "Text linksbündig",
+      label: "Links",
     },
     align_center: {
       tooltip: "Text zentrieren",
+      label: "Zentriert",
     },
     align_right: {
       tooltip: "Text rechtsbündig",
+      label: "Rechts",
     },
     align_justify: {
       tooltip: "Text Blocksatz",
+      label: "Blocksatz",
     },
     table_cell_merge: {
       tooltip: "Zellen zusammenführen",

--- a/packages/core/src/i18n/locales/en.ts
+++ b/packages/core/src/i18n/locales/en.ts
@@ -325,15 +325,19 @@ export const en = {
     },
     align_left: {
       tooltip: "Align text left",
+      label: "Left"
     },
     align_center: {
       tooltip: "Align text center",
+      label: "Center"
     },
     align_right: {
       tooltip: "Align text right",
+      label: "Right"
     },
     align_justify: {
       tooltip: "Justify text",
+      label: "Justify"
     },
     table_cell_merge: {
       tooltip: "Merge cells",

--- a/packages/core/src/i18n/locales/es.ts
+++ b/packages/core/src/i18n/locales/es.ts
@@ -323,15 +323,19 @@ export const es: Dictionary = {
     },
     align_left: {
       tooltip: "Alinear texto a la izquierda",
+      label: "Izquierda",
     },
     align_center: {
       tooltip: "Alinear texto al centro",
+      label: "Centro",
     },
     align_right: {
       tooltip: "Alinear texto a la derecha",
+      label: "Derecha",
     },
     align_justify: {
       tooltip: "Justificar texto",
+      label: "Justificar",
     },
     table_cell_merge: {
       tooltip: "Combinar celdas",

--- a/packages/core/src/i18n/locales/fa.ts
+++ b/packages/core/src/i18n/locales/fa.ts
@@ -293,15 +293,19 @@ export const fa = {
     },
     align_left: {
       tooltip: "تراز متن چپ",
+      label: "چپ",
     },
     align_center: {
       tooltip: "تراز متن وسط",
+      label: "وسط",
     },
     align_right: {
       tooltip: "تراز متن راست",
+      label: "راست",
     },
     align_justify: {
       tooltip: "تراز متن دوطرفه",
+      label: "دوطرفه",
     },
     table_cell_merge: {
       tooltip: "ادغام سلول‌ها",

--- a/packages/core/src/i18n/locales/fr.ts
+++ b/packages/core/src/i18n/locales/fr.ts
@@ -371,15 +371,19 @@ export const fr: Dictionary = {
     },
     align_left: {
       tooltip: "Aligner le texte à gauche",
+      label: "Gauche",
     },
     align_center: {
       tooltip: "Aligner le texte au centre",
+      label: "Centre",
     },
     align_right: {
       tooltip: "Aligner le texte à droite",
+      label: "Droite",
     },
     align_justify: {
       tooltip: "Justifier le texte",
+      label: "Justifier",
     },
     table_cell_merge: {
       tooltip: "Fusionner les cellules",

--- a/packages/core/src/i18n/locales/he.ts
+++ b/packages/core/src/i18n/locales/he.ts
@@ -325,15 +325,19 @@ export const he: Dictionary = {
     },
     align_left: {
       tooltip: "ישר טקסט לשמאל",
+      label: "שמאל",
     },
     align_center: {
       tooltip: "מרכז טקסט",
+      label: "מרכז",
     },
     align_right: {
       tooltip: "ישר טקסט לימין",
+      label: "ימין",
     },
     align_justify: {
       tooltip: "ישר טקסט לשני הצדדים",
+      label: "יישור",
     },
     table_cell_merge: {
       tooltip: "מיזוג תאים",

--- a/packages/core/src/i18n/locales/hr.ts
+++ b/packages/core/src/i18n/locales/hr.ts
@@ -338,15 +338,19 @@ export const hr: Dictionary = {
     },
     align_left: {
       tooltip: "Poravnaj tekst lijevo",
+      label: "Lijevo",
     },
     align_center: {
       tooltip: "Poravnaj tekst po sredini",
+      label: "Sredina",
     },
     align_right: {
       tooltip: "Poravnaj tekst desno",
+      label: "Desno",
     },
     align_justify: {
       tooltip: "Poravnaj tekst obostrano",
+      label: "Obostrano",
     },
     table_cell_merge: {
       tooltip: "Spoji ćelije",

--- a/packages/core/src/i18n/locales/is.ts
+++ b/packages/core/src/i18n/locales/is.ts
@@ -338,15 +338,19 @@ export const is: Dictionary = {
     },
     align_left: {
       tooltip: "Vinstrijafna texta",
+      label: "Vinstri",
     },
     align_center: {
       tooltip: "Miðjustilla texta",
+      label: "Miðja",
     },
     align_right: {
       tooltip: "Hægrijafna texta",
+      label: "Hægri",
     },
     align_justify: {
       tooltip: "Jafna texta",
+      label: "Jafna",
     },
     table_cell_merge: {
       tooltip: "Sameina dálka",

--- a/packages/core/src/i18n/locales/it.ts
+++ b/packages/core/src/i18n/locales/it.ts
@@ -347,15 +347,19 @@ export const it: Dictionary = {
     },
     align_left: {
       tooltip: "Allinea testo a sinistra",
+      label: "Sinistra",
     },
     align_center: {
       tooltip: "Allinea testo al centro",
+      label: "Centro",
     },
     align_right: {
       tooltip: "Allinea testo a destra",
+      label: "Destra",
     },
     align_justify: {
       tooltip: "Giustifica testo",
+      label: "Giustifica",
     },
     table_cell_merge: {
       tooltip: "Unisci celle",

--- a/packages/core/src/i18n/locales/ja.ts
+++ b/packages/core/src/i18n/locales/ja.ts
@@ -365,15 +365,19 @@ export const ja: Dictionary = {
     },
     align_left: {
       tooltip: "左揃え",
+      label: "左",
     },
     align_center: {
       tooltip: "中央揃え",
+      label: "中央",
     },
     align_right: {
       tooltip: "右揃え",
+      label: "右",
     },
     align_justify: {
       tooltip: "両端揃え",
+      label: "両端",
     },
     table_cell_merge: {
       tooltip: "セルを結合",

--- a/packages/core/src/i18n/locales/ko.ts
+++ b/packages/core/src/i18n/locales/ko.ts
@@ -338,15 +338,19 @@ export const ko: Dictionary = {
     },
     align_left: {
       tooltip: "텍스트 왼쪽 맞춤",
+      label: "왼쪽",
     },
     align_center: {
       tooltip: "텍스트 가운데 맞춤",
+      label: "가운데",
     },
     align_right: {
       tooltip: "텍스트 오른쪽 맞춤",
+      label: "오른쪽",
     },
     align_justify: {
       tooltip: "텍스트 양쪽 맞춤",
+      label: "양쪽",
     },
     table_cell_merge: {
       tooltip: "셀 병합",

--- a/packages/core/src/i18n/locales/nl.ts
+++ b/packages/core/src/i18n/locales/nl.ts
@@ -325,15 +325,19 @@ export const nl: Dictionary = {
     },
     align_left: {
       tooltip: "Tekst links uitlijnen",
+      label: "Links",
     },
     align_center: {
       tooltip: "Tekst centreren",
+      label: "Midden",
     },
     align_right: {
       tooltip: "Tekst rechts uitlijnen",
+      label: "Rechts",
     },
     align_justify: {
       tooltip: "Tekst uitvullen",
+      label: "Uitvullen",
     },
     table_cell_merge: {
       tooltip: "Voeg cellen samen",

--- a/packages/core/src/i18n/locales/no.ts
+++ b/packages/core/src/i18n/locales/no.ts
@@ -342,15 +342,19 @@ export const no: Dictionary = {
     },
     align_left: {
       tooltip: "Venstrejuster tekst",
+      label: "Venstre",
     },
     align_center: {
       tooltip: "Midtstill tekst",
+      label: "Midtstilt",
     },
     align_right: {
       tooltip: "Høyrejuster tekst",
+      label: "Høyre",
     },
     align_justify: {
       tooltip: "Juster tekst",
+      label: "Justert",
     },
     comment: {
       tooltip: "Legg til kommentar",

--- a/packages/core/src/i18n/locales/pl.ts
+++ b/packages/core/src/i18n/locales/pl.ts
@@ -316,15 +316,19 @@ export const pl: Dictionary = {
     },
     align_left: {
       tooltip: "Wyrównaj tekst do lewej",
+      label: "Lewo",
     },
     align_center: {
       tooltip: "Wyśrodkuj tekst",
+      label: "Środek",
     },
     align_right: {
       tooltip: "Wyrównaj tekst do prawej",
+      label: "Prawo",
     },
     align_justify: {
       tooltip: "Wyjustuj tekst",
+      label: "Wyjustuj",
     },
     table_cell_merge: {
       tooltip: "Połącz komórki",

--- a/packages/core/src/i18n/locales/pt.ts
+++ b/packages/core/src/i18n/locales/pt.ts
@@ -317,15 +317,19 @@ export const pt: Dictionary = {
     },
     align_left: {
       tooltip: "Alinhar à esquerda",
+      label: "Esquerda"
     },
     align_center: {
       tooltip: "Alinhar ao centro",
+      label: "Centro"
     },
     align_right: {
       tooltip: "Alinhar à direita",
+      label: "Direita"
     },
     align_justify: {
       tooltip: "Justificar texto",
+      label: "Justificar"
     },
     table_cell_merge: {
       tooltip: "Juntar células",

--- a/packages/core/src/i18n/locales/ru.ts
+++ b/packages/core/src/i18n/locales/ru.ts
@@ -368,15 +368,19 @@ export const ru: Dictionary = {
     },
     align_left: {
       tooltip: "Текст по левому краю",
+      label: "Влево",
     },
     align_center: {
       tooltip: "Текст по середине",
+      label: "По центру",
     },
     align_right: {
       tooltip: "Текст по правому краю",
+      label: "Вправо",
     },
     align_justify: {
       tooltip: "По середине текст",
+      label: "По ширине",
     },
     table_cell_merge: {
       tooltip: "Объединить ячейки",

--- a/packages/core/src/i18n/locales/sk.ts
+++ b/packages/core/src/i18n/locales/sk.ts
@@ -323,15 +323,19 @@ export const sk = {
     },
     align_left: {
       tooltip: "Zarovnať text vľavo",
+      label: "Vľavo",
     },
     align_center: {
       tooltip: "Zarovnať text na stred",
+      label: "Stred",
     },
     align_right: {
       tooltip: "Zarovnať text vpravo",
+      label: "Vpravo",
     },
     align_justify: {
       tooltip: "Zarovnať text do bloku",
+      label: "Do bloku",
     },
     table_cell_merge: {
       tooltip: "Zlúčiť bunky",

--- a/packages/core/src/i18n/locales/uk.ts
+++ b/packages/core/src/i18n/locales/uk.ts
@@ -349,15 +349,19 @@ export const uk: Dictionary = {
     },
     align_left: {
       tooltip: "Вирівняти за лівим краєм",
+      label: "Ліво",
     },
     align_center: {
       tooltip: "Вирівняти по центру",
+      label: "По центру",
     },
     align_right: {
       tooltip: "Вирівняти за правим краєм",
+      label: "Право",
     },
     align_justify: {
       tooltip: "Вирівняти за шириною",
+      label: "По ширині",
     },
     table_cell_merge: {
       tooltip: "Об'єднати клітинки",

--- a/packages/core/src/i18n/locales/uz.ts
+++ b/packages/core/src/i18n/locales/uz.ts
@@ -370,10 +370,10 @@ export const uz: Dictionary = {
     nest: { tooltip: "O‘ngga surish", secondary_tooltip: "Tab" },
     unnest: { tooltip: "Chapga surish", secondary_tooltip: "Shift+Tab" },
 
-    align_left: { tooltip: "Chapga tekislash" },
-    align_center: { tooltip: "Markazga tekislash" },
-    align_right: { tooltip: "O‘ngga tekislash" },
-    align_justify: { tooltip: "Eniga tekislash" },
+    align_left: { tooltip: "Chapga tekislash", label: "Chap" },
+    align_center: { tooltip: "Markazga tekislash", label: "Markaz" },
+    align_right: { tooltip: "O’ngga tekislash", label: "O’ng" },
+    align_justify: { tooltip: "Eniga tekislash", label: "Eni bo’yicha" },
 
     table_cell_merge: { tooltip: "Kataklarni birlashtirish" },
     comment: { tooltip: "Izoh qo‘shish" },

--- a/packages/core/src/i18n/locales/vi.ts
+++ b/packages/core/src/i18n/locales/vi.ts
@@ -324,15 +324,19 @@ export const vi: Dictionary = {
     },
     align_left: {
       tooltip: "Căn trái văn bản",
+      label: "Trái",
     },
     align_center: {
       tooltip: "Căn giữa văn bản",
+      label: "Giữa",
     },
     align_right: {
       tooltip: "Căn phải văn bản",
+      label: "Phải",
     },
     align_justify: {
       tooltip: "Căn đều văn bản",
+      label: "Đều",
     },
     table_cell_merge: {
       tooltip: "Gộp các ô",

--- a/packages/core/src/i18n/locales/zh-tw.ts
+++ b/packages/core/src/i18n/locales/zh-tw.ts
@@ -366,15 +366,19 @@ export const zhTW: Dictionary = {
     },
     align_left: {
       tooltip: "靠左對齊",
+      label: "靠左",
     },
     align_center: {
       tooltip: "置中",
+      label: "置中",
     },
     align_right: {
       tooltip: "靠右對齊",
+      label: "靠右",
     },
     align_justify: {
       tooltip: "兩端對齊",
+      label: "兩端",
     },
     table_cell_merge: {
       tooltip: "合併儲存格",

--- a/packages/core/src/i18n/locales/zh.ts
+++ b/packages/core/src/i18n/locales/zh.ts
@@ -366,15 +366,19 @@ export const zh: Dictionary = {
     },
     align_left: {
       tooltip: "左对齐",
+      label: "左对齐",
     },
     align_center: {
       tooltip: "居中",
+      label: "居中",
     },
     align_right: {
       tooltip: "右对齐",
+      label: "右对齐",
     },
     align_justify: {
       tooltip: "文本对齐",
+      label: "两端对齐",
     },
     table_cell_merge: {
       tooltip: "合并单元格",

--- a/packages/react/src/components/FormattingToolbar/DefaultSelects/TextAlignSelect.tsx
+++ b/packages/react/src/components/FormattingToolbar/DefaultSelects/TextAlignSelect.tsx
@@ -138,6 +138,7 @@ export const TextAlignSelect = () => {
           );
 
           cellSelection.cells.forEach(({ row, col }) => {
+            if (!newTable[row]?.cells[col]) { return; }
             newTable[row].cells[col] = {
               ...newTable[row].cells[col],
               props: {

--- a/packages/react/src/components/FormattingToolbar/DefaultSelects/TextAlignSelect.tsx
+++ b/packages/react/src/components/FormattingToolbar/DefaultSelects/TextAlignSelect.tsx
@@ -1,0 +1,179 @@
+import {
+  blockHasType,
+  BlockSchema,
+  defaultProps,
+  DefaultProps,
+  editorHasBlockWithType,
+  InlineContentSchema,
+  mapTableCell,
+  StyleSchema,
+  TableContent,
+} from "@blocknote/core";
+import { TableHandlesExtension } from "@blocknote/core/extensions";
+import { useCallback, useMemo } from "react";
+import { IconType } from "react-icons";
+import {
+  RiAlignCenter,
+  RiAlignJustify,
+  RiAlignLeft,
+  RiAlignRight,
+} from "react-icons/ri";
+
+import {
+  ComponentProps,
+  useComponentsContext,
+} from "../../../editor/ComponentsContext.js";
+import { useBlockNoteEditor } from "../../../hooks/useBlockNoteEditor.js";
+import { useEditorState } from "../../../hooks/useEditorState.js";
+import { useDictionary } from "../../../i18n/dictionary.js";
+
+type TextAlignment = DefaultProps["textAlignment"];
+
+const icons: Record<TextAlignment, IconType> = {
+  left: RiAlignLeft,
+  center: RiAlignCenter,
+  right: RiAlignRight,
+  justify: RiAlignJustify,
+};
+
+const alignments: TextAlignment[] = ["left", "center", "right", "justify"];
+
+export const TextAlignSelect = () => {
+  const Components = useComponentsContext()!;
+  const dict = useDictionary();
+
+  const editor = useBlockNoteEditor<
+    BlockSchema,
+    InlineContentSchema,
+    StyleSchema
+  >();
+
+  const state = useEditorState({
+    editor,
+    selector: ({ editor }) => {
+      if (!editor.isEditable) {
+        return undefined;
+      }
+
+      const selectedBlocks = editor.getSelection()?.blocks || [
+        editor.getTextCursorPosition().block,
+      ];
+
+      const firstBlock = selectedBlocks[0];
+
+      if (
+        blockHasType(firstBlock, editor, firstBlock.type, {
+          textAlignment: defaultProps.textAlignment,
+        })
+      ) {
+        return {
+          textAlignment: firstBlock.props.textAlignment,
+          blocks: selectedBlocks,
+        };
+      }
+
+      if (
+        selectedBlocks.length === 1 &&
+        blockHasType(firstBlock, editor, "table")
+      ) {
+        const cellSelection = editor
+          .getExtension(TableHandlesExtension)
+          ?.getCellSelection();
+
+        if (!cellSelection) {
+          return undefined;
+        }
+
+        return {
+          textAlignment: mapTableCell(
+            (firstBlock.content as TableContent<any, any>).rows[0].cells[0],
+          ).props.textAlignment,
+          blocks: [firstBlock],
+        };
+      }
+
+      return undefined;
+    },
+  });
+
+  const setTextAlignment = useCallback(
+    (textAlignment: TextAlignment) => {
+      if (state === undefined) {
+        return;
+      }
+
+      editor.focus();
+
+      for (const block of state.blocks) {
+        if (
+          blockHasType(block, editor, block.type, {
+            textAlignment: defaultProps.textAlignment,
+          }) &&
+          editorHasBlockWithType(editor, block.type, {
+            textAlignment: defaultProps.textAlignment,
+          })
+        ) {
+          editor.updateBlock(block, {
+            props: { textAlignment },
+          });
+        } else if (block.type === "table") {
+          const cellSelection = editor
+            .getExtension(TableHandlesExtension)
+            ?.getCellSelection();
+          if (!cellSelection) {
+            continue;
+          }
+
+          const newTable = (block.content as TableContent<any, any>).rows.map(
+            (row) => ({
+              ...row,
+              cells: row.cells.map((cell) => mapTableCell(cell)),
+            }),
+          );
+
+          cellSelection.cells.forEach(({ row, col }) => {
+            newTable[row].cells[col].props.textAlignment = textAlignment;
+          });
+
+          editor.updateBlock(block, {
+            type: "table",
+            content: {
+              ...(block.content as TableContent<any, any>),
+              type: "tableContent",
+              rows: newTable,
+            } as any,
+          });
+
+          editor.setTextCursorPosition(block);
+        }
+      }
+    },
+    [editor, state],
+  );
+
+  const selectItems: ComponentProps["FormattingToolbar"]["Select"]["items"] =
+    useMemo(
+      () =>
+        alignments.map((alignment) => {
+          const Icon = icons[alignment];
+          return {
+            text: dict.formatting_toolbar[`align_${alignment}`].label,
+            icon: <Icon size={16} />,
+            isSelected: state?.textAlignment === alignment,
+            onClick: () => setTextAlignment(alignment),
+          };
+        }),
+      [dict, setTextAlignment, state?.textAlignment],
+    );
+
+  if (state === undefined) {
+    return null;
+  }
+
+  return (
+    <Components.FormattingToolbar.Select
+      className={"bn-select"}
+      items={selectItems}
+    />
+  );
+};

--- a/packages/react/src/components/FormattingToolbar/DefaultSelects/TextAlignSelect.tsx
+++ b/packages/react/src/components/FormattingToolbar/DefaultSelects/TextAlignSelect.tsx
@@ -80,14 +80,20 @@ export const TextAlignSelect = () => {
           .getExtension(TableHandlesExtension)
           ?.getCellSelection();
 
-        if (!cellSelection) {
+        if (!cellSelection || cellSelection.cells.length === 0) {
+          return undefined;
+        }
+
+        const { row, col } = cellSelection.cells[0];
+        const tableContent = firstBlock.content as TableContent<any, any>;
+        const selectedCell = tableContent.rows[row]?.cells[col];
+
+        if (!selectedCell) {
           return undefined;
         }
 
         return {
-          textAlignment: mapTableCell(
-            (firstBlock.content as TableContent<any, any>).rows[0].cells[0],
-          ).props.textAlignment,
+          textAlignment: mapTableCell(selectedCell).props.textAlignment,
           blocks: [firstBlock],
         };
       }
@@ -132,7 +138,13 @@ export const TextAlignSelect = () => {
           );
 
           cellSelection.cells.forEach(({ row, col }) => {
-            newTable[row].cells[col].props.textAlignment = textAlignment;
+            newTable[row].cells[col] = {
+              ...newTable[row].cells[col],
+              props: {
+                ...newTable[row].cells[col].props,
+                textAlignment,
+              },
+            };
           });
 
           editor.updateBlock(block, {

--- a/packages/react/src/components/FormattingToolbar/DefaultSelects/TextAlignSelect.tsx
+++ b/packages/react/src/components/FormattingToolbar/DefaultSelects/TextAlignSelect.tsx
@@ -1,5 +1,7 @@
 import {
+  Block,
   blockHasType,
+  BlockNoteEditor,
   BlockSchema,
   defaultProps,
   DefaultProps,
@@ -10,6 +12,8 @@ import {
   TableContent,
 } from "@blocknote/core";
 import { TableHandlesExtension } from "@blocknote/core/extensions";
+import { TextSelection } from "@tiptap/pm/state";
+import { TableMap } from "@tiptap/pm/tables";
 import { useCallback, useMemo } from "react";
 import { IconType } from "react-icons";
 import {
@@ -28,6 +32,79 @@ import { useEditorState } from "../../../hooks/useEditorState.js";
 import { useDictionary } from "../../../i18n/dictionary.js";
 
 type TextAlignment = DefaultProps["textAlignment"];
+
+function getCellCursorOffset(tiptapEditor: { state: { selection: { $from: any } } }): number {
+  const { $from } = tiptapEditor.state.selection;
+  for (let d = $from.depth; d >= 0; d--) {
+    const role = $from.node(d).type.spec.tableRole as string | undefined;
+    if (role === "cell" || role === "header_cell") {
+      return $from.pos - $from.start(d);
+    }
+  }
+  return 0;
+}
+
+function restoreTableCellCursor(
+  tiptapEditor: { state: any; view: any },
+  targetRow: number,
+  targetCol: number,
+  cellOffset: number,
+): void {
+  const { state, view } = tiptapEditor;
+  const { $from } = state.selection;
+  for (let d = $from.depth; d >= 0; d--) {
+    if ($from.node(d).type.name === "table") {
+      const tableMap = TableMap.get($from.node(d));
+      if (targetRow < tableMap.height && targetCol < tableMap.width) {
+        const cellPos = $from.start(d) + tableMap.map[targetRow * tableMap.width + targetCol];
+        view.dispatch(state.tr.setSelection(TextSelection.create(state.doc, cellPos + 1 + cellOffset)));
+      }
+      break;
+    }
+  }
+}
+
+function applyTextAlignmentToTableBlock(
+  editor: BlockNoteEditor<BlockSchema, InlineContentSchema, StyleSchema>,
+  block: Block<any, any, any>,
+  textAlignment: TextAlignment,
+): void {
+  const cellSelection = editor
+    .getExtension(TableHandlesExtension)
+    ?.getCellSelection();
+  if (!cellSelection) return;
+
+  const { row: targetRow, col: targetCol } = cellSelection.cells[0];
+  const savedCellOffset = getCellCursorOffset(editor._tiptapEditor);
+
+  const newTable = (block.content as TableContent<any, any>).rows.map(
+    (row) => ({
+      ...row,
+      cells: row.cells.map((cell) => mapTableCell(cell)),
+    }),
+  );
+
+  cellSelection.cells.forEach(({ row, col }) => {
+    if (!newTable[row]?.cells[col]) return;
+    newTable[row].cells[col] = {
+      ...newTable[row].cells[col],
+      props: { ...newTable[row].cells[col].props, textAlignment },
+    };
+  });
+
+  editor.updateBlock(block, {
+    type: "table",
+    content: {
+      ...(block.content as TableContent<any, any>),
+      type: "tableContent",
+      rows: newTable,
+    } as any,
+  });
+
+  editor.setTextCursorPosition(block);
+  restoreTableCellCursor(editor._tiptapEditor, targetRow, targetCol, savedCellOffset);
+  editor.focus();
+}
 
 const icons: Record<TextAlignment, IconType> = {
   left: RiAlignLeft,
@@ -123,41 +200,7 @@ export const TextAlignSelect = () => {
             props: { textAlignment },
           });
         } else if (block.type === "table") {
-          const cellSelection = editor
-            .getExtension(TableHandlesExtension)
-            ?.getCellSelection();
-          if (!cellSelection) {
-            continue;
-          }
-
-          const newTable = (block.content as TableContent<any, any>).rows.map(
-            (row) => ({
-              ...row,
-              cells: row.cells.map((cell) => mapTableCell(cell)),
-            }),
-          );
-
-          cellSelection.cells.forEach(({ row, col }) => {
-            if (!newTable[row]?.cells[col]) { return; }
-            newTable[row].cells[col] = {
-              ...newTable[row].cells[col],
-              props: {
-                ...newTable[row].cells[col].props,
-                textAlignment,
-              },
-            };
-          });
-
-          editor.updateBlock(block, {
-            type: "table",
-            content: {
-              ...(block.content as TableContent<any, any>),
-              type: "tableContent",
-              rows: newTable,
-            } as any,
-          });
-
-          editor.setTextCursorPosition(block);
+          applyTextAlignmentToTableBlock(editor, block, textAlignment);
         }
       }
     },

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -34,6 +34,7 @@ export * from "./components/FormattingToolbar/DefaultButtons/NestBlockButtons.js
 export * from "./components/FormattingToolbar/DefaultButtons/TableCellMergeButton.js";
 export * from "./components/FormattingToolbar/DefaultButtons/TextAlignButton.js";
 export * from "./components/FormattingToolbar/DefaultSelects/BlockTypeSelect.js";
+export * from "./components/FormattingToolbar/DefaultSelects/TextAlignSelect.js";
 export * from "./components/FormattingToolbar/FormattingToolbar.js";
 export * from "./components/FormattingToolbar/FormattingToolbarController.js";
 export * from "./components/FormattingToolbar/ExperimentalMobileFormattingToolbarController.js";

--- a/tests/src/unit/react/TextAlignSelect.test.tsx
+++ b/tests/src/unit/react/TextAlignSelect.test.tsx
@@ -1,0 +1,88 @@
+import { BlockNoteEditor } from "@blocknote/core";
+import { BlockNoteView } from "@blocknote/mantine";
+import "@blocknote/mantine/style.css";
+import { TextAlignSelect } from "@blocknote/react";
+import { flushSync } from "react-dom";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+describe("TextAlignSelect", () => {
+  let container: HTMLDivElement;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    document.body.removeChild(container);
+  });
+
+  it("renders null when editor is not editable", () => {
+    const editor = BlockNoteEditor.create();
+    editor.isEditable = false;
+    const root = createRoot(container);
+
+    flushSync(() => {
+      root.render(
+        <BlockNoteView editor={editor} formattingToolbar={false}>
+          <TextAlignSelect />
+        </BlockNoteView>,
+      );
+    });
+
+    expect(container.querySelector("button")).toBeNull();
+
+    root.unmount();
+    editor._tiptapEditor.destroy();
+  });
+
+  it("renders select button for an alignable block", () => {
+    const editor = BlockNoteEditor.create();
+    const root = createRoot(container);
+
+    flushSync(() => {
+      root.render(
+        <BlockNoteView editor={editor} formattingToolbar={false}>
+          <TextAlignSelect />
+        </BlockNoteView>,
+      );
+    });
+
+    expect(container.querySelector("button")).not.toBeNull();
+
+    root.unmount();
+    editor._tiptapEditor.destroy();
+  });
+
+  it("reactively updates button label when block alignment changes", () => {
+    const editor = BlockNoteEditor.create();
+    const root = createRoot(container);
+
+    flushSync(() => {
+      root.render(
+        <BlockNoteView editor={editor} formattingToolbar={false}>
+          <TextAlignSelect />
+        </BlockNoteView>,
+      );
+    });
+
+    expect(container.querySelector("button")?.textContent).toContain("Left");
+
+    const block = editor.document[0];
+    flushSync(() => {
+      editor.updateBlock(block, { props: { textAlignment: "center" } });
+    });
+
+    expect(container.querySelector("button")?.textContent).toContain("Center");
+
+    flushSync(() => {
+      editor.updateBlock(block, { props: { textAlignment: "right" } });
+    });
+
+    expect(container.querySelector("button")?.textContent).toContain("Right");
+
+    root.unmount();
+    editor._tiptapEditor.destroy();
+  });
+});


### PR DESCRIPTION
# Summary

Added a selector component (Just like we have for the block-type selector) for the text align feature. 

## Rationale

I am thinking of 2 good reasons for this addition:
- With this component, hopefully, customized toolbars can use it in order to fit in less space than with the 3 buttons (besides also adding the justify, so, a bit of improvement there as well).
- Outside of that, we can take advantage of the user-experience with other major text editor softwares that already use this approach.

Besides those, there is one other reason.
- Currently in [BigBlueButton](https://github.com/bigbluebutton/bigbluebutton), we are integrating BlockNote as our new shared-notes, and we are currently making some changes to smooth the transition between Etherpad to BlockNote, one of those changes includes fix the toolbar on the top of the document, instead of appearing only when selecting the text. This ends up taking a lot of space so what we did was exactly this - compile these 3 alignment buttons into 1 selector (and we also removed the text of it just to save some space, but that's a minor detail of ours). See screenshot ahead 

<img width="1573" height="342" alt="image" src="https://github.com/user-attachments/assets/6ee964c2-9872-47c6-9e5d-7cc138bc275e" />

With that in mind, it would be much simpler if we had this component for us to use it out-of-the-box.

## Changes

- Added the `TextAlignSelect.tsx` component;
- Added 1 new i18n key to be the label of the new selection tool.  

## Impact

As this will not be part of the default toolbar, I'd say no impact on the other components (it will just be used by developers to create their own customized toolbar).

## Testing

I didn't create any automated tests, but if you guys wanted to have something like that, I can dig further.

As for manual testing, I just changed one of the playground examples and tried to break it some how.

In my case, I used `examples/03-ui-components/02-formatting-toolbar-buttons/src/App.tsx` I added it in place of the three align buttons:

```diff
-- a/examples/03-ui-components/02-formatting-toolbar-buttons/src/App.tsx
+++ b/examples/03-ui-components/02-formatting-toolbar-buttons/src/App.tsx
@@ -11,7 +11,7 @@ import {
   FormattingToolbar,
   FormattingToolbarController,
   NestBlockButton,
-  TextAlignButton,
+  TextAlignSelect,
   UnnestBlockButton,
   useCreateBlockNote,
 } from "@blocknote/react";
@@ -38,9 +38,7 @@ const CustomFormattingToolbar = () => (
     {/* Extra button to toggle code styles */}
     <BasicTextStyleButton key={"codeStyleButton"} basicTextStyle={"code"} />
 
-    <TextAlignButton textAlignment={"left"} key={"textAlignLeftButton"} />
-    <TextAlignButton textAlignment={"center"} key={"textAlignCenterButton"} />
-    <TextAlignButton textAlignment={"right"} key={"textAlignRightButton"} />
+    <TextAlignSelect key={"textAlignSelect"} />

```

After that I just had to build the lib and test it locally.

## Screenshots/Video

<img width="700"  alt="image" src="https://github.com/user-attachments/assets/a48f5aab-2877-4087-ae84-aeb9e5dfb5be" />


## Checklist

- [X] Code follows the project's coding standards.
- [x] Unit tests covering the new feature have been added.
- [x] All existing tests pass.
- [x] The documentation has been updated to reflect the new feature

~~I'll definitely dig into all that for the following commits.~~ All of the above is covered now.

## Additional Notes

I'd just like to mention that the Logic I use for the align text in the selector is exactly the same as for the button. So that's why I say it follows the project coding standards. 

PR I did the same thing for BBB is [here](https://github.com/bigbluebutton/bigbluebutton/pull/25023)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a text alignment dropdown to the formatting toolbar (Left, Center, Right, Justify) and exported it for use.

* **Localization**
  * Added human-readable labels for alignment options across many locales.

* **Documentation**
  * Added docs demonstrating how to add and use the text alignment dropdown.

* **Tests**
  * Added unit tests verifying rendering and reactive behavior of the alignment control.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TypeCellOS/BlockNote/pull/2728)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->