### PR TITLE
fix: React custom blocks cause infinite rerender on mobile (BLO-1212)

### DIFF
--- a/packages/react/src/schema/ReactBlockSpec.tsx
+++ b/packages/react/src/schema/ReactBlockSpec.tsx
@@ -315,6 +315,39 @@ export function createReactBlockSpec<
               },
               {
                 className: "bn-react-node-view-renderer",
+                // Any change to a block's content causes ProseMirror to
+                // re-render the block. On desktop, this change is detected
+                // using key presses. On mobile, it's instead detected using
+                // DOM mutations as touchscreen keyboards don't use typical key
+                // events. However, React's own rendering causes DOM mutations,
+                // triggering ProseMirror to re-render the block even if the
+                // mutation is outside the block's editable content. Therefore,
+                // we need to explicitly ignore mutations outside the block's
+                // editable content.
+                ignoreMutation: ({ mutation }) => {
+                  if (mutation.type === "selection") {
+                    return false;
+                  }
+
+                  const target =
+                    mutation.target.nodeType === Node.ELEMENT_NODE
+                      ? (mutation.target as HTMLElement)
+                      : mutation.target.parentElement;
+                  const content = target?.closest("[data-node-view-content]");
+
+                  // Ignore mutations outside a block's editable content.
+                  if (!content) {
+                    return true;
+                  }
+
+                  // Also ignore mutations for the editable content wrapper
+                  // element.
+                  if (mutation.target === content) {
+                    return true;
+                  }
+
+                  return false;
+                },
               },
             )(this.props!) as ReturnType<BlockImplementation["render"]>;
           } else {

--- a/packages/react/src/schema/ReactBlockSpec.tsx
+++ b/packages/react/src/schema/ReactBlockSpec.tsx
@@ -340,9 +340,14 @@ export function createReactBlockSpec<
                     return true;
                   }
 
-                  // Also ignore mutations for the editable content wrapper
-                  // element.
-                  if (mutation.target === content) {
+                  // Also ignore attribute mutations for the editable content
+                  // wrapper element. These include class names & other
+                  // attributes set via `contentRef`. Other mutations such as
+                  // `childList` are still valid.
+                  if (
+                    mutation.target === content &&
+                    mutation.type === "attributes"
+                  ) {
                     return true;
                   }
 


### PR DESCRIPTION
# Summary

<!-- Briefly describe the feature being introduced. -->

This PR fixes an issue with React custom blocks sometimes causing infinite re-render loops on mobile. This can be seen most easily with the [Alert Block with Full UX](https://www.blocknotejs.org/examples/custom-schema/alert-block-full-ux) example, where attempting to insert an alert block via the slash menu will result in an infinite re-render loop and crash. This can be replicated via the mobile emulator in Chrome dev tools.

The reason this happens is that the way ProseMirror detects when a block's editable content has changed is different on desktop vs mobile. On desktop, it's detected using key events within the editable content wrapper element. On mobile though, key inputs don't use actually use typical key events, but insert characters using IME composition (see [here](https://discuss.prosemirror.net/t/contenteditable-on-android-is-the-absolute-worst/3810) and [here](https://github.com/facebook/react/issues/6176)). Therefore, ProseMirror instead detects changes in the editable content based on DOM mutations. Yet for some reason, re-renders are triggered by DOM mutations anywhere in the block, not just within its editable content.

And so the problem is that React's own rendering also causes DOM mutations, leading to ProseMirror triggering a re-render, causing React to render the block again, and starting an infinite loop. Therefore, we need to explicitly tell ProseMirror to ignore mutations outside the editable content to avoid this from happening.

Closes #2804

## Rationale

<!-- Explain the reasoning behind this feature and its benefits to the project. -->

This is a severe issue on mobile.

## Changes

<!-- List the major changes made in this pull request. -->

- Added `ignoreMutation` to `createReactBlockSpec` to ignore DOM mutations outside of block's editable content.

## Impact

<!-- Discuss any potential impacts this feature may have on existing functionalities. -->

N/A

## Testing

<!-- Describe how the feature has been tested, including both automated and manual testing strategies. -->

N/A (we don't have testing infrastructure on mobile)

## Screenshots/Video

<!-- Include screenshots or video demonstrating the new feature, if applicable. -->

N/A

## Checklist

- [X] Code follows the project's coding standards.
- [ ] Unit tests covering the new feature have been added.
- [X] All existing tests pass.
- [ ] The documentation has been updated to reflect the new feature

## Additional Notes

<!-- Any additional information or context relevant to this PR. -->

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Reduced unnecessary editor re-renders triggered by React-driven DOM changes outside editable content areas, improving responsiveness and smoothing block editing. Selection changes remain unaffected.
* **Chores**
  * No changes to public APIs or exported types; internal behavior adjusted only.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->