### PR TITLE
fix: skip input rules on the Enter that confirms an IME composition

### DIFF
--- a/packages/core/src/editor/managers/ExtensionManager/index.ts
+++ b/packages/core/src/editor/managers/ExtensionManager/index.ts
@@ -385,6 +385,13 @@ export class ExtensionManager {
                 if (event.key !== "Enter") {
                   return false;
                 }
+                // The Enter that confirms an IME composition also fires a
+                // keydown here, so skip it to avoid running input rules in
+                // the middle of a composition. Mirrors the isComposing guard
+                // used by the editor's other Enter handlers.
+                if (event.isComposing) {
+                  return false;
+                }
                 // Only trigger on plain Enter — modifier combos like
                 // Shift/Cmd/Ctrl/Alt+Enter are reserved for other handlers
                 // (e.g. soft-break, submit) and should fall through.


### PR DESCRIPTION
# Summary

The input-rules-on-Enter handler in `ExtensionManager` does not check `event.isComposing`, so it also runs on the Enter that confirms an IME composition. This adds the same guard the editor's other Enter handlers already use.

## Rationale

`blocknote-input-rules` registers a sidecar ProseMirror plugin (`inputRulesEnter`) whose `handleKeyDown` delegates to the input-rules plugin with a synthetic `"\n"`, so that any rule whose regex matches `\s$` also fires on Enter (as the comment in that file explains).

On the Enter that commits an IME composition (for example, selecting a kanji candidate after typing hiragana), the browser fires a `keydown` with `isComposing === true` (`keyCode` 229). That event has `key === "Enter"` and no modifiers, so it currently reaches `handleTextInput`. If the committed text before the cursor matches an input rule, the rule fires in the middle of the composition and the handler returns `true`, which calls `preventDefault` and disrupts the commit.

Example: type `#` (no trailing space), switch to a Japanese IME, type some hiragana, then press Enter to confirm a candidate. The `#` plus the synthetic `"\n"` matches the heading rule, so the block is turned into a heading and the Enter is swallowed instead of confirming the composition.

The editor's other Enter handlers already guard against this. The closest one is the sibling ProseMirror `handleKeyDown` in `NodeSelectionKeyboard` (`packages/core/src/extensions/NodeSelectionKeyboard/NodeSelectionKeyboard.ts`), which checks `event.key === "Enter" && !event.isComposing`. The React-side handlers (`EditLinkMenuItems`, `FileRenameButton`, `FileCaptionButton`, `EmbedTab`, and the suggestion-menu handlers) use the same `isComposing` check via `nativeEvent`.

## Changes

- `packages/core/src/editor/managers/ExtensionManager/index.ts`: return early from `inputRulesEnter`'s `handleKeyDown` when `event.isComposing` is true, so input rules are not run on the composition-commit Enter.

## Impact

- A normal Enter is unchanged: `isComposing` is `false`, so the handler runs the input rules exactly as before.
- The composition-commit Enter now falls through to confirm the composition instead of triggering an input rule.
- No public API change. One guard, consistent with the existing handlers.

## Testing

- Verified by reading the code in both directions. With the guard removed (current `main`), a composition-commit Enter (`isComposing === true`) reaches `handleTextInput`, and per the existing `\s$` design a committed prefix such as `#` matches the heading rule and returns `true`, preventing the commit. With the guard, that path returns early and the composition confirms.
- A normal Enter (`isComposing === false`) takes the identical path as before, so the existing input-rule unit tests are unaffected. I did not run the full local suite for this change.

## Checklist

- [x] Code follows the project's coding standards.
- [ ] Unit tests covering the new feature have been added.
- [ ] All existing tests pass.
- [ ] The documentation has been updated to reflect the new feature

## Additional Notes

This mirrors the convention used across the other Enter handlers; the cited sibling is `NodeSelectionKeyboard`. Happy to add a unit test that dispatches a `keydown` with `isComposing` set if that would help.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Enter key behavior during IME text composition now avoids triggering input rules, preventing unintended actions while typing with an input method editor.
  - Plain Enter and modifier-key handling remains unchanged outside of composition mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->