### PR TITLE
fix: add `bn-thread-orphaned` CSS class to distinguish orphaned threads

### DIFF
--- a/packages/react/src/components/Comments/Thread.tsx
+++ b/packages/react/src/components/Comments/Thread.tsx
@@ -23,6 +23,12 @@ export type ThreadProps = {
    */
   selected?: boolean;
   /**
+   * A boolean flag for whether the thread is orphaned (i.e. the referenced text
+   * has been deleted from the document). Adds a `bn-thread-orphaned` CSS class
+   * to the thread.
+   */
+  orphaned?: boolean;
+  /**
    * The text in the editor that the thread refers to. See the
    * [`ThreadsSidebar`](https://github.com/TypeCellOS/BlockNote/tree/main/packages/react/src/components/Comments/ThreadsSidebar.tsx#L137)
    * component to find out how to get this.
@@ -55,6 +61,7 @@ export type ThreadProps = {
 export const Thread = ({
   thread,
   selected,
+  orphaned,
   referenceText,
   maxCommentsBeforeCollapse,
   onFocus,
@@ -94,7 +101,7 @@ export const Thread = ({
 
   return (
     <Components.Comments.Card
-      className={"bn-thread"}
+      className={mergeCSSClasses("bn-thread", orphaned && "bn-thread-orphaned")}
       headerText={referenceText}
       onFocus={onFocus}
       onBlur={onBlur}

--- a/packages/react/src/components/Comments/ThreadsSidebar.tsx
+++ b/packages/react/src/components/Comments/ThreadsSidebar.tsx
@@ -13,6 +13,7 @@ type ThreadItemProps = {
   editor: BlockNoteEditor<any, any, any>;
   maxCommentsBeforeCollapse?: number;
   referenceText: string;
+  orphaned?: boolean;
 };
 
 /**
@@ -25,6 +26,7 @@ const ThreadItem = React.memo(
     selectedThreadId,
     maxCommentsBeforeCollapse,
     referenceText,
+    orphaned,
   }: ThreadItemProps) => {
     const comments = useExtension(CommentsExtension);
 
@@ -76,6 +78,7 @@ const ThreadItem = React.memo(
       <Thread
         thread={thread}
         selected={thread.id === selectedThreadId}
+        orphaned={orphaned}
         referenceText={referenceText}
         maxCommentsBeforeCollapse={maxCommentsBeforeCollapse}
         onFocus={onFocus}
@@ -206,27 +209,30 @@ export function ThreadsSidebar(props: {
       threadPositions,
     );
 
-    const ret: Array<{ thread: ThreadData; referenceText: string }> = [];
+    const ret: Array<{
+      thread: ThreadData;
+      referenceText: string;
+      orphaned: boolean;
+    }> = [];
 
     for (const thread of sortedThreads) {
+      const threadPosition = threadPositions.get(thread.id);
+      const orphaned = threadPosition === undefined;
+
       if (!thread.resolved) {
         if (props.filter === "open" || props.filter === "all") {
           ret.push({
             thread,
-            referenceText: getReferenceText(
-              editor,
-              threadPositions.get(thread.id),
-            ),
+            referenceText: getReferenceText(editor, threadPosition),
+            orphaned,
           });
         }
       } else {
         if (props.filter === "resolved" || props.filter === "all") {
           ret.push({
             thread,
-            referenceText: getReferenceText(
-              editor,
-              threadPositions.get(thread.id),
-            ),
+            referenceText: getReferenceText(editor, threadPosition),
+            orphaned,
           });
         }
       }
@@ -244,6 +250,7 @@ export function ThreadsSidebar(props: {
           selectedThreadId={selectedThreadId}
           editor={editor}
           referenceText={thread.referenceText}
+          orphaned={thread.orphaned}
           maxCommentsBeforeCollapse={props.maxCommentsBeforeCollapse}
         />
       ))}


### PR DESCRIPTION
## Summary

- Adds a `bn-thread-orphaned` CSS class to the `Thread` component's card element when the thread's referenced text has been deleted from the document
- Introduces an `orphaned` prop on `ThreadProps` so consumers using `<Thread>` directly can also leverage this
- The `ThreadsSidebar` component automatically computes orphaned state by checking whether the thread has a position in `threadPositions`

## Details

When a comment mark is removed from the document (e.g. the annotated text is deleted), the thread still exists in the data layer but has no corresponding position. These "orphaned" threads were previously indistinguishable from normal threads in the DOM.

This change adds a `bn-thread-orphaned` class alongside the existing `bn-thread` class, enabling consumers to style or add specific behavior for orphaned threads via CSS (e.g. `.bn-thread-orphaned { opacity: 0.6; }`).

### Files changed

- `packages/react/src/components/Comments/Thread.tsx` — new `orphaned?: boolean` prop, conditionally applies `bn-thread-orphaned` class
- `packages/react/src/components/Comments/ThreadsSidebar.tsx` — computes and passes `orphaned` state through to `Thread`

Closes #2735

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for orphaned threads—threads without position data now automatically display with distinct styling to improve visibility and user experience.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TypeCellOS/BlockNote/pull/2737)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->