### PR TITLE
feat: `moveBlocks` behaviour when leaving empty columns (BLO-1109)

### DIFF
--- a/packages/core/src/api/blockManipulation/commands/moveBlocks/moveBlocks.ts
+++ b/packages/core/src/api/blockManipulation/commands/moveBlocks/moveBlocks.ts
@@ -164,7 +164,12 @@ export function moveBlocks(
     // When the non-empty block is moved up, the column is seen as empty and
     // collapsed in the removal step, so the following insertion fails.
     removeAndInsertBlocks(tr, blocks, [], { fixColumns: false });
-    insertBlocks(tr, flattenColumns(blocks), referenceBlock, placement);
+    insertBlocks<any, any, any>(
+      tr,
+      flattenColumns(blocks),
+      referenceBlock,
+      placement,
+    );
   });
 }
 

--- a/packages/core/src/api/blockManipulation/commands/moveBlocks/moveBlocks.ts
+++ b/packages/core/src/api/blockManipulation/commands/moveBlocks/moveBlocks.ts
@@ -13,7 +13,6 @@ import { getNearestBlockPos } from "../../../getBlockInfoFromPos.js";
 import { getNodeById } from "../../../nodeUtil.js";
 import { insertBlocks } from "../insertBlocks/insertBlocks.js";
 import { removeAndInsertBlocks } from "../replaceBlocks/replaceBlocks.js";
-import { fixColumnList } from "../replaceBlocks/util/fixColumnList.js";
 
 type BlockSelectionData = (
   | {
@@ -152,40 +151,20 @@ export function moveBlocks(
   placement: "before" | "after",
 ) {
   editor.transact((tr) => {
-    // A `columnList` reference can be dissolved by `fixColumnList` when its
-    // `column`s are removed, leaving its ID invalid for re-insertion. Anchor
-    // to an adjacent block instead, which is unaffected by the removal.
-    const refBlock = editor.getBlock(referenceBlock);
-    if (refBlock?.type === "columnList") {
-      const adjacent =
-        placement === "after"
-          ? editor.getNextBlock(refBlock)
-          : editor.getPrevBlock(refBlock);
-      if (adjacent) {
-        referenceBlock = adjacent;
-        placement = placement === "after" ? "before" : "after";
-      }
-    }
-
-    // Don't fix columns/columnLists in the removal step. Otherwise, the
-    // following case breaks:
+    // Don't fix columns/columnLists in the removal step. Since a move is a
+    // rearrangement rather than a deletion, columns that it empties out are
+    // deliberately left as-is instead of being collapsed - this keeps moves
+    // free of side effects (and reversible by moving back), and matches
+    // dragging a block out of a column, which doesn't collapse it either.
+    // Fixing them mid-move also broke the following case:
     // <column>
     //  <paragraph></paragraph>
     //  <paragraph>Paragraph</paragraph>
     // </column>
-    // When the non-empty block is moved up, the column is now seen as empty
-    // and collapsed in the removal step, so the following insertion fails.
-    const { affectedColumnLists } = removeAndInsertBlocks(tr, blocks, [], {
-      fixColumns: false,
-    });
+    // When the non-empty block is moved up, the column is seen as empty and
+    // collapsed in the removal step, so the following insertion fails.
+    removeAndInsertBlocks(tr, blocks, [], { fixColumns: false });
     insertBlocks(tr, flattenColumns(blocks), referenceBlock, placement);
-
-    affectedColumnLists.forEach((id) => {
-      const posInfo = getNodeById(id, tr.doc);
-      if (posInfo) {
-        fixColumnList(tr, posInfo.posBeforeNode);
-      }
-    });
   });
 }
 

--- a/packages/core/src/api/blockManipulation/commands/moveBlocks/moveBlocks.ts
+++ b/packages/core/src/api/blockManipulation/commands/moveBlocks/moveBlocks.ts
@@ -11,6 +11,9 @@ import type { BlockNoteEditor } from "../../../../editor/BlockNoteEditor";
 import { BlockIdentifier } from "../../../../schema/index.js";
 import { getNearestBlockPos } from "../../../getBlockInfoFromPos.js";
 import { getNodeById } from "../../../nodeUtil.js";
+import { insertBlocks } from "../insertBlocks/insertBlocks.js";
+import { removeAndInsertBlocks } from "../replaceBlocks/replaceBlocks.js";
+import { fixColumnList } from "../replaceBlocks/util/fixColumnList.js";
 
 type BlockSelectionData = (
   | {
@@ -148,7 +151,7 @@ export function moveBlocks(
   referenceBlock: BlockIdentifier,
   placement: "before" | "after",
 ) {
-  editor.transact(() => {
+  editor.transact((tr) => {
     // A `columnList` reference can be dissolved by `fixColumnList` when its
     // `column`s are removed, leaving its ID invalid for re-insertion. Anchor
     // to an adjacent block instead, which is unaffected by the removal.
@@ -164,8 +167,25 @@ export function moveBlocks(
       }
     }
 
-    editor.removeBlocks(blocks);
-    editor.insertBlocks(flattenColumns(blocks), referenceBlock, placement);
+    // Don't fix columns/columnLists in the removal step. Otherwise, the
+    // following case breaks:
+    // <column>
+    //  <paragraph></paragraph>
+    //  <paragraph>Paragraph</paragraph>
+    // </column>
+    // When the non-empty block is moved up, the column is now seen as empty
+    // and collapsed in the removal step, so the following insertion fails.
+    const { affectedColumnLists } = removeAndInsertBlocks(tr, blocks, [], {
+      fixColumns: false,
+    });
+    insertBlocks(tr, flattenColumns(blocks), referenceBlock, placement);
+
+    affectedColumnLists.forEach((id) => {
+      const posInfo = getNodeById(id, tr.doc);
+      if (posInfo) {
+        fixColumnList(tr, posInfo.posBeforeNode);
+      }
+    });
   });
 }
 

--- a/packages/core/src/api/blockManipulation/commands/replaceBlocks/replaceBlocks.ts
+++ b/packages/core/src/api/blockManipulation/commands/replaceBlocks/replaceBlocks.ts
@@ -20,9 +20,13 @@ export function removeAndInsertBlocks<
   tr: Transaction,
   blocksToRemove: BlockIdentifier[],
   blocksToInsert: PartialBlock<BSchema, I, S>[],
+  options: {
+    fixColumns?: boolean;
+  } = {},
 ): {
   insertedBlocks: Block<BSchema, I, S>[];
   removedBlocks: Block<BSchema, I, S>[];
+  affectedColumnLists: string[];
 } {
   const pmSchema = getPmSchema(tr);
   // Converts the `PartialBlock`s to ProseMirror nodes to insert them into the
@@ -112,12 +116,25 @@ export function removeAndInsertBlocks<
     );
   }
 
-  columnListPositions.forEach((pos) => fixColumnList(tr, pos));
+  // Saves IDs of columnLists containing removed blocks. If `fixColumns` is
+  // explicitly false, these are needed to run `fixColumnList` manually later.
+  const affectedColumnLists: string[] = [];
+  columnListPositions.forEach((pos) => {
+    const columnList = tr.doc.resolve(pos).nodeAfter;
+    if (columnList?.type.name === "columnList") {
+      affectedColumnLists.push(columnList.attrs.id);
+    }
+  });
+
+  // Collapses empty columns/columnLists
+  if (options.fixColumns !== false) {
+    columnListPositions.forEach((pos) => fixColumnList(tr, pos));
+  }
 
   // Converts the nodes created from `blocksToInsert` into full `Block`s.
   const insertedBlocks = nodesToInsert.map((node) =>
     nodeToBlock(node, pmSchema),
   ) as Block<BSchema, I, S>[];
 
-  return { insertedBlocks, removedBlocks };
+  return { insertedBlocks, removedBlocks, affectedColumnLists };
 }

--- a/packages/core/src/api/blockManipulation/commands/replaceBlocks/replaceBlocks.ts
+++ b/packages/core/src/api/blockManipulation/commands/replaceBlocks/replaceBlocks.ts
@@ -26,7 +26,6 @@ export function removeAndInsertBlocks<
 ): {
   insertedBlocks: Block<BSchema, I, S>[];
   removedBlocks: Block<BSchema, I, S>[];
-  affectedColumnLists: string[];
 } {
   const pmSchema = getPmSchema(tr);
   // Converts the `PartialBlock`s to ProseMirror nodes to insert them into the
@@ -116,17 +115,9 @@ export function removeAndInsertBlocks<
     );
   }
 
-  // Saves IDs of columnLists containing removed blocks. If `fixColumns` is
-  // explicitly false, these are needed to run `fixColumnList` manually later.
-  const affectedColumnLists: string[] = [];
-  columnListPositions.forEach((pos) => {
-    const columnList = tr.doc.resolve(pos).nodeAfter;
-    if (columnList?.type.name === "columnList") {
-      affectedColumnLists.push(columnList.attrs.id);
-    }
-  });
-
-  // Collapses empty columns/columnLists
+  // Collapses empty columns/columnLists. Callers where the removal isn't a
+  // deletion can opt out - e.g. `moveBlocks` re-inserts the blocks elsewhere
+  // and deliberately leaves emptied columns as-is.
   if (options.fixColumns !== false) {
     columnListPositions.forEach((pos) => fixColumnList(tr, pos));
   }
@@ -136,5 +127,5 @@ export function removeAndInsertBlocks<
     nodeToBlock(node, pmSchema),
   ) as Block<BSchema, I, S>[];
 
-  return { insertedBlocks, removedBlocks, affectedColumnLists };
+  return { insertedBlocks, removedBlocks };
 }

--- a/packages/xl-multi-column/src/test/commands/__snapshots__/moveBlocks.test.ts.snap
+++ b/packages/xl-multi-column/src/test/commands/__snapshots__/moveBlocks.test.ts.snap
@@ -743,21 +743,60 @@ exports[`Test moveBlocksDown > Selection across columns 1`] = `
     "type": "paragraph",
   },
   {
-    "children": [],
-    "content": [
+    "children": [
       {
-        "styles": {},
-        "text": "Column Paragraph 0",
-        "type": "text",
+        "children": [
+          {
+            "children": [],
+            "content": [
+              {
+                "styles": {},
+                "text": "Column Paragraph 0",
+                "type": "text",
+              },
+            ],
+            "id": "column-paragraph-0",
+            "props": {
+              "backgroundColor": "default",
+              "textAlignment": "left",
+              "textColor": "default",
+            },
+            "type": "paragraph",
+          },
+        ],
+        "content": undefined,
+        "id": "column-0",
+        "props": {
+          "width": 1,
+        },
+        "type": "column",
+      },
+      {
+        "children": [
+          {
+            "children": [],
+            "content": [],
+            "id": "1",
+            "props": {
+              "backgroundColor": "default",
+              "textAlignment": "left",
+              "textColor": "default",
+            },
+            "type": "paragraph",
+          },
+        ],
+        "content": undefined,
+        "id": "0",
+        "props": {
+          "width": 1,
+        },
+        "type": "column",
       },
     ],
-    "id": "column-paragraph-0",
-    "props": {
-      "backgroundColor": "default",
-      "textAlignment": "left",
-      "textColor": "default",
-    },
-    "type": "paragraph",
+    "content": undefined,
+    "id": "column-list-0",
+    "props": {},
+    "type": "columnList",
   },
   {
     "children": [],
@@ -2245,72 +2284,111 @@ exports[`Test moveBlocksUp > Selection across columns 1`] = `
     "type": "paragraph",
   },
   {
-    "children": [],
-    "content": [
+    "children": [
       {
-        "styles": {},
-        "text": "Column Paragraph 1",
-        "type": "text",
+        "children": [
+          {
+            "children": [],
+            "content": [
+              {
+                "styles": {},
+                "text": "Column Paragraph 1",
+                "type": "text",
+              },
+            ],
+            "id": "column-paragraph-1",
+            "props": {
+              "backgroundColor": "default",
+              "textAlignment": "left",
+              "textColor": "default",
+            },
+            "type": "paragraph",
+          },
+          {
+            "children": [],
+            "content": [
+              {
+                "styles": {},
+                "text": "Column Paragraph 2",
+                "type": "text",
+              },
+            ],
+            "id": "column-paragraph-2",
+            "props": {
+              "backgroundColor": "default",
+              "textAlignment": "left",
+              "textColor": "default",
+            },
+            "type": "paragraph",
+          },
+          {
+            "children": [],
+            "content": [
+              {
+                "styles": {},
+                "text": "Column Paragraph 3",
+                "type": "text",
+              },
+            ],
+            "id": "column-paragraph-3",
+            "props": {
+              "backgroundColor": "default",
+              "textAlignment": "left",
+              "textColor": "default",
+            },
+            "type": "paragraph",
+          },
+          {
+            "children": [],
+            "content": [
+              {
+                "styles": {},
+                "text": "Column Paragraph 0",
+                "type": "text",
+              },
+            ],
+            "id": "column-paragraph-0",
+            "props": {
+              "backgroundColor": "default",
+              "textAlignment": "left",
+              "textColor": "default",
+            },
+            "type": "paragraph",
+          },
+        ],
+        "content": undefined,
+        "id": "column-0",
+        "props": {
+          "width": 1,
+        },
+        "type": "column",
+      },
+      {
+        "children": [
+          {
+            "children": [],
+            "content": [],
+            "id": "1",
+            "props": {
+              "backgroundColor": "default",
+              "textAlignment": "left",
+              "textColor": "default",
+            },
+            "type": "paragraph",
+          },
+        ],
+        "content": undefined,
+        "id": "0",
+        "props": {
+          "width": 1,
+        },
+        "type": "column",
       },
     ],
-    "id": "column-paragraph-1",
-    "props": {
-      "backgroundColor": "default",
-      "textAlignment": "left",
-      "textColor": "default",
-    },
-    "type": "paragraph",
-  },
-  {
-    "children": [],
-    "content": [
-      {
-        "styles": {},
-        "text": "Column Paragraph 2",
-        "type": "text",
-      },
-    ],
-    "id": "column-paragraph-2",
-    "props": {
-      "backgroundColor": "default",
-      "textAlignment": "left",
-      "textColor": "default",
-    },
-    "type": "paragraph",
-  },
-  {
-    "children": [],
-    "content": [
-      {
-        "styles": {},
-        "text": "Column Paragraph 3",
-        "type": "text",
-      },
-    ],
-    "id": "column-paragraph-3",
-    "props": {
-      "backgroundColor": "default",
-      "textAlignment": "left",
-      "textColor": "default",
-    },
-    "type": "paragraph",
-  },
-  {
-    "children": [],
-    "content": [
-      {
-        "styles": {},
-        "text": "Column Paragraph 0",
-        "type": "text",
-      },
-    ],
-    "id": "column-paragraph-0",
-    "props": {
-      "backgroundColor": "default",
-      "textAlignment": "left",
-      "textColor": "default",
-    },
-    "type": "paragraph",
+    "content": undefined,
+    "id": "column-list-0",
+    "props": {},
+    "type": "columnList",
   },
   {
     "children": [],
@@ -2557,89 +2635,128 @@ exports[`Test moveBlocksUp > Selection starts in column, ends outside 1`] = `
     "type": "paragraph",
   },
   {
-    "children": [],
-    "content": [
+    "children": [
       {
-        "styles": {},
-        "text": "Column Paragraph 0",
-        "type": "text",
+        "children": [
+          {
+            "children": [],
+            "content": [
+              {
+                "styles": {},
+                "text": "Column Paragraph 0",
+                "type": "text",
+              },
+            ],
+            "id": "column-paragraph-0",
+            "props": {
+              "backgroundColor": "default",
+              "textAlignment": "left",
+              "textColor": "default",
+            },
+            "type": "paragraph",
+          },
+          {
+            "children": [],
+            "content": [
+              {
+                "styles": {},
+                "text": "Column Paragraph 1",
+                "type": "text",
+              },
+            ],
+            "id": "column-paragraph-1",
+            "props": {
+              "backgroundColor": "default",
+              "textAlignment": "left",
+              "textColor": "default",
+            },
+            "type": "paragraph",
+          },
+          {
+            "children": [],
+            "content": [
+              {
+                "styles": {},
+                "text": "Column Paragraph 2",
+                "type": "text",
+              },
+            ],
+            "id": "column-paragraph-2",
+            "props": {
+              "backgroundColor": "default",
+              "textAlignment": "left",
+              "textColor": "default",
+            },
+            "type": "paragraph",
+          },
+          {
+            "children": [],
+            "content": [
+              {
+                "styles": {},
+                "text": "Column Paragraph 3",
+                "type": "text",
+              },
+            ],
+            "id": "column-paragraph-3",
+            "props": {
+              "backgroundColor": "default",
+              "textAlignment": "left",
+              "textColor": "default",
+            },
+            "type": "paragraph",
+          },
+          {
+            "children": [],
+            "content": [
+              {
+                "styles": {},
+                "text": "Paragraph 2",
+                "type": "text",
+              },
+            ],
+            "id": "paragraph-2",
+            "props": {
+              "backgroundColor": "default",
+              "textAlignment": "left",
+              "textColor": "default",
+            },
+            "type": "paragraph",
+          },
+        ],
+        "content": undefined,
+        "id": "column-0",
+        "props": {
+          "width": 1,
+        },
+        "type": "column",
+      },
+      {
+        "children": [
+          {
+            "children": [],
+            "content": [],
+            "id": "0",
+            "props": {
+              "backgroundColor": "default",
+              "textAlignment": "left",
+              "textColor": "default",
+            },
+            "type": "paragraph",
+          },
+        ],
+        "content": undefined,
+        "id": "column-1",
+        "props": {
+          "width": 1,
+        },
+        "type": "column",
       },
     ],
-    "id": "column-paragraph-0",
-    "props": {
-      "backgroundColor": "default",
-      "textAlignment": "left",
-      "textColor": "default",
-    },
-    "type": "paragraph",
-  },
-  {
-    "children": [],
-    "content": [
-      {
-        "styles": {},
-        "text": "Column Paragraph 1",
-        "type": "text",
-      },
-    ],
-    "id": "column-paragraph-1",
-    "props": {
-      "backgroundColor": "default",
-      "textAlignment": "left",
-      "textColor": "default",
-    },
-    "type": "paragraph",
-  },
-  {
-    "children": [],
-    "content": [
-      {
-        "styles": {},
-        "text": "Column Paragraph 2",
-        "type": "text",
-      },
-    ],
-    "id": "column-paragraph-2",
-    "props": {
-      "backgroundColor": "default",
-      "textAlignment": "left",
-      "textColor": "default",
-    },
-    "type": "paragraph",
-  },
-  {
-    "children": [],
-    "content": [
-      {
-        "styles": {},
-        "text": "Column Paragraph 3",
-        "type": "text",
-      },
-    ],
-    "id": "column-paragraph-3",
-    "props": {
-      "backgroundColor": "default",
-      "textAlignment": "left",
-      "textColor": "default",
-    },
-    "type": "paragraph",
-  },
-  {
-    "children": [],
-    "content": [
-      {
-        "styles": {},
-        "text": "Paragraph 2",
-        "type": "text",
-      },
-    ],
-    "id": "paragraph-2",
-    "props": {
-      "backgroundColor": "default",
-      "textAlignment": "left",
-      "textColor": "default",
-    },
-    "type": "paragraph",
+    "content": undefined,
+    "id": "column-list-0",
+    "props": {},
+    "type": "columnList",
   },
 ]
 `;
@@ -2699,89 +2816,128 @@ exports[`Test moveBlocksUp > Selection starts in first column, ends outside 1`] 
     "type": "paragraph",
   },
   {
-    "children": [],
-    "content": [
+    "children": [
       {
-        "styles": {},
-        "text": "Column Paragraph 1",
-        "type": "text",
+        "children": [
+          {
+            "children": [],
+            "content": [
+              {
+                "styles": {},
+                "text": "Column Paragraph 1",
+                "type": "text",
+              },
+            ],
+            "id": "column-paragraph-1",
+            "props": {
+              "backgroundColor": "default",
+              "textAlignment": "left",
+              "textColor": "default",
+            },
+            "type": "paragraph",
+          },
+          {
+            "children": [],
+            "content": [
+              {
+                "styles": {},
+                "text": "Column Paragraph 2",
+                "type": "text",
+              },
+            ],
+            "id": "column-paragraph-2",
+            "props": {
+              "backgroundColor": "default",
+              "textAlignment": "left",
+              "textColor": "default",
+            },
+            "type": "paragraph",
+          },
+          {
+            "children": [],
+            "content": [
+              {
+                "styles": {},
+                "text": "Column Paragraph 3",
+                "type": "text",
+              },
+            ],
+            "id": "column-paragraph-3",
+            "props": {
+              "backgroundColor": "default",
+              "textAlignment": "left",
+              "textColor": "default",
+            },
+            "type": "paragraph",
+          },
+          {
+            "children": [],
+            "content": [
+              {
+                "styles": {},
+                "text": "Paragraph 2",
+                "type": "text",
+              },
+            ],
+            "id": "paragraph-2",
+            "props": {
+              "backgroundColor": "default",
+              "textAlignment": "left",
+              "textColor": "default",
+            },
+            "type": "paragraph",
+          },
+          {
+            "children": [],
+            "content": [
+              {
+                "styles": {},
+                "text": "Column Paragraph 0",
+                "type": "text",
+              },
+            ],
+            "id": "column-paragraph-0",
+            "props": {
+              "backgroundColor": "default",
+              "textAlignment": "left",
+              "textColor": "default",
+            },
+            "type": "paragraph",
+          },
+        ],
+        "content": undefined,
+        "id": "column-0",
+        "props": {
+          "width": 1,
+        },
+        "type": "column",
+      },
+      {
+        "children": [
+          {
+            "children": [],
+            "content": [],
+            "id": "1",
+            "props": {
+              "backgroundColor": "default",
+              "textAlignment": "left",
+              "textColor": "default",
+            },
+            "type": "paragraph",
+          },
+        ],
+        "content": undefined,
+        "id": "0",
+        "props": {
+          "width": 1,
+        },
+        "type": "column",
       },
     ],
-    "id": "column-paragraph-1",
-    "props": {
-      "backgroundColor": "default",
-      "textAlignment": "left",
-      "textColor": "default",
-    },
-    "type": "paragraph",
-  },
-  {
-    "children": [],
-    "content": [
-      {
-        "styles": {},
-        "text": "Column Paragraph 2",
-        "type": "text",
-      },
-    ],
-    "id": "column-paragraph-2",
-    "props": {
-      "backgroundColor": "default",
-      "textAlignment": "left",
-      "textColor": "default",
-    },
-    "type": "paragraph",
-  },
-  {
-    "children": [],
-    "content": [
-      {
-        "styles": {},
-        "text": "Column Paragraph 3",
-        "type": "text",
-      },
-    ],
-    "id": "column-paragraph-3",
-    "props": {
-      "backgroundColor": "default",
-      "textAlignment": "left",
-      "textColor": "default",
-    },
-    "type": "paragraph",
-  },
-  {
-    "children": [],
-    "content": [
-      {
-        "styles": {},
-        "text": "Paragraph 2",
-        "type": "text",
-      },
-    ],
-    "id": "paragraph-2",
-    "props": {
-      "backgroundColor": "default",
-      "textAlignment": "left",
-      "textColor": "default",
-    },
-    "type": "paragraph",
-  },
-  {
-    "children": [],
-    "content": [
-      {
-        "styles": {},
-        "text": "Column Paragraph 0",
-        "type": "text",
-      },
-    ],
-    "id": "column-paragraph-0",
-    "props": {
-      "backgroundColor": "default",
-      "textAlignment": "left",
-      "textColor": "default",
-    },
-    "type": "paragraph",
+    "content": undefined,
+    "id": "column-list-0",
+    "props": {},
+    "type": "columnList",
   },
 ]
 `;

--- a/packages/xl-multi-column/src/test/commands/__snapshots__/moveBlocks.test.ts.snap
+++ b/packages/xl-multi-column/src/test/commands/__snapshots__/moveBlocks.test.ts.snap
@@ -1,5 +1,183 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`Move past empty sibling within a column > Move down below empty sibling 1`] = `
+[
+  {
+    "children": [
+      {
+        "children": [
+          {
+            "children": [],
+            "content": [
+              {
+                "styles": {},
+                "text": "Text 0",
+                "type": "text",
+              },
+            ],
+            "id": "text-0",
+            "props": {
+              "backgroundColor": "default",
+              "textAlignment": "left",
+              "textColor": "default",
+            },
+            "type": "paragraph",
+          },
+          {
+            "children": [],
+            "content": [],
+            "id": "empty-0",
+            "props": {
+              "backgroundColor": "default",
+              "textAlignment": "left",
+              "textColor": "default",
+            },
+            "type": "paragraph",
+          },
+        ],
+        "content": undefined,
+        "id": "column-empty-0",
+        "props": {
+          "width": 1,
+        },
+        "type": "column",
+      },
+      {
+        "children": [
+          {
+            "children": [],
+            "content": [],
+            "id": "empty-1",
+            "props": {
+              "backgroundColor": "default",
+              "textAlignment": "left",
+              "textColor": "default",
+            },
+            "type": "paragraph",
+          },
+          {
+            "children": [],
+            "content": [
+              {
+                "styles": {},
+                "text": "Text 1",
+                "type": "text",
+              },
+            ],
+            "id": "text-1",
+            "props": {
+              "backgroundColor": "default",
+              "textAlignment": "left",
+              "textColor": "default",
+            },
+            "type": "paragraph",
+          },
+        ],
+        "content": undefined,
+        "id": "column-empty-1",
+        "props": {
+          "width": 1,
+        },
+        "type": "column",
+      },
+    ],
+    "content": undefined,
+    "id": "column-list-empty",
+    "props": {},
+    "type": "columnList",
+  },
+]
+`;
+
+exports[`Move past empty sibling within a column > Move up above empty sibling 1`] = `
+[
+  {
+    "children": [
+      {
+        "children": [
+          {
+            "children": [],
+            "content": [
+              {
+                "styles": {},
+                "text": "Text 0",
+                "type": "text",
+              },
+            ],
+            "id": "text-0",
+            "props": {
+              "backgroundColor": "default",
+              "textAlignment": "left",
+              "textColor": "default",
+            },
+            "type": "paragraph",
+          },
+          {
+            "children": [],
+            "content": [],
+            "id": "empty-0",
+            "props": {
+              "backgroundColor": "default",
+              "textAlignment": "left",
+              "textColor": "default",
+            },
+            "type": "paragraph",
+          },
+        ],
+        "content": undefined,
+        "id": "column-empty-0",
+        "props": {
+          "width": 1,
+        },
+        "type": "column",
+      },
+      {
+        "children": [
+          {
+            "children": [],
+            "content": [],
+            "id": "empty-1",
+            "props": {
+              "backgroundColor": "default",
+              "textAlignment": "left",
+              "textColor": "default",
+            },
+            "type": "paragraph",
+          },
+          {
+            "children": [],
+            "content": [
+              {
+                "styles": {},
+                "text": "Text 1",
+                "type": "text",
+              },
+            ],
+            "id": "text-1",
+            "props": {
+              "backgroundColor": "default",
+              "textAlignment": "left",
+              "textColor": "default",
+            },
+            "type": "paragraph",
+          },
+        ],
+        "content": undefined,
+        "id": "column-empty-1",
+        "props": {
+          "width": 1,
+        },
+        "type": "column",
+      },
+    ],
+    "content": undefined,
+    "id": "column-list-empty",
+    "props": {},
+    "type": "columnList",
+  },
+]
+`;
+
 exports[`Test moveBlocksDown > Move into column list 1`] = `
 [
   {

--- a/packages/xl-multi-column/src/test/commands/moveBlocks.test.ts
+++ b/packages/xl-multi-column/src/test/commands/moveBlocks.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vite-plus/test";
+import { beforeEach, describe, expect, it } from "vite-plus/test";
 
 import { setupTestEnv } from "../setupTestEnv.js";
 
@@ -147,6 +147,51 @@ describe("Test moveBlocksDown", () => {
     getEditor().setSelection("column-paragraph-1", "paragraph-2");
 
     getEditor().moveBlocksDown();
+
+    expect(getEditor().document).toMatchSnapshot();
+  });
+});
+
+describe("Move past empty sibling within a column", () => {
+  beforeEach(() => {
+    getEditor().replaceBlocks(getEditor().document, [
+      {
+        id: "column-list-empty",
+        type: "columnList",
+        children: [
+          {
+            id: "column-empty-0",
+            type: "column",
+            children: [
+              { id: "empty-0", type: "paragraph" },
+              { id: "text-0", type: "paragraph", content: "Text 0" },
+            ],
+          },
+          {
+            id: "column-empty-1",
+            type: "column",
+            children: [
+              { id: "empty-1", type: "paragraph" },
+              { id: "text-1", type: "paragraph", content: "Text 1" },
+            ],
+          },
+        ],
+      },
+    ]);
+  });
+
+  it("Move up above empty sibling", () => {
+    getEditor().setTextCursorPosition("text-0");
+
+    expect(() => getEditor().moveBlocksUp()).not.toThrow();
+
+    expect(getEditor().document).toMatchSnapshot();
+  });
+
+  it("Move down below empty sibling", () => {
+    getEditor().setTextCursorPosition("empty-0");
+
+    expect(() => getEditor().moveBlocksDown()).not.toThrow();
 
     expect(getEditor().document).toMatchSnapshot();
   });


### PR DESCRIPTION
# Summary

<!-- Briefly describe the feature being introduced. -->

This PR fixes an edge case when using `moveBlocks` with columns. `moveBlocks` first removes the target block(s), then inserts it/them above/below the previous/next block. In the removal step, `fixColumns` is called for all affected column lists, collapsing them or individual columns when they're empty.

This causes an error  in the following case:

```
<column>
  <paragraph></paragraph>
  <paragraph>Paragraph</paragraph>
</column>
```

When moving the non-empty paragraph block up, it's first removed. This leaves the column with a single empty paragraph, which `fixColumns` reads as an empty column, and so collapses it. Upon re-insertion, the reference block no longer exists and an error is thrown. This also happens when the order of the 2 blocks is flipped and the non-empty one is moved down.

After reviewing this, we have decided to change the behaviour of `moveBlocks` to not call `fixColumns`. If a column is left empty after a move, it's filled with an empty paragraph.

Closes #2594

## Rationale

<!-- Explain the reasoning behind this feature and its benefits to the project. -->

This is a bug, but also made us realize that we want to change the behaviour of `moveBlocks` to not remove empty columns altogether.

## Changes

<!-- List the major changes made in this pull request. -->

See above.

## Impact

<!-- Discuss any potential impacts this feature may have on existing functionalities. -->

N/A

## Testing

<!-- Describe how the feature has been tested, including both automated and manual testing strategies. -->

Added unit tests.

## Screenshots/Video

<!-- Include screenshots or video demonstrating the new feature, if applicable. -->

N/A

## Checklist

- [X] Code follows the project's coding standards.
- [X] Unit tests covering the new feature have been added.
- [X] All existing tests pass.
- [ ] The documentation has been updated to reflect the new feature

## Additional Notes

<!-- Any additional information or context relevant to this PR. -->

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability of block movement operations, ensuring moved blocks are removed and re-inserted reliably while maintaining surrounding layout structure.
  * Fixed edge cases for moving blocks within multi-column layouts, including scenarios involving empty sibling paragraphs.

* **Tests**
  * Added snapshot coverage for moving blocks up/down past empty siblings inside multi-column structures to prevent regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->