### PR TITLE
Fix IME composition query for suggestion menus

### DIFF
--- a/packages/core/src/extensions/SuggestionMenu/SuggestionMenu.test.ts
+++ b/packages/core/src/extensions/SuggestionMenu/SuggestionMenu.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import { BlockNoteEditor } from "../../editor/BlockNoteEditor.js";
 import { SuggestionMenu } from "./SuggestionMenu.js";
@@ -45,6 +45,32 @@ function simulateTextInput(editor: BlockNoteEditor, char: string): boolean {
   return (handler as any)(view, from, to, char) as boolean;
 }
 
+function simulateCompositionStart(editor: BlockNoteEditor): boolean {
+  const plugin = findSuggestionPlugin(editor);
+  const handler = plugin.props.handleDOMEvents?.compositionstart;
+  if (!handler) {
+    throw new Error("compositionstart not found on SuggestionMenu plugin");
+  }
+  return (handler as any)(editor._tiptapEditor.view, {
+    type: "compositionstart",
+  }) as boolean;
+}
+
+function simulateCompositionEnd(
+  editor: BlockNoteEditor,
+  data: string,
+): boolean {
+  const plugin = findSuggestionPlugin(editor);
+  const handler = plugin.props.handleDOMEvents?.compositionend;
+  if (!handler) {
+    throw new Error("compositionend not found on SuggestionMenu plugin");
+  }
+  return (handler as any)(editor._tiptapEditor.view, {
+    data,
+    type: "compositionend",
+  }) as boolean;
+}
+
 function createEditor() {
   const editor = BlockNoteEditor.create();
   const div = document.createElement("div");
@@ -85,6 +111,44 @@ describe("SuggestionMenu", () => {
     expect(pluginState.triggerCharacter).toBe("/");
 
     editor._tiptapEditor.destroy();
+  });
+
+  it("should use the final composition text for the active query", () => {
+    vi.useFakeTimers();
+
+    const editor = createEditor();
+    try {
+      const sm = editor.getExtension(SuggestionMenu)!;
+
+      sm.addSuggestionMenu({ triggerCharacter: "@" });
+
+      editor.replaceBlocks(editor.document, [
+        {
+          id: "paragraph-0",
+          type: "paragraph",
+          content: "Hello world",
+        },
+      ]);
+
+      editor.setTextCursorPosition("paragraph-0", "end");
+
+      expect(simulateTextInput(editor, "@")).toBe(true);
+      expect(getSuggestionPluginState(editor).query).toBe("");
+
+      expect(simulateCompositionStart(editor)).toBe(false);
+
+      editor._tiptapEditor.view.dispatch(
+        editor._tiptapEditor.state.tr.insertText("zhang"),
+      );
+      expect(getSuggestionPluginState(editor).query).toBe("zhang");
+
+      expect(simulateCompositionEnd(editor, "张")).toBe(false);
+      expect(getSuggestionPluginState(editor).query).toBe("张");
+    } finally {
+      vi.clearAllTimers();
+      vi.useRealTimers();
+      editor._tiptapEditor.destroy();
+    }
   });
 
   it("should not open suggestion menu in table content when shouldTrigger returns false", () => {

--- a/packages/core/src/extensions/SuggestionMenu/SuggestionMenu.ts
+++ b/packages/core/src/extensions/SuggestionMenu/SuggestionMenu.ts
@@ -149,6 +149,17 @@ type SuggestionPluginState =
     }
   | undefined;
 
+type SuggestionPluginTransactionMeta =
+  | {
+      triggerCharacter: string;
+      deleteTriggerCharacter?: boolean;
+      ignoreQueryLength?: boolean;
+    }
+  | {
+      compositionQuery: string;
+    }
+  | null;
+
 export type SuggestionMenuOptions = {
   triggerCharacter: string;
   /**
@@ -174,6 +185,7 @@ const suggestionMenuPluginKey = new PluginKey("SuggestionMenuPlugin");
 export const SuggestionMenu = createExtension(({ editor }) => {
   const suggestionMenus = new Map<string, SuggestionMenuOptions>();
   let view: SuggestionMenuView | undefined = undefined;
+  let queryBeforeComposition: string | undefined = undefined;
   const store = createStore<
     (SuggestionMenuState & { triggerCharacter: string }) | undefined
   >(undefined);
@@ -255,15 +267,29 @@ export const SuggestionMenu = createExtension(({ editor }) => {
 
             // Either contains the trigger character if the menu should be shown,
             // or null if it should be hidden.
-            const suggestionPluginTransactionMeta: {
-              triggerCharacter: string;
-              deleteTriggerCharacter?: boolean;
-              ignoreQueryLength?: boolean;
-            } | null = transaction.getMeta(suggestionMenuPluginKey);
+            const suggestionPluginTransactionMeta:
+              | SuggestionPluginTransactionMeta
+              | undefined = transaction.getMeta(suggestionMenuPluginKey);
 
             if (
               typeof suggestionPluginTransactionMeta === "object" &&
-              suggestionPluginTransactionMeta !== null
+              suggestionPluginTransactionMeta !== null &&
+              "compositionQuery" in suggestionPluginTransactionMeta
+            ) {
+              if (prev === undefined) {
+                return prev;
+              }
+
+              return {
+                ...prev,
+                query: suggestionPluginTransactionMeta.compositionQuery,
+              };
+            }
+
+            if (
+              typeof suggestionPluginTransactionMeta === "object" &&
+              suggestionPluginTransactionMeta !== null &&
+              "triggerCharacter" in suggestionPluginTransactionMeta
             ) {
               if (prev) {
                 // Close the previous menu if it exists
@@ -332,6 +358,71 @@ export const SuggestionMenu = createExtension(({ editor }) => {
         },
 
         props: {
+          handleDOMEvents: {
+            compositionstart(view) {
+              const suggestionPluginState: SuggestionPluginState =
+                suggestionMenuPluginKey.getState(view.state);
+
+              if (suggestionPluginState === undefined) {
+                queryBeforeComposition = undefined;
+                return false;
+              }
+
+              queryBeforeComposition = view.state.doc.textBetween(
+                suggestionPluginState.queryStartPos(),
+                view.state.selection.from,
+              );
+              return false;
+            },
+
+            compositionend(view, event) {
+              const suggestionPluginState: SuggestionPluginState =
+                suggestionMenuPluginKey.getState(view.state);
+
+              if (
+                suggestionPluginState === undefined ||
+                queryBeforeComposition === undefined
+              ) {
+                queryBeforeComposition = undefined;
+                return false;
+              }
+
+              const compositionText = (event as CompositionEvent).data || "";
+              const compositionQuery =
+                queryBeforeComposition + compositionText;
+
+              view.dispatch(
+                view.state.tr.setMeta(suggestionMenuPluginKey, {
+                  compositionQuery,
+                }),
+              );
+
+              setTimeout(() => {
+                const currentPluginState: SuggestionPluginState =
+                  suggestionMenuPluginKey.getState(view.state);
+
+                if (currentPluginState === undefined) {
+                  return;
+                }
+
+                const docQuery = view.state.doc.textBetween(
+                  currentPluginState.queryStartPos(),
+                  view.state.selection.from,
+                );
+
+                if (
+                  docQuery !== currentPluginState.query &&
+                  (!compositionText || docQuery.includes(compositionText))
+                ) {
+                  view.dispatch(view.state.tr);
+                }
+              }, 0);
+
+              queryBeforeComposition = undefined;
+              return false;
+            },
+          },
+
           handleTextInput(view, from, to, text) {
             // only on insert
             if (from === to) {


### PR DESCRIPTION
## Summary

- track active suggestion query around IME composition events
- update the query with the final composed text on compositionend, so Chinese mention searches use committed characters instead of transient pinyin text
- add coverage for replacing an active query with final composed text

Closes #1283

## Verification

- git diff --check
- Targeted vitest was not run locally because dependency installation did not complete in this environment: pnpm install --filter @blocknote/core --frozen-lockfile stalled on registry downloads after most packages were fetched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved support for IME (Input Method Editor) input when using the suggestion menu. The menu now correctly updates when composing characters with input methods commonly used for Asian languages and other complex writing systems.

* **Tests**
  * Added test coverage for IME composition event handling in the suggestion menu.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TypeCellOS/BlockNote/pull/2747)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->