### PR TITLE
fix(core): add editor cleanup in BlockNoteEditor.test.ts

### DIFF
--- a/packages/core/src/editor/BlockNoteEditor.test.ts
+++ b/packages/core/src/editor/BlockNoteEditor.test.ts
@@ -1,4 +1,4 @@
-import { expect, it } from "vitest";
+import { afterEach, expect, it } from "vitest";
 import * as Y from "yjs";
 
 import {
@@ -11,8 +11,19 @@ import { BlocksChanged } from "../api/getBlocksChangedByTransaction.js";
 /**
  * @vitest-environment jsdom
  */
+
+const editorsToCleanup: BlockNoteEditor<any, any, any>[] = [];
+
+afterEach(() => {
+  for (const editor of editorsToCleanup) {
+    editor.unmount();
+  }
+  editorsToCleanup.length = 0;
+});
+
 it("creates an editor", () => {
   const editor = BlockNoteEditor.create();
+  editorsToCleanup.push(editor);
   const posInfo = editor.transact((tr) => getNearestBlockPos(tr.doc, 2));
   const info = getBlockInfo(posInfo);
   expect(info.blockNoteType).toEqual("paragraph");
@@ -20,6 +31,7 @@ it("creates an editor", () => {
 
 it("immediately replaces doc", async () => {
   const editor = BlockNoteEditor.create();
+  editorsToCleanup.push(editor);
   const blocks = await editor.tryParseMarkdownToBlocks(
     "This is a normal text\n\n# And this is a large heading",
   );
@@ -70,6 +82,7 @@ it("adds id attribute when requested", async () => {
   const editor = BlockNoteEditor.create({
     setIdAttribute: true,
   });
+  editorsToCleanup.push(editor);
   const blocks = await editor.tryParseMarkdownToBlocks(
     "This is a normal text\n\n# And this is a large heading",
   );
@@ -81,6 +94,7 @@ it("adds id attribute when requested", async () => {
 
 it("updates block", () => {
   const editor = BlockNoteEditor.create();
+  editorsToCleanup.push(editor);
   editor.updateBlock(editor.document[0], {
     content: "hello",
   });
@@ -89,6 +103,7 @@ it("updates block", () => {
 it("block prop types", () => {
   // this test checks whether the block props are correctly typed in typescript
   const editor = BlockNoteEditor.create();
+  editorsToCleanup.push(editor);
   const block = editor.document[0];
   if (block.type === "paragraph") {
     // @ts-expect-error
@@ -108,6 +123,7 @@ it("block prop types", () => {
 
 it("onMount and onUnmount", async () => {
   const editor = BlockNoteEditor.create();
+  editorsToCleanup.push(editor);
   let mounted = false;
   let unmounted = false;
   editor.onMount(() => {
@@ -143,6 +159,7 @@ it("sets an initial block id when using Y.js", async () => {
       },
     },
   });
+  editorsToCleanup.push(editor);
 
   editor.mount(document.createElement("div"));
 
@@ -193,6 +210,7 @@ it("sets an initial block id when using Y.js", async () => {
 
 it("onBeforeChange", () => {
   const editor = BlockNoteEditor.create();
+  editorsToCleanup.push(editor);
   let beforeChangeCalled = false;
   let changes: BlocksChanged<any, any, any> = [];
   editor.onBeforeChange(({ getChanges }) => {


### PR DESCRIPTION
## Problem

The Fresh Install Tests CI workflow fails at the "Run unit tests" step with:

```
ReferenceError: document is not defined
 ❯ EditorView.get root [as root] prosemirror-view/dist/index.js:5665:26
 ❯ EditorView.domSelection prosemirror-view/dist/index.js:5824:21
 ❯ DOMObserver.flush prosemirror-view/dist/index.js:4714:24
 ❯ Timeout._onTimeout prosemirror-view/dist/index.js:4644:46
```

All 28 test files pass individually (449 tests), but Vitest catches 1 unhandled error originating from `BlockNoteEditor.test.ts`.

## Root Cause

Two tests (`sets an initial block id when using Y.js` and `onBeforeChange`) call `editor.mount()` to create a ProseMirror `EditorView` but never call `editor.unmount()`. This leaves ProseMirror's `DOMObserver` active with a 20ms `setTimeout` that fires after jsdom is torn down, causing the `document is not defined` error.

When `pnpm update --prod` bumps `prosemirror-view` to `1.41.8`, timing changes make this latent bug surface.

## Fix

Add an `afterEach` cleanup hook that calls `editor.unmount()` on all editors created during each test, following the same pattern already used in `transformPasted.test.ts`. This ensures `EditorView.destroy()` is called, which sets `docView = null` so any lingering DOMObserver timers bail out harmlessly.

## Testing

- `vitest run src/editor/BlockNoteEditor.test.ts` — 8/8 tests pass, 0 unhandled errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test cleanup infrastructure to automatically unmount editor instances after each test, ensuring proper resource management and preventing test interference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->