### PR TITLE
Potential fix for code scanning alert no. 21: Incomplete URL scheme check

### DIFF
--- a/packages/react/src/util/sanitizeUrl.ts
+++ b/packages/react/src/util/sanitizeUrl.ts
@@ -8,8 +8,8 @@ export function sanitizeUrl(inputUrl: string, baseUrl: string): string {
   try {
     const url = new URL(inputUrl, baseUrl);
 
-    // eslint-disable-next-line no-script-url -- false positive, we are explicitly checking if the protocol is safe to prevent XSS
     if (
+      // eslint-disable-next-line no-script-url -- false positive, we are explicitly checking if the protocol is safe to prevent XSS
       url.protocol !== "javascript:" &&
       url.protocol !== "data:" &&
       url.protocol !== "vbscript:"

--- a/packages/react/src/util/sanitizeUrl.ts
+++ b/packages/react/src/util/sanitizeUrl.ts
@@ -9,7 +9,11 @@ export function sanitizeUrl(inputUrl: string, baseUrl: string): string {
     const url = new URL(inputUrl, baseUrl);
 
     // eslint-disable-next-line no-script-url -- false positive, we are explicitly checking if the protocol is safe to prevent XSS
-    if (url.protocol !== "javascript:") {
+    if (
+      url.protocol !== "javascript:" &&
+      url.protocol !== "data:" &&
+      url.protocol !== "vbscript:"
+    ) {
       return url.href;
     }
   } catch (error) {


### PR DESCRIPTION
Potential fix for [https://github.com/TypeCellOS/BlockNote/security/code-scanning/21](https://github.com/TypeCellOS/BlockNote/security/code-scanning/21)

The best fix is to explicitly block all known dangerous executable schemes in this sanitizer, not just `javascript:`.  
Without changing existing behavior otherwise, update the condition in `packages/react/src/util/sanitizeUrl.ts` so the function only returns `url.href` when the protocol is **not** any of: `javascript:`, `data:`, `vbscript:`. For blocked schemes (or parse errors), continue returning `"#"` exactly as now.

Concretely, edit the `if` on line 12 region to include all three checks. No new imports, methods, or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
