### PR TITLE
fix: Comments emoji picker button issues (BLO-1199)

### DIFF
--- a/packages/react/src/components/Comments/Comment.tsx
+++ b/packages/react/src/components/Comments/Comment.tsx
@@ -130,6 +130,88 @@ export const Comment = ({
 
   const user = useUser(comment.userId);
 
+  const CommentEditorActions = useCallback(
+    ({ isEmpty }: { isFocused: boolean; isEmpty: boolean }) => {
+      const canAddReaction = threadStore.auth.canAddReaction(comment);
+
+      return (
+        <>
+          {comment.reactions.length > 0 && !isEditing && (
+            <Components.Generic.Badge.Group
+              className={mergeCSSClasses(
+                "bn-badge-group",
+                "bn-comment-reactions",
+              )}
+            >
+              {comment.reactions.map((reaction) => (
+                <ReactionBadge
+                  key={reaction.emoji}
+                  comment={comment}
+                  emoji={reaction.emoji}
+                  onReactionSelect={onReactionSelect}
+                />
+              ))}
+              {canAddReaction && (
+                <EmojiPicker
+                  onEmojiSelect={(emoji: { native: string }) =>
+                    onReactionSelect(emoji.native)
+                  }
+                  onOpenChange={setEmojiPickerOpen}
+                >
+                  <Components.Generic.Badge.Root
+                    className={mergeCSSClasses(
+                      "bn-badge",
+                      "bn-comment-add-reaction",
+                    )}
+                    text={"+"}
+                    icon={<RiEmotionLine size={16} />}
+                    mainTooltip={dict.comments.actions.add_reaction}
+                  />
+                </EmojiPicker>
+              )}
+            </Components.Generic.Badge.Group>
+          )}
+          {isEditing && (
+            <Components.Generic.Toolbar.Root
+              variant="action-toolbar"
+              className={mergeCSSClasses(
+                "bn-action-toolbar",
+                "bn-comment-actions",
+              )}
+            >
+              <Components.Generic.Toolbar.Button
+                mainTooltip={dict.comments.save_button_text}
+                variant="compact"
+                onClick={onEditSubmit}
+                isDisabled={isEmpty}
+              >
+                {dict.comments.save_button_text}
+              </Components.Generic.Toolbar.Button>
+              <Components.Generic.Toolbar.Button
+                className={"bn-button"}
+                mainTooltip={dict.comments.cancel_button_text}
+                variant="compact"
+                onClick={onEditCancel}
+              >
+                {dict.comments.cancel_button_text}
+              </Components.Generic.Toolbar.Button>
+            </Components.Generic.Toolbar.Root>
+          )}
+        </>
+      );
+    },
+    [
+      comment,
+      isEditing,
+      threadStore,
+      onReactionSelect,
+      onEditSubmit,
+      onEditCancel,
+      Components,
+      dict,
+    ],
+  );
+
   if (!comment.body) {
     return null;
   }
@@ -249,71 +331,7 @@ export const Comment = ({
         editable={isEditing}
         actions={
           comment.reactions.length > 0 || isEditing
-            ? ({ isEmpty }) => (
-                <>
-                  {comment.reactions.length > 0 && !isEditing && (
-                    <Components.Generic.Badge.Group
-                      className={mergeCSSClasses(
-                        "bn-badge-group",
-                        "bn-comment-reactions",
-                      )}
-                    >
-                      {comment.reactions.map((reaction) => (
-                        <ReactionBadge
-                          key={reaction.emoji}
-                          comment={comment}
-                          emoji={reaction.emoji}
-                          onReactionSelect={onReactionSelect}
-                        />
-                      ))}
-                      {canAddReaction && (
-                        <EmojiPicker
-                          onEmojiSelect={(emoji: { native: string }) =>
-                            onReactionSelect(emoji.native)
-                          }
-                          onOpenChange={setEmojiPickerOpen}
-                        >
-                          <Components.Generic.Badge.Root
-                            className={mergeCSSClasses(
-                              "bn-badge",
-                              "bn-comment-add-reaction",
-                            )}
-                            text={"+"}
-                            icon={<RiEmotionLine size={16} />}
-                            mainTooltip={dict.comments.actions.add_reaction}
-                          />
-                        </EmojiPicker>
-                      )}
-                    </Components.Generic.Badge.Group>
-                  )}
-                  {isEditing && (
-                    <Components.Generic.Toolbar.Root
-                      variant="action-toolbar"
-                      className={mergeCSSClasses(
-                        "bn-action-toolbar",
-                        "bn-comment-actions",
-                      )}
-                    >
-                      <Components.Generic.Toolbar.Button
-                        mainTooltip={dict.comments.save_button_text}
-                        variant="compact"
-                        onClick={onEditSubmit}
-                        isDisabled={isEmpty}
-                      >
-                        {dict.comments.save_button_text}
-                      </Components.Generic.Toolbar.Button>
-                      <Components.Generic.Toolbar.Button
-                        className={"bn-button"}
-                        mainTooltip={dict.comments.cancel_button_text}
-                        variant="compact"
-                        onClick={onEditCancel}
-                      >
-                        {dict.comments.cancel_button_text}
-                      </Components.Generic.Toolbar.Button>
-                    </Components.Generic.Toolbar.Root>
-                  )}
-                </>
-              )
+            ? CommentEditorActions
             : undefined
         }
       />

--- a/packages/react/src/components/Comments/Comment.tsx
+++ b/packages/react/src/components/Comments/Comment.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-import { mergeCSSClasses } from "@blocknote/core";
+import { Dictionary, mergeCSSClasses } from "@blocknote/core";
 import { CommentsExtension } from "@blocknote/core/comments";
 import type { CommentData, ThreadData } from "@blocknote/core/comments";
-import { MouseEvent, ReactNode, useCallback, useState } from "react";
+import { ThreadStore } from "@blocknote/core/comments";
+import { MouseEvent, ReactNode, memo, useCallback, useState } from "react";
 import {
   RiArrowGoBackFill,
   RiCheckFill,
@@ -13,7 +14,7 @@ import {
   RiMoreFill,
 } from "react-icons/ri";
 
-import { useComponentsContext } from "../../editor/ComponentsContext.js";
+import { Components, useComponentsContext } from "../../editor/ComponentsContext.js";
 import { useCreateBlockNote } from "../../hooks/useCreateBlockNote.js";
 import { useExtension } from "../../hooks/useExtension.js";
 import { useDictionary } from "../../i18n/dictionary.js";
@@ -22,6 +23,103 @@ import { EmojiPicker } from "./EmojiPicker.js";
 import { ReactionBadge } from "./ReactionBadge.js";
 import { defaultCommentEditorSchema } from "./defaultCommentEditorSchema.js";
 import { useUser } from "./useUsers.js";
+
+type CommentEditorActionsProps = {
+  isFocused: boolean;
+  isEmpty: boolean;
+  comment: CommentData;
+  isEditing: boolean;
+  threadStore: ThreadStore;
+  onReactionSelect: (emoji: string) => Promise<void>;
+  onEditSubmit: (event: MouseEvent) => Promise<void>;
+  onEditCancel: () => void;
+  onEmojiPickerOpenChange: (open: boolean) => void;
+  Components: Components;
+  dict: Dictionary;
+};
+
+const CommentEditorActionsComponent = memo(
+  ({
+    isEmpty: _isEmpty,
+    comment,
+    isEditing,
+    threadStore,
+    onReactionSelect,
+    onEditSubmit,
+    onEditCancel,
+    onEmojiPickerOpenChange,
+    Components,
+    dict,
+  }: CommentEditorActionsProps) => {
+    const canAddReaction = threadStore.auth.canAddReaction(comment);
+
+    return (
+      <>
+        {comment.reactions.length > 0 && !isEditing && (
+          <Components.Generic.Badge.Group
+            className={mergeCSSClasses(
+              "bn-badge-group",
+              "bn-comment-reactions",
+            )}
+          >
+            {comment.reactions.map((reaction) => (
+              <ReactionBadge
+                key={reaction.emoji}
+                comment={comment}
+                emoji={reaction.emoji}
+                onReactionSelect={onReactionSelect}
+              />
+            ))}
+            {canAddReaction && (
+              <EmojiPicker
+                onEmojiSelect={(emoji: { native: string }) =>
+                  onReactionSelect(emoji.native)
+                }
+                onOpenChange={onEmojiPickerOpenChange}
+              >
+                <Components.Generic.Badge.Root
+                  className={mergeCSSClasses(
+                    "bn-badge",
+                    "bn-comment-add-reaction",
+                  )}
+                  text={"+"}
+                  icon={<RiEmotionLine size={16} />}
+                  mainTooltip={dict.comments.actions.add_reaction}
+                />
+              </EmojiPicker>
+            )}
+          </Components.Generic.Badge.Group>
+        )}
+        {isEditing && (
+          <Components.Generic.Toolbar.Root
+            variant="action-toolbar"
+            className={mergeCSSClasses(
+              "bn-action-toolbar",
+              "bn-comment-actions",
+            )}
+          >
+            <Components.Generic.Toolbar.Button
+              mainTooltip={dict.comments.save_button_text}
+              variant="compact"
+              onClick={onEditSubmit}
+              isDisabled={_isEmpty}
+            >
+              {dict.comments.save_button_text}
+            </Components.Generic.Toolbar.Button>
+            <Components.Generic.Toolbar.Button
+              className={"bn-button"}
+              mainTooltip={dict.comments.cancel_button_text}
+              variant="compact"
+              onClick={onEditCancel}
+            >
+              {dict.comments.cancel_button_text}
+            </Components.Generic.Toolbar.Button>
+          </Components.Generic.Toolbar.Root>
+        )}
+      </>
+    );
+  },
+);
 
 export type CommentProps = {
   comment: CommentData;
@@ -129,88 +227,6 @@ export const Comment = ({
   }, [thread.id, threadStore]);
 
   const user = useUser(comment.userId);
-
-  const CommentEditorActions = useCallback(
-    ({ isEmpty }: { isFocused: boolean; isEmpty: boolean }) => {
-      const canAddReaction = threadStore.auth.canAddReaction(comment);
-
-      return (
-        <>
-          {comment.reactions.length > 0 && !isEditing && (
-            <Components.Generic.Badge.Group
-              className={mergeCSSClasses(
-                "bn-badge-group",
-                "bn-comment-reactions",
-              )}
-            >
-              {comment.reactions.map((reaction) => (
-                <ReactionBadge
-                  key={reaction.emoji}
-                  comment={comment}
-                  emoji={reaction.emoji}
-                  onReactionSelect={onReactionSelect}
-                />
-              ))}
-              {canAddReaction && (
-                <EmojiPicker
-                  onEmojiSelect={(emoji: { native: string }) =>
-                    onReactionSelect(emoji.native)
-                  }
-                  onOpenChange={setEmojiPickerOpen}
-                >
-                  <Components.Generic.Badge.Root
-                    className={mergeCSSClasses(
-                      "bn-badge",
-                      "bn-comment-add-reaction",
-                    )}
-                    text={"+"}
-                    icon={<RiEmotionLine size={16} />}
-                    mainTooltip={dict.comments.actions.add_reaction}
-                  />
-                </EmojiPicker>
-              )}
-            </Components.Generic.Badge.Group>
-          )}
-          {isEditing && (
-            <Components.Generic.Toolbar.Root
-              variant="action-toolbar"
-              className={mergeCSSClasses(
-                "bn-action-toolbar",
-                "bn-comment-actions",
-              )}
-            >
-              <Components.Generic.Toolbar.Button
-                mainTooltip={dict.comments.save_button_text}
-                variant="compact"
-                onClick={onEditSubmit}
-                isDisabled={isEmpty}
-              >
-                {dict.comments.save_button_text}
-              </Components.Generic.Toolbar.Button>
-              <Components.Generic.Toolbar.Button
-                className={"bn-button"}
-                mainTooltip={dict.comments.cancel_button_text}
-                variant="compact"
-                onClick={onEditCancel}
-              >
-                {dict.comments.cancel_button_text}
-              </Components.Generic.Toolbar.Button>
-            </Components.Generic.Toolbar.Root>
-          )}
-        </>
-      );
-    },
-    [
-      comment,
-      isEditing,
-      threadStore,
-      onReactionSelect,
-      onEditSubmit,
-      onEditCancel,
-      Components,
-      dict,
-    ],
-  );
 
   if (!comment.body) {
     return null;
@@ -331,7 +347,21 @@ export const Comment = ({
         editable={isEditing}
         actions={
           comment.reactions.length > 0 || isEditing
-            ? CommentEditorActions
+            ? ({ isFocused, isEmpty }) => (
+                <CommentEditorActionsComponent
+                  isFocused={isFocused}
+                  isEmpty={isEmpty}
+                  comment={comment}
+                  isEditing={isEditing}
+                  threadStore={threadStore}
+                  onReactionSelect={onReactionSelect}
+                  onEditSubmit={onEditSubmit}
+                  onEditCancel={onEditCancel}
+                  onEmojiPickerOpenChange={setEmojiPickerOpen}
+                  Components={Components}
+                  dict={dict}
+                />
+              )
             : undefined
         }
       />

--- a/packages/react/src/components/Comments/CommentEditor.tsx
+++ b/packages/react/src/components/Comments/CommentEditor.tsx
@@ -1,5 +1,5 @@
 import { BlockNoteEditor } from "@blocknote/core";
-import { FC, useCallback, useEffect, useState } from "react";
+import { ReactNode, useCallback, useEffect, useState } from "react";
 import { useComponentsContext } from "../../editor/ComponentsContext.js";
 import { useEditorState } from "../../hooks/useEditorState.js";
 
@@ -16,10 +16,7 @@ import { useEditorState } from "../../hooks/useEditorState.js";
 export const CommentEditor = (props: {
   autoFocus?: boolean;
   editable: boolean;
-  actions?: FC<{
-    isFocused: boolean;
-    isEmpty: boolean;
-  }>;
+  actions?: (args: { isFocused: boolean; isEmpty: boolean }) => ReactNode;
   editor: BlockNoteEditor<any, any, any>;
 }) => {
   const [isFocused, setIsFocused] = useState(false);
@@ -58,7 +55,7 @@ export const CommentEditor = (props: {
       />
       {props.actions && (
         <div className={"bn-comment-actions-wrapper"}>
-          <props.actions isFocused={isFocused} isEmpty={isEmpty} />
+          {props.actions({ isFocused, isEmpty })}
         </div>
       )}
     </>

--- a/packages/react/src/components/Comments/FloatingComposer.tsx
+++ b/packages/react/src/components/Comments/FloatingComposer.tsx
@@ -3,14 +3,15 @@ import {
   DefaultBlockSchema,
   DefaultInlineContentSchema,
   DefaultStyleSchema,
+  Dictionary,
   InlineContentSchema,
   mergeCSSClasses,
   StyleSchema,
 } from "@blocknote/core";
 import { CommentsExtension } from "@blocknote/core/comments";
-import { useCallback } from "react";
+import { memo, useCallback } from "react";
 
-import { useComponentsContext } from "../../editor/ComponentsContext.js";
+import { Components, useComponentsContext } from "../../editor/ComponentsContext.js";
 import { useCreateBlockNote } from "../../hooks/useCreateBlockNote.js";
 import { useExtension } from "../../hooks/useExtension.js";
 import { useDictionary } from "../../i18n/dictionary.js";
@@ -18,6 +19,33 @@ import { CommentEditor } from "./CommentEditor.js";
 import { defaultCommentEditorSchema } from "./defaultCommentEditorSchema.js";
 import { useBlockNoteEditor } from "../../hooks/useBlockNoteEditor.js";
 import { TextSelection } from "@tiptap/pm/state";
+
+type FloatingComposerActionsProps = {
+  isFocused: boolean;
+  isEmpty: boolean;
+  onSave: () => Promise<void>;
+  Components: Components;
+  dict: Dictionary;
+};
+
+const FloatingComposerActionsComponent = memo(
+  ({ isEmpty, onSave, Components, dict }: FloatingComposerActionsProps) => (
+    <Components.Generic.Toolbar.Root
+      className={mergeCSSClasses("bn-action-toolbar", "bn-comment-actions")}
+      variant="action-toolbar"
+    >
+      <Components.Generic.Toolbar.Button
+        className={"bn-button"}
+        mainTooltip={dict.comments.save_button_text}
+        variant="compact"
+        isDisabled={isEmpty}
+        onClick={onSave}
+      >
+        {dict.comments.save_button_text}
+      </Components.Generic.Toolbar.Button>
+    </Components.Generic.Toolbar.Root>
+  ),
+);
 
 /**
  * The FloatingComposer component displays a comment editor "floating" card.
@@ -47,37 +75,19 @@ export function FloatingComposer<
     schema: comments.commentEditorSchema || defaultCommentEditorSchema,
   });
 
-  const Actions = useCallback(
-    ({ isEmpty }: { isFocused: boolean; isEmpty: boolean }) => (
-      <Components.Generic.Toolbar.Root
-        className={mergeCSSClasses("bn-action-toolbar", "bn-comment-actions")}
-        variant="action-toolbar"
-      >
-        <Components.Generic.Toolbar.Button
-          className={"bn-button"}
-          mainTooltip={dict.comments.save_button_text}
-          variant="compact"
-          isDisabled={isEmpty}
-          onClick={async () => {
-            // (later) For REST API, we should implement a loading state and error state
-            await comments.createThread({
-              initialComment: {
-                body: newCommentEditor.document,
-              },
-            });
-            comments.stopPendingComment();
-            editor.transact((tr) => {
-              tr.setSelection(TextSelection.create(tr.doc, tr.selection.to));
-            });
-            editor.focus();
-          }}
-        >
-          {dict.comments.save_button_text}
-        </Components.Generic.Toolbar.Button>
-      </Components.Generic.Toolbar.Root>
-    ),
-    [Components, dict, comments, newCommentEditor, editor],
-  );
+  const onSave = useCallback(async () => {
+    // (later) For REST API, we should implement a loading state and error state
+    await comments.createThread({
+      initialComment: {
+        body: newCommentEditor.document,
+      },
+    });
+    comments.stopPendingComment();
+    editor.transact((tr) => {
+      tr.setSelection(TextSelection.create(tr.doc, tr.selection.to));
+    });
+    editor.focus();
+  }, [comments, newCommentEditor, editor]);
 
   return (
     <Components.Comments.Card className={"bn-thread"}>
@@ -85,7 +95,15 @@ export function FloatingComposer<
         autoFocus={true}
         editable={true}
         editor={newCommentEditor}
-        actions={Actions}
+        actions={({ isFocused, isEmpty }) => (
+          <FloatingComposerActionsComponent
+            isFocused={isFocused}
+            isEmpty={isEmpty}
+            onSave={onSave}
+            Components={Components}
+            dict={dict}
+          />
+        )}
       />
     </Components.Comments.Card>
   );

--- a/packages/react/src/components/Comments/FloatingComposer.tsx
+++ b/packages/react/src/components/Comments/FloatingComposer.tsx
@@ -8,6 +8,7 @@ import {
   StyleSchema,
 } from "@blocknote/core";
 import { CommentsExtension } from "@blocknote/core/comments";
+import { useCallback } from "react";
 
 import { useComponentsContext } from "../../editor/ComponentsContext.js";
 import { useCreateBlockNote } from "../../hooks/useCreateBlockNote.js";
@@ -46,45 +47,45 @@ export function FloatingComposer<
     schema: comments.commentEditorSchema || defaultCommentEditorSchema,
   });
 
+  const Actions = useCallback(
+    ({ isEmpty }: { isFocused: boolean; isEmpty: boolean }) => (
+      <Components.Generic.Toolbar.Root
+        className={mergeCSSClasses("bn-action-toolbar", "bn-comment-actions")}
+        variant="action-toolbar"
+      >
+        <Components.Generic.Toolbar.Button
+          className={"bn-button"}
+          mainTooltip={dict.comments.save_button_text}
+          variant="compact"
+          isDisabled={isEmpty}
+          onClick={async () => {
+            // (later) For REST API, we should implement a loading state and error state
+            await comments.createThread({
+              initialComment: {
+                body: newCommentEditor.document,
+              },
+            });
+            comments.stopPendingComment();
+            editor.transact((tr) => {
+              tr.setSelection(TextSelection.create(tr.doc, tr.selection.to));
+            });
+            editor.focus();
+          }}
+        >
+          {dict.comments.save_button_text}
+        </Components.Generic.Toolbar.Button>
+      </Components.Generic.Toolbar.Root>
+    ),
+    [Components, dict, comments, newCommentEditor, editor],
+  );
+
   return (
     <Components.Comments.Card className={"bn-thread"}>
       <CommentEditor
         autoFocus={true}
         editable={true}
         editor={newCommentEditor}
-        actions={({ isEmpty }) => (
-          <Components.Generic.Toolbar.Root
-            className={mergeCSSClasses(
-              "bn-action-toolbar",
-              "bn-comment-actions",
-            )}
-            variant="action-toolbar"
-          >
-            <Components.Generic.Toolbar.Button
-              className={"bn-button"}
-              mainTooltip={dict.comments.save_button_text}
-              variant="compact"
-              isDisabled={isEmpty}
-              onClick={async () => {
-                // (later) For REST API, we should implement a loading state and error state
-                await comments.createThread({
-                  initialComment: {
-                    body: newCommentEditor.document,
-                  },
-                });
-                comments.stopPendingComment();
-                editor.transact((tr) => {
-                  tr.setSelection(
-                    TextSelection.create(tr.doc, tr.selection.to),
-                  );
-                });
-                editor.focus();
-              }}
-            >
-              {dict.comments.save_button_text}
-            </Components.Generic.Toolbar.Button>
-          </Components.Generic.Toolbar.Root>
-        )}
+        actions={Actions}
       />
     </Components.Comments.Card>
   );

--- a/packages/react/src/components/Comments/Thread.tsx
+++ b/packages/react/src/components/Comments/Thread.tsx
@@ -1,15 +1,47 @@
-import { mergeCSSClasses } from "@blocknote/core";
+import { Dictionary, mergeCSSClasses } from "@blocknote/core";
 import { CommentsExtension } from "@blocknote/core/comments";
 import { ThreadData } from "@blocknote/core/comments";
-import { FocusEvent, useCallback } from "react";
+import { FocusEvent, memo, useCallback } from "react";
 
-import { useComponentsContext } from "../../editor/ComponentsContext.js";
+import { Components, useComponentsContext } from "../../editor/ComponentsContext.js";
 import { useCreateBlockNote } from "../../hooks/useCreateBlockNote.js";
 import { useExtension } from "../../hooks/useExtension.js";
 import { useDictionary } from "../../i18n/dictionary.js";
 import { CommentEditor } from "./CommentEditor.js";
 import { Comments } from "./Comments.js";
 import { defaultCommentEditorSchema } from "./defaultCommentEditorSchema.js";
+
+type ReplyActionsProps = {
+  isFocused: boolean;
+  isEmpty: boolean;
+  onNewCommentSave: () => Promise<void>;
+  Components: Components;
+  dict: Dictionary;
+};
+
+const ReplyActionsComponent = memo(
+  ({ isEmpty, onNewCommentSave, Components, dict }: ReplyActionsProps) => {
+    if (isEmpty) {
+      return null;
+    }
+
+    return (
+      <Components.Generic.Toolbar.Root
+        variant="action-toolbar"
+        className={mergeCSSClasses("bn-action-toolbar", "bn-comment-actions")}
+      >
+        <Components.Generic.Toolbar.Button
+          mainTooltip={dict.comments.save_button_text}
+          variant="compact"
+          isDisabled={isEmpty}
+          onClick={onNewCommentSave}
+        >
+          {dict.comments.save_button_text}
+        </Components.Generic.Toolbar.Button>
+      </Components.Generic.Toolbar.Root>
+    );
+  },
+);
 
 export type ThreadProps = {
   /**
@@ -92,31 +124,6 @@ export const Thread = ({
     newCommentEditor.removeBlocks(newCommentEditor.document);
   }, [comments, newCommentEditor, thread.id]);
 
-  const ReplyActions = useCallback(
-    ({ isEmpty }: { isFocused: boolean; isEmpty: boolean }) => {
-      if (isEmpty) {
-        return null;
-      }
-
-      return (
-        <Components.Generic.Toolbar.Root
-          variant="action-toolbar"
-          className={mergeCSSClasses("bn-action-toolbar", "bn-comment-actions")}
-        >
-          <Components.Generic.Toolbar.Button
-            mainTooltip={dict.comments.save_button_text}
-            variant="compact"
-            isDisabled={isEmpty}
-            onClick={onNewCommentSave}
-          >
-            {dict.comments.save_button_text}
-          </Components.Generic.Toolbar.Button>
-        </Components.Generic.Toolbar.Root>
-      );
-    },
-    [Components, dict, onNewCommentSave],
-  );
-
   return (
     <Components.Comments.Card
       className={"bn-thread"}
@@ -140,7 +147,15 @@ export const Thread = ({
             autoFocus={false}
             editable={true}
             editor={newCommentEditor}
-            actions={ReplyActions}
+            actions={({ isFocused, isEmpty }) => (
+              <ReplyActionsComponent
+                isFocused={isFocused}
+                isEmpty={isEmpty}
+                onNewCommentSave={onNewCommentSave}
+                Components={Components}
+                dict={dict}
+              />
+            )}
           />
         </Components.Comments.CardSection>
       )}

--- a/packages/react/src/components/Comments/Thread.tsx
+++ b/packages/react/src/components/Comments/Thread.tsx
@@ -92,6 +92,31 @@ export const Thread = ({
     newCommentEditor.removeBlocks(newCommentEditor.document);
   }, [comments, newCommentEditor, thread.id]);
 
+  const ReplyActions = useCallback(
+    ({ isEmpty }: { isFocused: boolean; isEmpty: boolean }) => {
+      if (isEmpty) {
+        return null;
+      }
+
+      return (
+        <Components.Generic.Toolbar.Root
+          variant="action-toolbar"
+          className={mergeCSSClasses("bn-action-toolbar", "bn-comment-actions")}
+        >
+          <Components.Generic.Toolbar.Button
+            mainTooltip={dict.comments.save_button_text}
+            variant="compact"
+            isDisabled={isEmpty}
+            onClick={onNewCommentSave}
+          >
+            {dict.comments.save_button_text}
+          </Components.Generic.Toolbar.Button>
+        </Components.Generic.Toolbar.Root>
+      );
+    },
+    [Components, dict, onNewCommentSave],
+  );
+
   return (
     <Components.Comments.Card
       className={"bn-thread"}
@@ -115,30 +140,7 @@ export const Thread = ({
             autoFocus={false}
             editable={true}
             editor={newCommentEditor}
-            actions={({ isEmpty }) => {
-              if (isEmpty) {
-                return null;
-              }
-
-              return (
-                <Components.Generic.Toolbar.Root
-                  variant="action-toolbar"
-                  className={mergeCSSClasses(
-                    "bn-action-toolbar",
-                    "bn-comment-actions",
-                  )}
-                >
-                  <Components.Generic.Toolbar.Button
-                    mainTooltip={dict.comments.save_button_text}
-                    variant="compact"
-                    isDisabled={isEmpty}
-                    onClick={onNewCommentSave}
-                  >
-                    {dict.comments.save_button_text}
-                  </Components.Generic.Toolbar.Button>
-                </Components.Generic.Toolbar.Root>
-              );
-            }}
+            actions={ReplyActions}
           />
         </Components.Comments.CardSection>
       )}

--- a/tests/src/end-to-end/comments/comments.test.ts
+++ b/tests/src/end-to-end/comments/comments.test.ts
@@ -3,11 +3,54 @@ import { test } from "../../setup/setupScript.js";
 import { COMMENTS_URL, LINK_BUTTON_SELECTOR } from "../../utils/const.js";
 import { focusOnEditor } from "../../utils/editor.js";
 
+const EMOJI_BUTTON_SELECTOR = "em-emoji-picker button[aria-posinset]";
+
 test.beforeEach(async ({ page }) => {
   await page.goto(COMMENTS_URL);
 });
 
 test.describe("Check Comments functionality", () => {
+  test("Should be able to add reactions", async ({ page }) => {
+    await focusOnEditor(page);
+
+    await page.keyboard.type("hello");
+    await page.locator("text=hello").dblclick();
+
+    await page.click('[data-test="addcomment"]');
+    await page.waitForSelector(".bn-thread");
+
+    await page.keyboard.type("test comment");
+    await page.click('button[data-test="save"]');
+
+    // Wait for comment composer to close.
+    await expect(page.locator(".bn-thread")).toHaveCount(0);
+
+    await page.locator("span.bn-thread-mark").first().click();
+    await expect(page.locator(".bn-thread-comment")).toBeVisible();
+
+    // Hover comment to reveal action toolbar.
+    await page.locator(".bn-thread-comment").first().hover();
+    await expect(page.locator('[data-test="addreaction"]')).toBeVisible();
+
+    // Add a reaction via the action toolbar's add-reaction button.
+    await page.click('[data-test="addreaction"]');
+    await expect(page.locator(EMOJI_BUTTON_SELECTOR).first()).toBeVisible();
+    await page.locator(EMOJI_BUTTON_SELECTOR).first().click();
+    await expect(page.locator("em-emoji-picker")).toHaveCount(0);
+    await expect(page.locator(".bn-comment-reaction")).toHaveCount(1);
+
+    // Add a second reaction via the add-reaction badge.
+    await page.locator(".bn-thread-comment").first().hover();
+    await page.click(".bn-comment-add-reaction");
+    await expect(page.locator(EMOJI_BUTTON_SELECTOR).first()).toBeVisible();
+    
+    // Pick a different emoji so it's added as a new reaction rather than
+    // toggling the first one off.
+    await page.locator(EMOJI_BUTTON_SELECTOR).nth(5).click();
+    await expect(page.locator("em-emoji-picker")).toHaveCount(0);
+    await expect(page.locator(".bn-comment-reaction")).toHaveCount(2);
+  });
+
   test("Should preserve existing comments when adding a link", async ({
     page,
   }) => {
@@ -30,7 +73,7 @@ test.describe("Check Comments functionality", () => {
     await page.keyboard.type("https://example.com");
     await page.keyboard.press("Enter");
 
-    await expect(await page.locator("span.bn-thread-mark")).toBeVisible();
+    await expect(page.locator("span.bn-thread-mark")).toBeVisible();
   });
 
   test("Should select thread on first click and open link on second click", async ({
@@ -64,6 +107,7 @@ test.describe("Check Comments functionality", () => {
     await page.keyboard.press("ArrowDown");
     await page.waitForTimeout(500);
     await expect(page.locator(".bn-thread-mark-selected")).toHaveCount(0);
+    await expect(page.locator(".bn-formatting-toolbar")).toBeHidden();
 
     const link = page.locator('a[data-inline-content-type="link"]').first();
 


### PR DESCRIPTION
# Summary

<!-- Briefly describe the feature being introduced. -->

This PR fixes 2 issues with the emoji picker button in comments:

1. The user often has to click the button multiple times to bring up the emoji picker.
2. Clicking an emoji does nothing.

This is because the component passed to the `actions` prop of `CommentEditor` in the `Comment` component was inlined. This passed component contains the reactions & problematic "add reaction" button This caused it to get re-rendered every time `emojiPickerOpen` changed, so on each click of the "add reaction" button.

Closes #2763

## Rationale

<!-- Explain the reasoning behind this feature and its benefits to the project. -->

This is a bug.

## Changes

<!-- List the major changes made in this pull request. -->

- Memoized the component passed to the `CommentEditor`'s `actions` prop for each consumer.

## Impact

<!-- Discuss any potential impacts this feature may have on existing functionalities. -->

N/A

## Testing

<!-- Describe how the feature has been tested, including both automated and manual testing strategies. -->

Added e2e test.

## Screenshots/Video

<!-- Include screenshots or video demonstrating the new feature, if applicable. -->

N/A

## Checklist

- [X] Code follows the project's coding standards.
- [ ] Unit tests covering the new feature have been added.
- [X] All existing tests pass.
- [ ] The documentation has been updated to reflect the new feature

## Additional Notes

<!-- Any additional information or context relevant to this PR. -->

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Streamlined comment, reply, and composer action rendering for more consistent and efficient editor toolbar behavior.

* **New Features / UX**
  * Comment action toolbar now more reliably shows reaction badges, an emoji picker when appropriate, and save/cancel controls while editing.
  * Reply composer displays a contextual "save reply" action only when there’s content.

* **Tests**
  * Expanded end-to-end coverage for adding reactions and thread/link UI behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->