### PR TITLE
fix(xl-ai): remove 'use client' from server entry

### DIFF
--- a/packages/xl-ai/src/server.ts
+++ b/packages/xl-ai/src/server.ts
@@ -1,4 +1,3 @@
-"use client";
 // exports that are safe to use on server
 // for now, this is everything except
 // React components, hooks and AIExtension (because it uses @ai-sdk/react)


### PR DESCRIPTION
# Summary

The `@blocknote/xl-ai/server` entry was marked with a `"use client"` directive, which broke server-side usage.

## Rationale

`packages/xl-ai/src/server.ts` is the dedicated build entry for `@blocknote/xl-ai/server`. The `"use client"` directive at the top of the file was copied verbatim into the built `dist/server.js` and `dist/server.cjs`. As a result, frameworks like Next.js treated the entire server bundle as client-only, causing errors such as:

```
Attempted to call injectDocumentStateMessages() from the server but injectDocumentStateMessages is on the client.
```

The directive was misplaced — the server entry is meant for server use only, and its exports are server-safe.

## Changes

- Removed the `"use client";` directive from `packages/xl-ai/src/server.ts`.

## Impact

Server-side consumers (Next.js API routes, Node.js backends) can now import from `@blocknote/xl-ai/server` and use exports like `injectDocumentStateMessages` without errors.

Verified the rebuilt `dist/server.js`/`dist/server.cjs` no longer contain `"use client"`, and that no client-only deps (e.g. `@ai-sdk/react`) are pulled into the server bundle — the type-only imports are erased at build time.

## Testing

- Rebuilt the package and confirmed `"use client"` is gone from the server bundle and all exports remain intact.

## Checklist

- [x] Code follows the project's coding standards.
- [ ] Unit tests covering the new feature have been added.
- [x] All existing tests pass.
- [ ] The documentation has been updated to reflect the new feature

Closes #2841

🤖 Generated with [Claude Code](https://claude.com/claude-code)