### PR TITLE
fix(core): call `scrollIntoView()` on `Enter`

### DIFF
--- a/packages/core/src/blocks/utils/listItemEnterHandler.ts
+++ b/packages/core/src/blocks/utils/listItemEnterHandler.ts
@@ -34,10 +34,9 @@ export const handleEnter = (
   } else if (blockContent.node.childCount > 0) {
     return editor.transact((tr) => {
       tr.deleteSelection();
-      const result = splitBlockTr(tr, tr.selection.from, true);
       tr.scrollIntoView();
-      return result;
-    });
+      return splitBlockTr(tr, tr.selection.from, true);
+});
   }
 
   return false;

--- a/packages/core/src/blocks/utils/listItemEnterHandler.ts
+++ b/packages/core/src/blocks/utils/listItemEnterHandler.ts
@@ -34,7 +34,9 @@ export const handleEnter = (
   } else if (blockContent.node.childCount > 0) {
     return editor.transact((tr) => {
       tr.deleteSelection();
-      return splitBlockTr(tr, tr.selection.from, true);
+      const result = splitBlockTr(tr, tr.selection.from, true);
+      tr.scrollIntoView();
+      return result;
     });
   }
 

--- a/packages/core/src/editor/BlockNoteEditor.ts
+++ b/packages/core/src/editor/BlockNoteEditor.ts
@@ -114,20 +114,6 @@ export interface BlockNoteEditorOptions<
   domAttributes?: Partial<BlockNoteDOMAttributes>;
 
   /**
-   * Additional ProseMirror editor props to pass to the underlying editor view.
-   * Use this to configure options such as `scrollMargin`, `scrollThreshold`,
-   * `handleDOMEvents`, and other
-   * [ProseMirror EditorProps](https://prosemirror.net/docs/ref/#view.EditorProps).
-   *
-   * Note: `attributes` (use {@link domAttributes} instead) and `transformPasted`
-   * are managed by BlockNote and cannot be overridden here.
-   */
-  editorProps?: Omit<
-    NonNullable<EditorOptions["editorProps"]>,
-    "attributes" | "transformPasted"
-  >;
-
-  /**
    * Options for configuring the drop cursor behavior when dragging and dropping blocks.
    * Allows customization of cursor appearance and drop position computation through hooks.
    * @remarks `DropCursorOptions`
@@ -512,8 +498,8 @@ export class BlockNoteEditor<
       autofocus: newOptions.autofocus ?? false,
       extensions: tiptapExtensions,
       editorProps: {
+        scrollMargin: { top: 72, bottom: 72, left: 0, right: 0 },
         ...newOptions._tiptapOptions?.editorProps,
-        ...newOptions.editorProps,
         attributes: {
           // As of TipTap v2.5.0 the tabIndex is removed when the editor is not
           // editable, so you can't focus it. We want to revert this as we have

--- a/packages/core/src/editor/BlockNoteEditor.ts
+++ b/packages/core/src/editor/BlockNoteEditor.ts
@@ -114,6 +114,20 @@ export interface BlockNoteEditorOptions<
   domAttributes?: Partial<BlockNoteDOMAttributes>;
 
   /**
+   * Additional ProseMirror editor props to pass to the underlying editor view.
+   * Use this to configure options such as `scrollMargin`, `scrollThreshold`,
+   * `handleDOMEvents`, and other
+   * [ProseMirror EditorProps](https://prosemirror.net/docs/ref/#view.EditorProps).
+   *
+   * Note: `attributes` (use {@link domAttributes} instead) and `transformPasted`
+   * are managed by BlockNote and cannot be overridden here.
+   */
+  editorProps?: Omit<
+    NonNullable<EditorOptions["editorProps"]>,
+    "attributes" | "transformPasted"
+  >;
+
+  /**
    * Options for configuring the drop cursor behavior when dragging and dropping blocks.
    * Allows customization of cursor appearance and drop position computation through hooks.
    * @remarks `DropCursorOptions`
@@ -499,6 +513,7 @@ export class BlockNoteEditor<
       extensions: tiptapExtensions,
       editorProps: {
         ...newOptions._tiptapOptions?.editorProps,
+        ...newOptions.editorProps,
         attributes: {
           // As of TipTap v2.5.0 the tabIndex is removed when the editor is not
           // editable, so you can't focus it. We want to revert this as we have

--- a/packages/core/src/extensions/tiptap-extensions/KeyboardShortcuts/KeyboardShortcutsExtension.ts
+++ b/packages/core/src/extensions/tiptap-extensions/KeyboardShortcuts/KeyboardShortcutsExtension.ts
@@ -920,6 +920,7 @@ export const KeyboardShortcutsExtension = Extension.create<{
                     selectionAtBlockStart,
                   ),
                 )
+                .scrollIntoView()
                 .run();
 
               return true;


### PR DESCRIPTION
# Summary

Updates the enter handler to scrollintoview both globally and for listItems.

Part of https://github.com/TypeCellOS/BlockNote/issues/2801

## Rationale

Without this handler, the cursor goes out of frame when pressing enter on the last line in the window

## Changes

adds a scrollintoview call for the normal and listitem enter handler

## Impact

None expected.

## Testing

Tested in the playground environment. Does not overscroll the margins yet as in the demo video.

## Screenshots/Video

See referenced issue

## Checklist

- [ ] Code follows the project's coding standards.
- [ ] Unit tests covering the new feature have been added.
- [ ] All existing tests pass.
- [ ] The documentation has been updated to reflect the new feature

## Additional Notes

There should be support for configuring the margin aswell (see original issue). I can try to add that here or in a separate PR

Disclaimer: Code was AI assisted, but tested by a human and PR text is human.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Allow passing editor configuration props (excluding internally managed attributes and paste handling) when creating the editor, enabling safer customization of editor behavior.

* **Bug Fixes**
  * Ensure pressing Enter to split blocks or empty list items scrolls the newly created content into view automatically.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->