### PR TITLE
fix: align side menu to tables (BLO-1117)

### DIFF
--- a/packages/react/src/editor/styles.css
+++ b/packages/react/src/editor/styles.css
@@ -284,6 +284,10 @@ inline styles, it is added to the base z-index. */
   height: 54px;
 }
 
+.bn-side-menu[data-block-type="table"] {
+  height: 60px;
+}
+
 /* Thread sidebar styling */
 .bn-threads-sidebar {
   border-radius: var(--bn-border-radius-medium);


### PR DESCRIPTION
# Summary

<!-- Briefly describe the feature being introduced. -->

This PR makes the side menu slightly taller when next to table blocks, so that it's aligned with the first row.

Closes #2604

## Rationale

<!-- Explain the reasoning behind this feature and its benefits to the project. -->

This is a minor visual improvement.

## Changes

<!-- List the major changes made in this pull request. -->

- Added CSS rule.

## Impact

<!-- Discuss any potential impacts this feature may have on existing functionalities. -->

N/A

## Testing

<!-- Describe how the feature has been tested, including both automated and manual testing strategies. -->

N/A (imo too minor to warrant a visual regression test)

## Screenshots/Video

<!-- Include screenshots or video demonstrating the new feature, if applicable. -->

N/A

## Checklist

- [X] Code follows the project's coding standards.
- [ ] Unit tests covering the new feature have been added.
- [X] All existing tests pass.
- [ ] The documentation has been updated to reflect the new feature

## Additional Notes

<!-- Any additional information or context relevant to this PR. -->

N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted the table editor side menu height for improved visual layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->