### PR TITLE
fix(table): prevent crash when pressing Enter in a table cell

### DIFF
--- a/packages/core/src/blocks/Table/TableExtension.test.ts
+++ b/packages/core/src/blocks/Table/TableExtension.test.ts
@@ -9,10 +9,6 @@ import type { PartialBlock } from "../defaultBlocks.js";
  * @vitest-environment jsdom
  */
 
-/**
- * Simulate a keyboard shortcut by invoking the view's handleKeyDown prop,
- * which is how ProseMirror routes keymap-based handlers like Enter.
- */
 function pressEnter(editor: BlockNoteEditor) {
   const view = editor.prosemirrorView;
   const event = new KeyboardEvent("keydown", { key: "Enter" });
@@ -52,9 +48,6 @@ describe("Table Enter keyboard shortcut", () => {
     editor.replaceBlocks(editor.document, testDocument);
   });
 
-  /**
-   * Returns the document position just inside the cell containing `cellText`.
-   */
   function posInCell(cellText: string): number {
     const view = editor.prosemirrorView;
     let pos = -1;
@@ -92,7 +85,6 @@ describe("Table Enter keyboard shortcut", () => {
 
     const before = editor.document;
     expect(() => pressEnter(editor)).not.toThrow();
-    // The table structure must be left intact (Enter is a no-op here).
     expect(editor.document).toStrictEqual(before);
   });
 

--- a/packages/core/src/blocks/Table/TableExtension.test.ts
+++ b/packages/core/src/blocks/Table/TableExtension.test.ts
@@ -1,0 +1,134 @@
+import { TextSelection } from "prosemirror-state";
+import { CellSelection } from "prosemirror-tables";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+
+import { BlockNoteEditor } from "../../editor/BlockNoteEditor.js";
+import type { PartialBlock } from "../defaultBlocks.js";
+
+/**
+ * @vitest-environment jsdom
+ */
+
+/**
+ * Simulate a keyboard shortcut by invoking the view's handleKeyDown prop,
+ * which is how ProseMirror routes keymap-based handlers like Enter.
+ */
+function pressEnter(editor: BlockNoteEditor) {
+  const view = editor.prosemirrorView;
+  const event = new KeyboardEvent("keydown", { key: "Enter" });
+  view.someProp("handleKeyDown", (f) => f(view, event));
+}
+
+const testDocument: PartialBlock[] = [
+  {
+    id: "table-0",
+    type: "table",
+    content: {
+      type: "tableContent",
+      rows: [
+        { cells: ["Cell 1", "Cell 2", "Cell 3"] },
+        { cells: ["Cell 4", "Cell 5", "Cell 6"] },
+        { cells: ["Cell 7", "Cell 8", "Cell 9"] },
+      ],
+    },
+  },
+];
+
+describe("Table Enter keyboard shortcut", () => {
+  let editor: BlockNoteEditor;
+  const div = document.createElement("div");
+
+  beforeAll(() => {
+    editor = BlockNoteEditor.create();
+    editor.mount(div);
+  });
+
+  afterAll(() => {
+    editor._tiptapEditor.destroy();
+    editor = undefined as any;
+  });
+
+  beforeEach(() => {
+    editor.replaceBlocks(editor.document, testDocument);
+  });
+
+  /**
+   * Returns the document position just inside the cell containing `cellText`.
+   */
+  function posInCell(cellText: string): number {
+    const view = editor.prosemirrorView;
+    let pos = -1;
+    view.state.doc.descendants((node, nodePos) => {
+      if (pos === -1 && node.isText && node.text === cellText) {
+        pos = nodePos;
+      }
+      return true;
+    });
+    if (pos === -1) {
+      throw new Error(`Cell with text "${cellText}" not found`);
+    }
+    return pos;
+  }
+
+  function setCursorInCell(cellText: string, offset = 1) {
+    const pos = posInCell(cellText);
+    editor.transact((tr) =>
+      tr.setSelection(TextSelection.create(tr.doc, pos + offset)),
+    );
+  }
+
+  it("moves the selection to the cell below", () => {
+    setCursorInCell("Cell 5");
+
+    pressEnter(editor);
+
+    const parentText =
+      editor.prosemirrorView.state.selection.$head.parent.textContent;
+    expect(parentText).toBe("Cell 8");
+  });
+
+  it("does not crash and is a no-op on the last row", () => {
+    setCursorInCell("Cell 8");
+
+    const before = editor.document;
+    expect(() => pressEnter(editor)).not.toThrow();
+    // The table structure must be left intact (Enter is a no-op here).
+    expect(editor.document).toStrictEqual(before);
+  });
+
+  it("does not crash with a (non-empty) text selection in the last row", () => {
+    const start = posInCell("Cell 8");
+    editor.transact((tr) =>
+      tr.setSelection(TextSelection.create(tr.doc, start, start + 4)),
+    );
+
+    const before = editor.document;
+    expect(() => pressEnter(editor)).not.toThrow();
+    expect(editor.document).toStrictEqual(before);
+  });
+
+  it("does not crash with a multi-cell selection", () => {
+    const view = editor.prosemirrorView;
+    const cellPositions: number[] = [];
+    view.state.doc.descendants((node, pos) => {
+      if (node.type.name === "tableCell" || node.type.name === "tableHeader") {
+        cellPositions.push(pos);
+      }
+      return true;
+    });
+
+    editor.transact((tr) =>
+      tr.setSelection(
+        CellSelection.create(
+          tr.doc,
+          cellPositions[0],
+          cellPositions[1],
+        ) as any,
+      ),
+    );
+
+    const before = editor.document;
+    expect(() => pressEnter(editor)).not.toThrow();
+    expect(editor.document).toStrictEqual(before);
+  });
+});

--- a/packages/core/src/blocks/Table/TableExtension.ts
+++ b/packages/core/src/blocks/Table/TableExtension.ts
@@ -35,26 +35,19 @@ export const TableExtension = Extension.create({
     return {
       // Moves the selection to the cell below.
       Enter: () => {
-        if (
-          this.editor.state.selection.$head.parent.type.name !==
-          "tableParagraph"
-        ) {
+        // We use `isInTable` rather than checking whether the cursor's parent
+        // is a `tableParagraph`, since for cell selections that span multiple
+        // cells the selection head resolves to a `tableRow` instead.
+        if (!isInTable(this.editor.state)) {
           return false;
         }
 
         return this.editor.commands.command(({ state, dispatch }) => {
-          if (!isInTable(state)) {
-            return false;
-          }
-
           const $cell = selectionCell(state);
-          const $nextCell = nextCell($cell, "vert", 1);
+          const $nextCell = $cell ? nextCell($cell, "vert", 1) : null;
 
-          if (!$nextCell) {
-            return false;
-          }
-
-          if (dispatch) {
+          // Moves the selection to the cell below, if there is one.
+          if ($nextCell && dispatch) {
             dispatch(
               state.tr
                 .setSelection(
@@ -64,6 +57,12 @@ export const TableExtension = Extension.create({
             );
           }
 
+          // Always consume the Enter key while inside a table, even when there
+          // is no cell below (e.g. the last row) or the selection spans
+          // multiple cells. Otherwise it falls through to the default
+          // `splitBlock` handler, which tries to split the table cell and
+          // throws `Cannot join tableCell onto blockContainer`, crashing the
+          // editor. On the last row, Enter simply becomes a no-op.
           return true;
         });
       },

--- a/packages/core/src/blocks/Table/TableExtension.ts
+++ b/packages/core/src/blocks/Table/TableExtension.ts
@@ -35,9 +35,6 @@ export const TableExtension = Extension.create({
     return {
       // Moves the selection to the cell below.
       Enter: () => {
-        // We use `isInTable` rather than checking whether the cursor's parent
-        // is a `tableParagraph`, since for cell selections that span multiple
-        // cells the selection head resolves to a `tableRow` instead.
         if (!isInTable(this.editor.state)) {
           return false;
         }
@@ -46,7 +43,6 @@ export const TableExtension = Extension.create({
           const $cell = selectionCell(state);
           const $nextCell = $cell ? nextCell($cell, "vert", 1) : null;
 
-          // Moves the selection to the cell below, if there is one.
           if ($nextCell && dispatch) {
             dispatch(
               state.tr
@@ -57,12 +53,6 @@ export const TableExtension = Extension.create({
             );
           }
 
-          // Always consume the Enter key while inside a table, even when there
-          // is no cell below (e.g. the last row) or the selection spans
-          // multiple cells. Otherwise it falls through to the default
-          // `splitBlock` handler, which tries to split the table cell and
-          // throws `Cannot join tableCell onto blockContainer`, crashing the
-          // editor. On the last row, Enter simply becomes a no-op.
           return true;
         });
       },


### PR DESCRIPTION
## Summary

Fixes a crash where pressing **Enter** inside a table cell throws `TransformError: Cannot join tableCell onto blockContainer` and leaves the editor in an unrecoverable state.

Closes #2792.

## Symptom & minimal reproduction

Reproducible on the official demo (no app-specific code needed): https://www.blocknotejs.org/demo#pwls9

1. Open the demo (it contains a table).
2. Click inside a cell in the **last row**.
3. Press **Enter** → the editor crashes.

It also reproduces by:
- selecting text within a last-row cell and pressing Enter;
- selecting across multiple cells (a `CellSelection`) and pressing Enter.

## Stack trace

```
TransformError: Cannot join tableCell onto blockContainer
  at new TransformError (prosemirror-transform)
  at Transaction.step (prosemirror-transform)
  at split (prosemirror-transform)
  at Transaction.split (prosemirror-transform)
  at splitBlockTr (packages/core/src/api/blockManipulation/commands/splitBlock/splitBlock.ts:55)  // tr.split(posInBlock, 2, types)
  at splitBlockCommand (.../splitBlock.ts:22)
  at KeyboardShortcutsExtension Enter handler (.../KeyboardShortcuts/KeyboardShortcutsExtension.ts:918)
      // chain().deleteSelection().command(splitBlockCommand(...)).run() — reached because the
      // table's Enter handler returned false and fell through to the default splitBlock
```

## Cause

The table-specific Enter handler in `packages/core/src/blocks/Table/TableExtension.ts` (added in #2685, "feat: Enter moves selection to cell below in tables (BLO-1006)") only handles the case where a cell exists **below** the cursor. In several edge cases it returns `false` and falls through to the default `splitBlock` handler.

`splitBlockTr` resolves the nearest block container of a cell to the **outer `blockContainer` that wraps the whole table** (whose content — the table — is non-empty, so the "empty block" early-outs don't apply), and then calls `tr.split(pos, 2, ...)` at a position deep inside the cell. Splitting a `tableCell` at depth 2 is invalid, so ProseMirror throws `Cannot join tableCell onto blockContainer`.

Edge cases that triggered the fallback (and therefore the crash):

1. Cursor in a cell on the **last row** (no cell below → `!$nextCell` → `false`).
2. A **non-empty text selection** inside a last-row cell.
3. A **multi-cell selection** (`CellSelection`) — the selection head resolves to a `tableRow`, so the handler's previous `$head.parent.type.name === "tableParagraph"` guard was bypassed entirely.

## Fix

- Detect being inside a table with `isInTable` instead of checking that the cursor's parent is a `tableParagraph`. This also covers multi-cell selections, where the head resolves to a `tableRow`.
- Move the selection to the cell below when there is one (existing behavior preserved).
- **Always consume the Enter key while inside a table**, so it never falls through to the default `splitBlock` handler. On the last row, Enter is now a no-op.

## Affected versions

`@blocknote/core` 0.51.2 and 0.51.3 (latest). The regression was introduced in 0.50.0 by #2685.

## Tests

Adds `packages/core/src/blocks/Table/TableExtension.test.ts` with regression tests that:
- confirm Enter still moves the selection to the cell below;
- confirm Enter on the last row no longer crashes and is a no-op (table structure intact);
- confirm a non-empty text selection in the last row no longer crashes;
- confirm a multi-cell `CellSelection` no longer crashes.

All `@blocknote/core` tests pass (449 passed / 3 skipped), and lint + build (tsc) succeed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enter now consistently moves focus to the cell below when inside tables and consumes the Enter key to avoid unexpected behavior.
  * Pressing Enter on the last row (cursor, text selection, or multi-cell selection) no longer alters the document or causes issues.

* **Tests**
  * Added tests covering Enter behavior across table positions and selection types.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TypeCellOS/BlockNote/pull/2793?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->