### PR TITLE
fix: add explicit type annotations to fix Fresh Install Tests CI

### DIFF
--- a/packages/ariakit/src/badge/Badge.tsx
+++ b/packages/ariakit/src/badge/Badge.tsx
@@ -8,7 +8,7 @@ import {
 
 import { assertEmpty, mergeCSSClasses } from "@blocknote/core";
 import { ComponentProps } from "@blocknote/react";
-import { forwardRef } from "react";
+import { type MouseEvent, forwardRef } from "react";
 
 export const Badge = forwardRef<
   HTMLButtonElement,
@@ -36,7 +36,7 @@ export const Badge = forwardRef<
         isSelected && "bn-ak-primary",
       )}
       aria-selected={isSelected === true}
-      onClick={(event) => onClick?.(event)}
+      onClick={(event: MouseEvent<HTMLButtonElement>) => onClick?.(event)}
       onMouseEnter={onMouseEnter}
       ref={ref}
     >

--- a/packages/ariakit/src/panel/Panel.tsx
+++ b/packages/ariakit/src/panel/Panel.tsx
@@ -32,7 +32,7 @@ export const Panel = forwardRef<
       <AriakitTabProvider
         defaultSelectedId={defaultOpenTab}
         selectedId={openTab}
-        setActiveId={(activeId) => {
+        setActiveId={(activeId: string | null | undefined) => {
           if (activeId) {
             setOpenTab(activeId);
           }

--- a/packages/ariakit/src/panel/PanelFileInput.tsx
+++ b/packages/ariakit/src/panel/PanelFileInput.tsx
@@ -5,7 +5,7 @@ import {
 
 import { assertEmpty } from "@blocknote/core";
 import { ComponentProps } from "@blocknote/react";
-import { forwardRef } from "react";
+import { forwardRef, type ChangeEvent } from "react";
 
 export const PanelFileInput = forwardRef<
   HTMLInputElement,
@@ -24,7 +24,7 @@ export const PanelFileInput = forwardRef<
         type={"file"}
         accept={accept}
         value={value ? value.name : undefined}
-        onChange={async (e) => onChange?.(e.target.files![0])}
+        onChange={async (e: ChangeEvent<HTMLInputElement>) => onChange?.(e.target.files![0])}
         placeholder={placeholder}
       />
     </AriakitFormProvider>

--- a/packages/ariakit/src/toolbar/ToolbarButton.tsx
+++ b/packages/ariakit/src/toolbar/ToolbarButton.tsx
@@ -7,7 +7,7 @@ import {
 
 import { assertEmpty, isSafari, mergeCSSClasses } from "@blocknote/core";
 import { ComponentProps } from "@blocknote/react";
-import { forwardRef } from "react";
+import { forwardRef, type MouseEvent } from "react";
 
 type ToolbarButtonProps = ComponentProps["Generic"]["Toolbar"]["Button"];
 
@@ -46,7 +46,7 @@ export const ToolbarButton = forwardRef<HTMLButtonElement, ToolbarButtonProps>(
               )}
               // Needed as Safari doesn't focus button elements on mouse down
               // unlike other browsers.
-              onMouseDown={(e) => {
+              onMouseDown={(e: MouseEvent<HTMLButtonElement>) => {
                 if (isSafari()) {
                   (e.currentTarget as HTMLButtonElement).focus();
                 }

--- a/packages/xl-ai/src/components/AIMenu/AIMenuController.tsx
+++ b/packages/xl-ai/src/components/AIMenu/AIMenuController.tsx
@@ -70,7 +70,7 @@ export const AIMenuController = (props: {
           // We should just be able to set `referencePress: true` instead of
           // using this listener, but this doesn't seem to trigger.
           // (probably because we don't assign the referenceProps to the reference element)
-          outsidePress: (event) => {
+          outsidePress: (event: MouseEvent) => {
             if (event.target instanceof Element) {
               const blockElement = event.target.closest(".bn-block");
               if (


### PR DESCRIPTION
## Problem

The **Fresh Install Tests** CI workflow ([failing run](https://github.com/TypeCellOS/BlockNote/actions/runs/26733312787/job/78781486961)) updates production dependencies to their latest semver-compatible versions before building. When `@ariakit/react` updated its internal module structure (from `@ariakit/react-core` to `@ariakit/react-components`), contextual typing from external library component props broke, causing `TS7006: Parameter implicitly has an 'any' type` errors.

## Fix

Add explicit type annotations to 5 callback parameters that relied on external library types for inference:

| File | Parameter | Type Added |
|------|-----------|------------|
| `packages/ariakit/src/panel/Panel.tsx:35` | `activeId` | `string \| null \| undefined` |
| `packages/ariakit/src/toolbar/ToolbarButton.tsx:49` | `e` | `MouseEvent<HTMLButtonElement>` |
| `packages/ariakit/src/panel/PanelFileInput.tsx:27` | `e` | `ChangeEvent<HTMLInputElement>` |
| `packages/ariakit/src/badge/Badge.tsx:39` | `event` | `MouseEvent<HTMLButtonElement>` |
| `packages/xl-ai/src/components/AIMenu/AIMenuController.tsx:73` | `event` | `MouseEvent` |

All annotations use React/DOM built-in types rather than library-specific types, making them resilient to future dependency updates.

## Verification

Full fresh install simulation was run locally:
1. `pnpm install` (from lockfile)
2. `pnpm update --prod` (for all published packages — simulates fresh user install)
3. `pnpm dedupe`
4. `pnpm run build` — **0 errors**
5. `pnpm run test` — **27/27 targets succeeded**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved type safety across component event handlers in Badge, Panel, PanelFileInput, ToolbarButton, and AIMenuController components.
  * Enhanced type consistency in callback and event parameter declarations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->