### PR TITLE
fix(xl-pdf-exporter): fix emoji rendering for ZWJ sequences in PDF export

### DIFF
--- a/packages/xl-pdf-exporter/src/pdf/pdfExporter.tsx
+++ b/packages/xl-pdf-exporter/src/pdf/pdfExporter.tsx
@@ -32,7 +32,7 @@ const PIXELS_PER_POINT = 0.75;
 type Options = ExporterOptions & {
   /**
    *
-   * @default uses the remote emoji source hosted on cloudflare (https://cdnjs.cloudflare.com/ajax/libs/twemoji/14.0.2/72x72/)
+   * @default uses Twemoji images from jdecked/twemoji on jsDelivr CDN
    */
   emojiSource: false | ReturnType<typeof Font.getEmojiSource>;
 };
@@ -97,8 +97,15 @@ export class PDFExporter<
   ) {
     const defaults = {
       emojiSource: {
-        format: "png",
-        url: "https://cdnjs.cloudflare.com/ajax/libs/twemoji/14.0.2/72x72/",
+        builder: (code: string) => {
+          // Twemoji filenames include fe0f in ZWJ sequences but not in
+          // standalone emojis, so strip it only when there's no ZWJ (200d).
+          const resolved = code.includes("200d")
+            ? code
+            : code.replace(/-fe0f/g, "");
+          return `https://cdn.jsdelivr.net/gh/jdecked/twemoji@v17.0.3/assets/72x72/${resolved}.png`;
+        },
+        withVariationSelectors: true,
       },
       resolveFileUrl: corsProxyResolveFileUrl,
       colors: COLORS_DEFAULT,


### PR DESCRIPTION
# Summary

Fix PDF export failures for emojis that use ZWJ (Zero Width Joiner) sequences, such as 🚶‍♀️ and 🏃‍♀️.

Fixes #1978

## Rationale

The PDF exporter used `@react-pdf/renderer`'s `Font.registerEmojiSource()` with a simple URL pointing to the archived Twemoji 14.0.2 CDN. React-pdf strips variation selectors (U+FE0F) from emoji codepoints by default, but Twemoji filenames for ZWJ sequences require `fe0f` — causing 404s when fetching emoji images during export.

## Changes

- Switched from a URL-based emoji source to a `builder` function with `withVariationSelectors: true`, which correctly preserves `fe0f` in ZWJ sequences while stripping it for standalone emojis (matching Twemoji's naming convention).
- Updated CDN from the archived Twemoji 14.0.2 on cdnjs to `jdecked/twemoji` v17.0.3 on jsDelivr — the actively maintained fork with Unicode 16 support.

## Impact

- Users who override `emojiSource` with their own config are unaffected.
- Default emoji rendering switches from Twemoji 14.0.2 to 17.0.3 (same art style, broader coverage).

## Testing

- All 7 existing `xl-pdf-exporter` tests pass.
- Verified CDN availability for affected emojis (🚶‍♀️, 🏃‍♀️, ❤️, ❤️‍🔥, 👨‍👩‍👧) with both the old and new URL construction logic.

## Checklist

- [x] Code follows the project's coding standards.
- [ ] Unit tests covering the new feature have been added.
- [x] All existing tests pass.
- [ ] The documentation has been updated to reflect the new feature

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the default emoji image source used in PDF exports to a newer Twemoji CDN-backed setup.
  * Improved emoji URL handling so exported PDFs render emoji more consistently, including support for variation selectors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->