### PR TITLE
Fix suggestion menu handling during IME composition

### DIFF
--- a/packages/core/src/extensions/SuggestionMenu/SuggestionMenu.test.ts
+++ b/packages/core/src/extensions/SuggestionMenu/SuggestionMenu.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { TextSelection } from "prosemirror-state";
 
 import { BlockNoteEditor } from "../../editor/BlockNoteEditor.js";
 import { SuggestionMenu } from "./SuggestionMenu.js";
@@ -186,6 +187,62 @@ describe("SuggestionMenu", () => {
     expect(pluginState).toBeDefined();
     expect(pluginState.triggerCharacter).toBe("@");
 
+    editor._tiptapEditor.destroy();
+  });
+
+  it("should keep suggestion menu open during IME composition", () => {
+    const editor = createEditor();
+    const sm = editor.getExtension(SuggestionMenu)!;
+
+    sm.addSuggestionMenu({ triggerCharacter: "@" });
+
+    editor.replaceBlocks(editor.document, [
+      {
+        id: "paragraph-0",
+        type: "paragraph",
+        content: "Hello world",
+      },
+    ]);
+
+    editor.setTextCursorPosition("paragraph-0", "end");
+    expect(simulateTextInput(editor, "@")).toBe(true);
+
+    const view = editor.prosemirrorView;
+    let composing = true;
+    Object.defineProperty(view, "composing", {
+      configurable: true,
+      get: () => composing,
+    });
+
+    view.dispatch(view.state.tr.insertText("shi"));
+
+    let pluginState = getSuggestionPluginState(editor);
+    expect(pluginState).toBeDefined();
+    expect(pluginState.query).toBe("shi");
+    expect(pluginState.composing).toBe(true);
+
+    const cursor = view.state.selection.from;
+    view.dispatch(
+      view.state.tr.setSelection(
+        TextSelection.create(view.state.doc, cursor - 1, cursor),
+      ),
+    );
+
+    pluginState = getSuggestionPluginState(editor);
+    expect(pluginState).toBeDefined();
+    expect(pluginState.query).toBe("shi");
+
+    composing = false;
+    view.dispatch(
+      view.state.tr.setSelection(TextSelection.create(view.state.doc, cursor)),
+    );
+
+    pluginState = getSuggestionPluginState(editor);
+    expect(pluginState).toBeDefined();
+    expect(pluginState.query).toBe("shi");
+    expect(pluginState.composing).toBe(false);
+
+    delete (view as any).composing;
     editor._tiptapEditor.destroy();
   });
 });

--- a/packages/core/src/extensions/SuggestionMenu/SuggestionMenu.ts
+++ b/packages/core/src/extensions/SuggestionMenu/SuggestionMenu.ts
@@ -15,6 +15,7 @@ const findBlock = findParentNode((node) => node.type.name === "blockContainer");
 export type SuggestionMenuState = UiElementPosition & {
   query: string;
   ignoreQueryLength?: boolean;
+  composing?: boolean;
 };
 
 class SuggestionMenuView {
@@ -38,6 +39,7 @@ class SuggestionMenuView {
       emitUpdate(menuName, {
         ...this.state,
         ignoreQueryLength: this.pluginState?.ignoreQueryLength,
+        composing: this.pluginState?.composing,
       });
     };
 
@@ -146,6 +148,7 @@ type SuggestionPluginState =
       query: string;
       decorationId: string;
       ignoreQueryLength?: boolean;
+      composing?: boolean;
     }
   | undefined;
 
@@ -260,6 +263,7 @@ export const SuggestionMenu = createExtension(({ editor }) => {
               deleteTriggerCharacter?: boolean;
               ignoreQueryLength?: boolean;
             } | null = transaction.getMeta(suggestionMenuPluginKey);
+            const composing = editor.prosemirrorView.composing;
 
             if (
               typeof suggestionPluginTransactionMeta === "object" &&
@@ -289,6 +293,7 @@ export const SuggestionMenu = createExtension(({ editor }) => {
                 decorationId: `id_${Math.floor(Math.random() * 0xffffffff)}`,
                 ignoreQueryLength:
                   suggestionPluginTransactionMeta?.ignoreQueryLength,
+                composing,
               };
             }
 
@@ -300,7 +305,8 @@ export const SuggestionMenu = createExtension(({ editor }) => {
             // Checks if the menu should be hidden.
             if (
               // Highlighting text should hide the menu.
-              newState.selection.from !== newState.selection.to ||
+              (!composing &&
+                newState.selection.from !== newState.selection.to) ||
               // Transactions with plugin metadata should hide the menu.
               suggestionPluginTransactionMeta === null ||
               // Certain mouse events should hide the menu.
@@ -319,7 +325,15 @@ export const SuggestionMenu = createExtension(({ editor }) => {
               return undefined;
             }
 
+            if (composing) {
+              return {
+                ...prev,
+                composing,
+              };
+            }
+
             const next = { ...prev };
+            next.composing = composing;
 
             // Updates the current query.
             next.query = newState.doc.textBetween(

--- a/packages/react/src/components/SuggestionMenu/GridSuggestionMenu/GridSuggestionMenuController.tsx
+++ b/packages/react/src/components/SuggestionMenu/GridSuggestionMenu/GridSuggestionMenuController.tsx
@@ -184,6 +184,7 @@ export function GridSuggestionMenuController<
           query={state.query}
           closeMenu={suggestionMenu.closeMenu}
           clearQuery={suggestionMenu.clearQuery}
+          composing={state.composing}
           getItems={getItemsOrDefault}
           columns={columns}
           gridSuggestionMenuComponent={

--- a/packages/react/src/components/SuggestionMenu/GridSuggestionMenu/GridSuggestionMenuWrapper.tsx
+++ b/packages/react/src/components/SuggestionMenu/GridSuggestionMenu/GridSuggestionMenuWrapper.tsx
@@ -12,6 +12,7 @@ export function GridSuggestionMenuWrapper<Item>(props: {
   query: string;
   closeMenu: () => void;
   clearQuery: () => void;
+  composing?: boolean;
   getItems: (query: string) => Promise<Item[]>;
   columns: number;
   onItemClick?: (item: Item) => void;
@@ -31,6 +32,7 @@ export function GridSuggestionMenuWrapper<Item>(props: {
     query,
     clearQuery,
     closeMenu,
+    composing,
     onItemClick,
     columns,
   } = props;
@@ -49,7 +51,7 @@ export function GridSuggestionMenuWrapper<Item>(props: {
     getItems,
   );
 
-  useCloseSuggestionMenuNoItems(items, usedQuery, closeMenu);
+  useCloseSuggestionMenuNoItems(items, usedQuery, closeMenu, 3, composing);
 
   const { selectedIndex } = useGridSuggestionMenuKeyboardNavigation(
     editor,

--- a/packages/react/src/components/SuggestionMenu/SuggestionMenuController.tsx
+++ b/packages/react/src/components/SuggestionMenu/SuggestionMenuController.tsx
@@ -177,6 +177,7 @@ export function SuggestionMenuController<
           query={state.query}
           closeMenu={suggestionMenu.closeMenu}
           clearQuery={suggestionMenu.clearQuery}
+          composing={state.composing}
           getItems={getItemsOrDefault}
           suggestionMenuComponent={
             suggestionMenuComponent || SuggestionMenu<ItemType<GetItemsType>>

--- a/packages/react/src/components/SuggestionMenu/SuggestionMenuWrapper.tsx
+++ b/packages/react/src/components/SuggestionMenu/SuggestionMenuWrapper.tsx
@@ -12,6 +12,7 @@ export function SuggestionMenuWrapper<Item>(props: {
   query: string;
   closeMenu: () => void;
   clearQuery: () => void;
+  composing?: boolean;
   getItems: (query: string) => Promise<Item[]>;
   onItemClick?: (item: Item) => void;
   suggestionMenuComponent: FC<SuggestionMenuProps<Item>>;
@@ -30,6 +31,7 @@ export function SuggestionMenuWrapper<Item>(props: {
     query,
     clearQuery,
     closeMenu,
+    composing,
     onItemClick,
   } = props;
 
@@ -47,7 +49,7 @@ export function SuggestionMenuWrapper<Item>(props: {
     getItems,
   );
 
-  useCloseSuggestionMenuNoItems(items, usedQuery, closeMenu);
+  useCloseSuggestionMenuNoItems(items, usedQuery, closeMenu, 3, composing);
 
   const { selectedIndex } = useSuggestionMenuKeyboardNavigation(
     editor,

--- a/packages/react/src/components/SuggestionMenu/hooks/useCloseSuggestionMenuNoItems.ts
+++ b/packages/react/src/components/SuggestionMenu/hooks/useCloseSuggestionMenuNoItems.ts
@@ -8,11 +8,17 @@ export function useCloseSuggestionMenuNoItems<Item>(
   usedQuery: string | undefined,
   closeMenu: () => void,
   invalidQueries = 3,
+  disabled = false,
 ) {
   const lastUsefulQueryLength = useRef(0);
 
   useEffect(() => {
     if (usedQuery === undefined) {
+      return;
+    }
+
+    if (disabled) {
+      lastUsefulQueryLength.current = usedQuery.length;
       return;
     }
 
@@ -24,5 +30,5 @@ export function useCloseSuggestionMenuNoItems<Item>(
     ) {
       closeMenu();
     }
-  }, [closeMenu, invalidQueries, items.length, usedQuery]);
+  }, [closeMenu, disabled, invalidQueries, items.length, usedQuery]);
 }


### PR DESCRIPTION
Fixes #1283

## Summary
- keep suggestion menus open while IME composition is active
- continue updating the query during composition, including non-collapsed composition ranges
- prevent empty-result auto-close from firing until composition finishes
- apply the behavior to both list and grid suggestion menus

## Verification
- pnpm --filter @blocknote/core lint
- pnpm --filter @blocknote/core build
- pnpm --filter @blocknote/react lint
- pnpm --filter @blocknote/react build
- git diff --check

## Note
I could not run the Vitest path reliably in this local shell because the repository expects Node 22.14.0 while this shell has Node 20.13.1. The changed core test is included for CI to run under the repo Node version.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced suggestion menu behavior during IME text composition. The menu now maintains its open state and accurately preserves the search query while composing text through input method editors, eliminating the previous behavior where the menu would unexpectedly close or lose its query during character composition sessions.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TypeCellOS/BlockNote/pull/2738)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->