### PR TITLE
fix(tests): stabilize webkit keyboard handler tests with programmatic cursor positioning

### DIFF
--- a/tests/src/end-to-end/keyboardhandlers/keyboardhandlers.test.ts
+++ b/tests/src/end-to-end/keyboardhandlers/keyboardhandlers.test.ts
@@ -5,7 +5,12 @@ import {
   ITALIC_BUTTON_SELECTOR,
 } from "../../utils/const.js";
 import { insertHeading, insertParagraph } from "../../utils/copypaste.js";
-import { compareDocToSnapshot, focusOnEditor } from "../../utils/editor.js";
+import {
+  compareDocToSnapshot,
+  focusOnEditor,
+  moveCursorToBlockEnd,
+  moveCursorToBlockStart,
+} from "../../utils/editor.js";
 import { executeSlashCommand } from "../../utils/slashmenu.js";
 
 test.describe.configure({ mode: "serial" });
@@ -96,7 +101,7 @@ test.describe("Check Keyboard Handlers' Behaviour", () => {
     await focusOnEditor(page);
     await insertHeading(page, 1);
 
-    await page.keyboard.press("Control+ArrowLeft");
+    await moveCursorToBlockStart(page);
     await page.keyboard.press("Backspace");
 
     await compareDocToSnapshot(page, "backspaceStartOfBlock.json");
@@ -143,7 +148,7 @@ test.describe("Check Keyboard Handlers' Behaviour", () => {
       await page.keyboard.press("ArrowUp");
     }
 
-    await page.keyboard.press("Control+ArrowLeft");
+    await moveCursorToBlockStart(page);
     await page.keyboard.press("Backspace");
 
     await compareDocToSnapshot(page, "backspacePreservesNestedBlocks.json");
@@ -283,6 +288,7 @@ test.describe("Check Keyboard Handlers' Behaviour", () => {
 
     await page.keyboard.press("ArrowUp");
     await page.keyboard.press("ArrowUp");
+    await moveCursorToBlockEnd(page);
     await page.keyboard.press("Delete");
 
     await compareDocToSnapshot(page, "deleteMultipleChildren.json");
@@ -299,6 +305,7 @@ test.describe("Check Keyboard Handlers' Behaviour", () => {
 
     await page.keyboard.press("ArrowUp");
     await page.keyboard.press("ArrowUp");
+    await moveCursorToBlockEnd(page);
     await page.keyboard.press("Delete");
 
     await compareDocToSnapshot(page, "deleteNestedChildren.json");
@@ -314,6 +321,7 @@ test.describe("Check Keyboard Handlers' Behaviour", () => {
     await insertParagraph(page);
 
     await page.keyboard.press("ArrowUp");
+    await moveCursorToBlockEnd(page);
     await page.keyboard.press("Delete");
 
     await compareDocToSnapshot(page, "deleteShallowerBlock.json");
@@ -335,8 +343,7 @@ test.describe("Check Keyboard Handlers' Behaviour", () => {
 
     await page.keyboard.press("ArrowUp");
     await page.keyboard.press("ArrowUp");
-    await page.keyboard.press("ControlOrMeta+ArrowLeft");
-    await page.keyboard.press("ControlOrMeta+ArrowRight");
+    await moveCursorToBlockEnd(page);
     await page.keyboard.press("Delete");
 
     await compareDocToSnapshot(page, "deleteShallowerBlockWithChildren.json");

--- a/tests/src/utils/editor.ts
+++ b/tests/src/utils/editor.ts
@@ -46,3 +46,32 @@ export async function compareDocToSnapshot(page: Page, name: string) {
   const doc = JSON.stringify(await getDoc(page), null, 2);
   expect(doc).toMatchSnapshot(`${name}.json`);
 }
+
+/**
+ * Programmatically move cursor to end of the current block content.
+ * This avoids relying on keyboard navigation (ArrowUp/End) which can
+ * position the cursor incorrectly in WebKit when crossing blocks with
+ * different indentation levels.
+ */
+export async function moveCursorToBlockEnd(page: Page) {
+  await page.evaluate(() => {
+    const tiptap = (window as any).ProseMirror;
+    const bnEditor = tiptap.schema.cached.blockNoteEditor;
+    const block = bnEditor.getTextCursorPosition().block;
+    bnEditor.setTextCursorPosition(block, "end");
+  });
+}
+
+/**
+ * Programmatically move cursor to start of the current block content.
+ * This avoids relying on keyboard navigation which can be unreliable
+ * in WebKit.
+ */
+export async function moveCursorToBlockStart(page: Page) {
+  await page.evaluate(() => {
+    const tiptap = (window as any).ProseMirror;
+    const bnEditor = tiptap.schema.cached.blockNoteEditor;
+    const block = bnEditor.getTextCursorPosition().block;
+    bnEditor.setTextCursorPosition(block, "start");
+  });
+}


### PR DESCRIPTION
## Summary

Fixes flaky WebKit Playwright test failures in keyboard handler tests (`keyboardhandlers.test.ts`). These tests were failing intermittently on Linux WebKit CI but never on Chromium or Firefox.

## Root Cause

When `ArrowUp` navigates the cursor between blocks at **different indentation levels**, the browser maps the visual X coordinate from the source line into the target line. If the target block is more indented (starts further right), the end-of-text X from a shallower block falls **mid-text** in the deeper block, causing the cursor to land before the end of the line.

This is correct browser behavior (ArrowUp preserves visual X position), not a bug. The cursor position is also slightly non-deterministic due to sub-pixel rendering, varying by 1 character position between runs.

### Why only some tests are affected

- **Same indentation**: ArrowUp between blocks at the same indent level works fine -- both blocks start at the same X, so end-of-text maps to end-of-text.
- **Deep → shallow** (more indented → less indented): Also fine -- the higher X from the deeper block maps to at-or-beyond the end of the shallower block's text, so browsers clamp to the end.
- **Shallow → deep** (less indented → more indented): **Broken** -- the shallower block's end-of-text X falls short of the deeper block's end, landing mid-text.

### Why only WebKit on Linux CI

Tested all 3 browsers on macOS -- both Chromium and WebKit land mid-text in the affected cases (Firefox always clamps to line end). Linux Chromium appears to handle this differently (always landing at line end), which is why only Linux WebKit exhibited the flakiness.

### Why not use keyboard shortcuts (End, Meta+Arrow) instead?

Tested across all 3 browsers:
- `End` key: doesn't work in WebKit (cursor stays put)
- `Home` key: doesn't work in Firefox or WebKit
- `Meta+ArrowRight/Left`: works on macOS but maps to `Ctrl+Arrow` on Linux (word jump, not line end)

No single keyboard shortcut reliably moves to line start/end across all browsers and platforms.

## Fix

Added two helper functions in `tests/src/utils/editor.ts`:
- `moveCursorToBlockEnd(page)` -- programmatically sets cursor to end of current block via BlockNote API
- `moveCursorToBlockStart(page)` -- programmatically sets cursor to start of current block via BlockNote API

These use `editor.setTextCursorPosition(block, "end"/"start")` which is deterministic and browser-independent. Applied to the 6 tests that navigate across different indentation levels before pressing Delete/Backspace.

## Tests modified

| Test | Issue | Fix |
|------|-------|-----|
| Backspace at the start of a block | Flaky heading→paragraph conversion | `moveCursorToBlockStart` |
| Backspace preserves nested blocks | ArrowUp x2 across indent levels | `moveCursorToBlockStart` |
| Delete end of block with multiple children | ArrowUp x2 shallow→deep | `moveCursorToBlockEnd` |
| Delete end of block with nested children | ArrowUp x2 shallow→deep | `moveCursorToBlockEnd` |
| Delete before shallower block | ArrowUp shallow→deep | `moveCursorToBlockEnd` |
| Delete before shallower block with children | ArrowUp x2 shallow→deep | `moveCursorToBlockEnd` |