### PR TITLE
fix: keep suggestion menus open during IME composition

### DIFF
--- a/packages/core/src/extensions/SuggestionMenu/SuggestionMenu.test.ts
+++ b/packages/core/src/extensions/SuggestionMenu/SuggestionMenu.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { TextSelection } from "prosemirror-state";
 
 import { BlockNoteEditor } from "../../editor/BlockNoteEditor.js";
 import { SuggestionMenu } from "./SuggestionMenu.js";
@@ -46,8 +47,27 @@ function simulateTextInput(editor: BlockNoteEditor, char: string): boolean {
 }
 
 function createEditor() {
+  Object.defineProperty(Element.prototype, "getBoundingClientRect", {
+    configurable: true,
+    value: () => ({
+      x: 0,
+      y: 0,
+      width: 0,
+      height: 0,
+      top: 0,
+      right: 0,
+      bottom: 0,
+      left: 0,
+      toJSON() {
+        return this;
+      },
+    }),
+  });
+
   const editor = BlockNoteEditor.create();
   const div = document.createElement("div");
+  document.body.replaceChildren();
+  document.body.appendChild(div);
   editor.mount(div);
   return editor;
 }
@@ -186,6 +206,78 @@ describe("SuggestionMenu", () => {
     expect(pluginState).toBeDefined();
     expect(pluginState.triggerCharacter).toBe("@");
 
+    editor._tiptapEditor.destroy();
+  });
+
+  it("should keep suggestion menu open during IME composition selection updates", () => {
+    const editor = createEditor();
+    const sm = editor.getExtension(SuggestionMenu)!;
+
+    sm.addSuggestionMenu({ triggerCharacter: "@" });
+
+    editor.replaceBlocks(editor.document, [
+      {
+        id: "paragraph-0",
+        type: "paragraph",
+        content: "Hello world",
+      },
+    ]);
+
+    editor.setTextCursorPosition("paragraph-0", "end");
+
+    expect(simulateTextInput(editor, "@")).toBe(true);
+
+    const view = editor._tiptapEditor.view;
+    view.dispatch(view.state.tr.insertText("shi"));
+
+    expect(getSuggestionPluginState(editor)?.query).toBe("shi");
+
+    const cursor = view.state.selection.from;
+    Object.defineProperty(view, "composing", {
+      configurable: true,
+      get: () => true,
+    });
+    view.dispatch(
+      view.state.tr.setSelection(
+        TextSelection.create(view.state.doc, cursor - 1, cursor),
+      ),
+    );
+
+    expect(getSuggestionPluginState(editor)).toBeDefined();
+    expect(getSuggestionPluginState(editor)?.composing).toBe(true);
+
+    delete (view as any).composing;
+    editor._tiptapEditor.destroy();
+  });
+
+  it("should still close suggestion menu explicitly during IME composition", () => {
+    const editor = createEditor();
+    const sm = editor.getExtension(SuggestionMenu)!;
+
+    sm.addSuggestionMenu({ triggerCharacter: "@" });
+
+    editor.replaceBlocks(editor.document, [
+      {
+        id: "paragraph-0",
+        type: "paragraph",
+        content: "Hello world",
+      },
+    ]);
+
+    editor.setTextCursorPosition("paragraph-0", "end");
+    expect(simulateTextInput(editor, "@")).toBe(true);
+
+    const view = editor._tiptapEditor.view;
+    Object.defineProperty(view, "composing", {
+      configurable: true,
+      get: () => true,
+    });
+
+    sm.closeMenu();
+
+    expect(getSuggestionPluginState(editor)).toBeUndefined();
+
+    delete (view as any).composing;
     editor._tiptapEditor.destroy();
   });
 });

--- a/packages/core/src/extensions/SuggestionMenu/SuggestionMenu.ts
+++ b/packages/core/src/extensions/SuggestionMenu/SuggestionMenu.ts
@@ -15,6 +15,7 @@ const findBlock = findParentNode((node) => node.type.name === "blockContainer");
 export type SuggestionMenuState = UiElementPosition & {
   query: string;
   ignoreQueryLength?: boolean;
+  composing?: boolean;
 };
 
 class SuggestionMenuView {
@@ -38,6 +39,7 @@ class SuggestionMenuView {
       emitUpdate(menuName, {
         ...this.state,
         ignoreQueryLength: this.pluginState?.ignoreQueryLength,
+        composing: this.pluginState?.composing,
       });
     };
 
@@ -146,6 +148,7 @@ type SuggestionPluginState =
       query: string;
       decorationId: string;
       ignoreQueryLength?: boolean;
+      composing?: boolean;
     }
   | undefined;
 
@@ -260,6 +263,7 @@ export const SuggestionMenu = createExtension(({ editor }) => {
               deleteTriggerCharacter?: boolean;
               ignoreQueryLength?: boolean;
             } | null = transaction.getMeta(suggestionMenuPluginKey);
+            const composing = editor._tiptapEditor.view.composing;
 
             if (
               typeof suggestionPluginTransactionMeta === "object" &&
@@ -289,6 +293,7 @@ export const SuggestionMenu = createExtension(({ editor }) => {
                 decorationId: `id_${Math.floor(Math.random() * 0xffffffff)}`,
                 ignoreQueryLength:
                   suggestionPluginTransactionMeta?.ignoreQueryLength,
+                composing,
               };
             }
 
@@ -300,7 +305,9 @@ export const SuggestionMenu = createExtension(({ editor }) => {
             // Checks if the menu should be hidden.
             if (
               // Highlighting text should hide the menu.
-              newState.selection.from !== newState.selection.to ||
+              (!composing &&
+                !prev.composing &&
+                newState.selection.from !== newState.selection.to) ||
               // Transactions with plugin metadata should hide the menu.
               suggestionPluginTransactionMeta === null ||
               // Certain mouse events should hide the menu.
@@ -319,7 +326,15 @@ export const SuggestionMenu = createExtension(({ editor }) => {
               return undefined;
             }
 
+            if (composing) {
+              return {
+                ...prev,
+                composing,
+              };
+            }
+
             const next = { ...prev };
+            next.composing = composing;
 
             // Updates the current query.
             next.query = newState.doc.textBetween(

--- a/packages/core/src/extensions/SuggestionMenu/SuggestionMenu.ts
+++ b/packages/core/src/extensions/SuggestionMenu/SuggestionMenu.ts
@@ -263,7 +263,7 @@ export const SuggestionMenu = createExtension(({ editor }) => {
               deleteTriggerCharacter?: boolean;
               ignoreQueryLength?: boolean;
             } | null = transaction.getMeta(suggestionMenuPluginKey);
-            const composing = editor._tiptapEditor.view.composing;
+            const composing = editor.prosemirrorView.composing;
 
             if (
               typeof suggestionPluginTransactionMeta === "object" &&

--- a/packages/react/src/components/SuggestionMenu/GridSuggestionMenu/GridSuggestionMenuController.tsx
+++ b/packages/react/src/components/SuggestionMenu/GridSuggestionMenu/GridSuggestionMenuController.tsx
@@ -184,6 +184,7 @@ export function GridSuggestionMenuController<
           query={state.query}
           closeMenu={suggestionMenu.closeMenu}
           clearQuery={suggestionMenu.clearQuery}
+          composing={state.composing}
           getItems={getItemsOrDefault}
           columns={columns}
           gridSuggestionMenuComponent={

--- a/packages/react/src/components/SuggestionMenu/GridSuggestionMenu/GridSuggestionMenuWrapper.tsx
+++ b/packages/react/src/components/SuggestionMenu/GridSuggestionMenu/GridSuggestionMenuWrapper.tsx
@@ -12,6 +12,7 @@ export function GridSuggestionMenuWrapper<Item>(props: {
   query: string;
   closeMenu: () => void;
   clearQuery: () => void;
+  composing?: boolean;
   getItems: (query: string) => Promise<Item[]>;
   columns: number;
   onItemClick?: (item: Item) => void;
@@ -31,6 +32,7 @@ export function GridSuggestionMenuWrapper<Item>(props: {
     query,
     clearQuery,
     closeMenu,
+    composing,
     onItemClick,
     columns,
   } = props;
@@ -49,7 +51,7 @@ export function GridSuggestionMenuWrapper<Item>(props: {
     getItems,
   );
 
-  useCloseSuggestionMenuNoItems(items, usedQuery, closeMenu);
+  useCloseSuggestionMenuNoItems(items, usedQuery, closeMenu, 3, composing);
 
   const { selectedIndex } = useGridSuggestionMenuKeyboardNavigation(
     editor,

--- a/packages/react/src/components/SuggestionMenu/SuggestionMenuController.tsx
+++ b/packages/react/src/components/SuggestionMenu/SuggestionMenuController.tsx
@@ -177,6 +177,7 @@ export function SuggestionMenuController<
           query={state.query}
           closeMenu={suggestionMenu.closeMenu}
           clearQuery={suggestionMenu.clearQuery}
+          composing={state.composing}
           getItems={getItemsOrDefault}
           suggestionMenuComponent={
             suggestionMenuComponent || SuggestionMenu<ItemType<GetItemsType>>

--- a/packages/react/src/components/SuggestionMenu/SuggestionMenuWrapper.tsx
+++ b/packages/react/src/components/SuggestionMenu/SuggestionMenuWrapper.tsx
@@ -12,6 +12,7 @@ export function SuggestionMenuWrapper<Item>(props: {
   query: string;
   closeMenu: () => void;
   clearQuery: () => void;
+  composing?: boolean;
   getItems: (query: string) => Promise<Item[]>;
   onItemClick?: (item: Item) => void;
   suggestionMenuComponent: FC<SuggestionMenuProps<Item>>;
@@ -30,6 +31,7 @@ export function SuggestionMenuWrapper<Item>(props: {
     query,
     clearQuery,
     closeMenu,
+    composing,
     onItemClick,
   } = props;
 
@@ -47,7 +49,7 @@ export function SuggestionMenuWrapper<Item>(props: {
     getItems,
   );
 
-  useCloseSuggestionMenuNoItems(items, usedQuery, closeMenu);
+  useCloseSuggestionMenuNoItems(items, usedQuery, closeMenu, 3, composing);
 
   const { selectedIndex } = useSuggestionMenuKeyboardNavigation(
     editor,

--- a/packages/react/src/components/SuggestionMenu/hooks/useCloseSuggestionMenuNoItems.ts
+++ b/packages/react/src/components/SuggestionMenu/hooks/useCloseSuggestionMenuNoItems.ts
@@ -8,11 +8,17 @@ export function useCloseSuggestionMenuNoItems<Item>(
   usedQuery: string | undefined,
   closeMenu: () => void,
   invalidQueries = 3,
+  disabled = false,
 ) {
   const lastUsefulQueryLength = useRef(0);
 
   useEffect(() => {
     if (usedQuery === undefined) {
+      return;
+    }
+
+    if (disabled) {
+      lastUsefulQueryLength.current = usedQuery.length;
       return;
     }
 
@@ -24,5 +30,5 @@ export function useCloseSuggestionMenuNoItems<Item>(
     ) {
       closeMenu();
     }
-  }, [closeMenu, invalidQueries, items.length, usedQuery]);
+  }, [closeMenu, disabled, invalidQueries, items.length, usedQuery]);
 }


### PR DESCRIPTION
/claim #1283

## What

Fixes #1283 by keeping suggestion menus open while IME composition is active, so Chinese/Japanese/etc. input can finish composing before the menu decides whether to close or whether the current query has no matching items.

## Why

The menu could close during IME composition because ProseMirror can temporarily expose a non-empty selection while composition is active. The earlier discussion on #1295 pointed at `EditorView.composing`, so this PR uses ProseMirror's own composition state instead of manual DOM composition event flags.

## Changes

- Track `editor._tiptapEditor.view.composing` in the core suggestion menu plugin state.
- Keep the active suggestion menu state during composition transactions instead of closing on temporary selection updates.
- Expose the core composition state to React suggestion wrappers.
- Pause the React no-items auto-close behavior while composition is active.
- Add a focused unit test for the IME composition selection-update path.

## Verification

- `pnpm --filter @blocknote/core test -- SuggestionMenu.test.ts`
- `pnpm --filter @blocknote/core build`
- `pnpm exec tsc --noEmit -p packages/react/tsconfig.json`
- `pnpm --filter @blocknote/react lint`
- `pnpm --filter @blocknote/core lint`
- `pnpm --filter @blocknote/react build`

## Demo

Local demo verified with the official mentions example at `examples/06-custom-schema/02-suggestion-menus-mentions`: typing `@st` keeps the menu open and filters to `Steve`. The hosted Vercel preview is currently blocked by the maintainer-team fork authorization gate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Suggestion menu no longer closes unexpectedly during IME/text composition; composing input preserves the menu and selection behavior.
  * Menu update/hide logic now respects composition state so composition does not disrupt suggestions.
  * Explicit close still works while composing.

* **Tests**
  * Added IME-focused tests to ensure the suggestion menu remains active during composition and closes when explicitly requested.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TypeCellOS/BlockNote/pull/2731)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->