### PR TITLE
fix(table): guard stale block after changes for table handles

### DIFF
--- a/packages/core/src/extensions/TableHandles/TableHandles.ts
+++ b/packages/core/src/extensions/TableHandles/TableHandles.ts
@@ -163,13 +163,9 @@ export class TableHandlesView implements PluginView {
       any
     >,
     private readonly pmView: EditorView,
-    emitUpdate: (state: TableHandlesState) => void,
+    emitUpdate: (state: TableHandlesState | undefined) => void,
   ) {
     this.emitUpdate = () => {
-      if (!this.state) {
-        throw new Error("Attempting to update uninitialized image toolbar");
-      }
-
       emitUpdate(this.state);
     };
 
@@ -298,7 +294,7 @@ export class TableHandlesView implements PluginView {
 
       const hideHandles =
         // always hide handles when the actively hovered table changed
-        this.state?.block.id !== tableBlock.id ||
+        this.state?.block?.id !== tableBlock.id ||
         // make sure we don't hide existing handles (keep col / row index) when
         // we're hovering just above or to the right of a table
         event.clientX > tableRect.right ||
@@ -543,9 +539,9 @@ export class TableHandlesView implements PluginView {
       // because yjs replaces the element when for example you change the color via the side menu
       !this.tableElement?.isConnected
     ) {
-      this.state.show = false;
-      this.state.showAddOrRemoveRowsButton = false;
-      this.state.showAddOrRemoveColumnsButton = false;
+      this.state = undefined;
+      this.tableId = undefined;
+      this.tableElement = undefined;
       this.emitUpdate();
 
       return;
@@ -628,7 +624,7 @@ export const TableHandlesExtension = createExtension(({ editor }) => {
         view: (editorView) => {
           view = new TableHandlesView(editor as any, editorView, (state) => {
             store.setState(
-              state.block
+              state?.block
                 ? {
                     ...state,
                     draggingState: state.draggingState


### PR DESCRIPTION
## Summary

Fixes a `TypeError: Cannot read properties of undefined (reading 'id')` in `TableHandlesView.mouseMoveHandler` when hovering a table wrapper after the underlying table block was removed or became invalid (e.g. collaborative edits / Yjs DOM replacement).

## Root cause

1. `update()` refreshes `this.state.block` via `getBlock(id)`. When the block is gone, `block` becomes `undefined`, but the PluginView kept the `state` object (only `show` was set to `false`).
2. On a later `mousemove` over the table wrapper, this expression ran before new state was assigned:

   ```ts
   this.state?.block.id !== tableBlock.id
   ```

   Because optional chaining stops at `block`, `(this.state?.block).id` throws when `block` is `undefined`.

## Fix

- Use `this.state?.block?.id` in the wrapper hover branch.
- When the table block is invalid in `update()`, clear internal PluginView state (`this.state`, `tableId`, `tableElement`) instead of leaving a stale object.
- Allow `emitUpdate` to pass `undefined` to the extension store (matching existing `state.block ? … : undefined` logic).

## Reproduction (consumer apps)

1. Open an editor with collaboration enabled and a table in the document.
2. Hover the table so table handles state is initialized.
3. Remove or replace the table block remotely (or disconnect the table DOM).
4. Move the mouse to the table wrapper area (below/right of the table).

## Reported in

- ovice-ui Sentry: [OVICE-UI-15SZ](https://ovice.sentry.io/issues/7518310990/) (`@blocknote/core` 0.51, staging, `mouseMoveHandler`)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed crashes during table handle initialization by safely handling uninitialized state.
  * Resolved hover-related crashes with more robust table identification logic.
  * Ensured full cleanup of internal table tracking when a table becomes invalid or disconnected.
  * Allowed the table-handle state to be cleared to undefined to improve stability during view/store updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->