### PR TITLE
fix: remove cursor flicker in trailing block

### DIFF
--- a/packages/core/src/editor/Block.css
+++ b/packages/core/src/editor/Block.css
@@ -52,6 +52,7 @@ BASIC STYLES
 .bn-trailing-block {
   cursor: text;
   height: 30px;
+  user-select: none;
 }
 
 /*

--- a/packages/core/src/extensions/TrailingNode/TrailingNode.ts
+++ b/packages/core/src/extensions/TrailingNode/TrailingNode.ts
@@ -1,5 +1,10 @@
 import type { Node as PMNode } from "prosemirror-model";
-import { Plugin, PluginKey, type Transaction } from "prosemirror-state";
+import {
+  Plugin,
+  PluginKey,
+  Selection,
+  type Transaction,
+} from "prosemirror-state";
 import { Decoration, DecorationSet } from "prosemirror-view";
 import {
   createExtension,
@@ -127,6 +132,33 @@ export const TrailingNodeExtension = createExtension(
           },
           props: {
             decorations: (state) => PLUGIN_KEY.getState(state),
+            // Prevents ProseMirror from trying to move the selection into the
+            // trailing block, which causes the text caret to flicker in it
+            // before returning to its previous position.
+            handleKeyDown: (view, event) => {
+              if (event.key !== "ArrowRight" && event.key !== "ArrowDown") {
+                return false;
+              }
+
+              const { selection } = view.state;
+              if (!selection.empty) {
+                return false;
+              }
+
+              const docEnd = Selection.atEnd(view.state.doc);
+              if (selection.$head.pos !== docEnd.$head.pos) {
+                return false;
+              }
+
+              if (
+                !shouldShowTrailingWidget(view.state.doc, editor.isEditable)
+              ) {
+                return false;
+              }
+
+              event.preventDefault();
+              return true;
+            },
           },
         }),
       ],


### PR DESCRIPTION
# Summary

<!-- Briefly describe the feature being introduced. -->

Currently, pressing the right or down arrow at the end of the last block in the document makes ProseMirror attempt to move the text cursor into the trailing block. Because the trailing block is just a decoration and can't actually contain the text cursor though, the cursor just flickers and returns to its previous position.

This PR adds explicit keyboard handling to prevent this from happening. Adding `user-select: none` or other CSS styles/HTML attributes to the trailing block isn't enough to fix the issue itself.

## Rationale

<!-- Explain the reasoning behind this feature and its benefits to the project. -->

The flicker looks janky and unpolished, even it it doesn't functionally do anything.

## Changes

<!-- List the major changes made in this pull request. -->

- Added `handleKeyDown` to `TrailingNodeExtension`.
- Updated CSS.

## Impact

<!-- Discuss any potential impacts this feature may have on existing functionalities. -->

N/A

## Testing

<!-- Describe how the feature has been tested, including both automated and manual testing strategies. -->

I don't think this can even be tested. The selection doesn't actually update during the flicker AFAIK, so cannot test the editor state and visual regression testing is not really feasible either.

## Screenshots/Video

<!-- Include screenshots or video demonstrating the new feature, if applicable. -->

N/A

## Checklist

- [X] Code follows the project's coding standards.
- [ ] Unit tests covering the new feature have been added.
- [X] All existing tests pass.
- [ ] The documentation has been updated to reflect the new feature

## Additional Notes

<!-- Any additional information or context relevant to this PR. -->

N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed caret flicker when navigating with arrow keys at the end of a document.
  * Prevented text selection on the trailing block element for improved user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->