### PR TITLE
fix(xl-pdf-exporter): Keep image aspect ratio, page fit fixes

### DIFF
--- a/packages/xl-pdf-exporter/src/pdf/__snapshots__/example.jsx
+++ b/packages/xl-pdf-exporter/src/pdf/__snapshots__/example.jsx
@@ -650,12 +650,17 @@
           <IMAGE
             src={[object Blob]}
             style={{
+              maxHeight: 722.99,
+              maxWidth: '100%',
+              objectFit: 'contain',
+              objectPosition: '0% 0%',
               width: undefined
             }}
           />
           <TEXT
             style={{
               fontSize: 9.600000000000001,
+              maxWidth: '100%',
               width: undefined
             }}
           >
@@ -678,6 +683,10 @@
           <IMAGE
             src={[object Blob]}
             style={{
+              maxHeight: 737.39,
+              maxWidth: '100%',
+              objectFit: 'contain',
+              objectPosition: '100% 0%',
               width: 150
             }}
           />
@@ -719,6 +728,7 @@
           <TEXT
             style={{
               fontSize: 9.600000000000001,
+              maxWidth: '100%',
               width: undefined
             }}
           >
@@ -762,6 +772,7 @@
           <TEXT
             style={{
               fontSize: 9.600000000000001,
+              maxWidth: '100%',
               width: undefined
             }}
           >
@@ -818,6 +829,7 @@
           <TEXT
             style={{
               fontSize: 9.600000000000001,
+              maxWidth: '100%',
               width: undefined
             }}
           >

--- a/packages/xl-pdf-exporter/src/pdf/__snapshots__/exampleWithAlignedImages.jsx
+++ b/packages/xl-pdf-exporter/src/pdf/__snapshots__/exampleWithAlignedImages.jsx
@@ -1,0 +1,87 @@
+<DOCUMENT>
+  <PAGE
+    dpi={100}
+    size="A4"
+    style={{
+      fontFamily: 'Inter',
+      fontSize: 12,
+      lineHeight: 1.5,
+      paddingBottom: 65,
+      paddingHorizontal: 35,
+      paddingTop: 35
+    }}
+  >
+    <React.Fragment key=".1:$">
+      <VIEW
+        style={{
+          alignItems: undefined,
+          backgroundColor: undefined,
+          color: undefined,
+          paddingVertical: 2.25,
+          textAlign: 'left'
+        }}
+      >
+        <VIEW>
+          <IMAGE
+            src={[object Blob]}
+            style={{
+              maxHeight: 737.39,
+              maxWidth: '100%',
+              objectFit: 'contain',
+              objectPosition: '0% 0%',
+              width: 1500
+            }}
+          />
+        </VIEW>
+      </VIEW>
+    </React.Fragment>
+    <React.Fragment key=".1:$">
+      <VIEW
+        style={{
+          alignItems: 'center',
+          backgroundColor: undefined,
+          color: undefined,
+          paddingVertical: 2.25,
+          textAlign: 'center'
+        }}
+      >
+        <VIEW>
+          <IMAGE
+            src={[object Blob]}
+            style={{
+              maxHeight: 737.39,
+              maxWidth: '100%',
+              objectFit: 'contain',
+              objectPosition: '50% 0%',
+              width: 1500
+            }}
+          />
+        </VIEW>
+      </VIEW>
+    </React.Fragment>
+    <React.Fragment key=".1:$">
+      <VIEW
+        style={{
+          alignItems: 'flex-end',
+          backgroundColor: undefined,
+          color: undefined,
+          paddingVertical: 2.25,
+          textAlign: 'right'
+        }}
+      >
+        <VIEW>
+          <IMAGE
+            src={[object Blob]}
+            style={{
+              maxHeight: 737.39,
+              maxWidth: '100%',
+              objectFit: 'contain',
+              objectPosition: '100% 0%',
+              width: 1500
+            }}
+          />
+        </VIEW>
+      </VIEW>
+    </React.Fragment>
+  </PAGE>
+</DOCUMENT>

--- a/packages/xl-pdf-exporter/src/pdf/__snapshots__/exampleWithHeaderAndFooter.jsx
+++ b/packages/xl-pdf-exporter/src/pdf/__snapshots__/exampleWithHeaderAndFooter.jsx
@@ -658,12 +658,17 @@
           <IMAGE
             src={[object Blob]}
             style={{
+              maxHeight: 722.99,
+              maxWidth: '100%',
+              objectFit: 'contain',
+              objectPosition: '0% 0%',
               width: undefined
             }}
           />
           <TEXT
             style={{
               fontSize: 9.600000000000001,
+              maxWidth: '100%',
               width: undefined
             }}
           >
@@ -686,6 +691,10 @@
           <IMAGE
             src={[object Blob]}
             style={{
+              maxHeight: 737.39,
+              maxWidth: '100%',
+              objectFit: 'contain',
+              objectPosition: '100% 0%',
               width: 150
             }}
           />
@@ -727,6 +736,7 @@
           <TEXT
             style={{
               fontSize: 9.600000000000001,
+              maxWidth: '100%',
               width: undefined
             }}
           >
@@ -770,6 +780,7 @@
           <TEXT
             style={{
               fontSize: 9.600000000000001,
+              maxWidth: '100%',
               width: undefined
             }}
           >
@@ -826,6 +837,7 @@
           <TEXT
             style={{
               fontSize: 9.600000000000001,
+              maxWidth: '100%',
               width: undefined
             }}
           >

--- a/packages/xl-pdf-exporter/src/pdf/defaultSchema/blocks.tsx
+++ b/packages/xl-pdf-exporter/src/pdf/defaultSchema/blocks.tsx
@@ -15,9 +15,16 @@ import {
   ListItem,
 } from "../util/listItem.js";
 import { Table } from "../util/table/Table.js";
+import { Style } from "../types.js";
+import {
+  BLOCK_VERTICAL_PADDING,
+  PAGE_HEIGHT,
+  type PDFExporter,
+} from "../pdfExporter.js";
 
 const PIXELS_PER_POINT = 0.75;
 const FONT_SIZE = 16;
+const CAPTION_FONT_SIZE = FONT_SIZE * 0.8 * PIXELS_PER_POINT;
 
 export const pdfBlockMappingForDefaultSchema: BlockMapping<
   DefaultBlockSchema & {
@@ -237,11 +244,7 @@ export const pdfBlockMappingForDefaultSchema: BlockMapping<
       <View wrap={false} key={"image" + block.id}>
         <Image
           src={await t.resolveFile(block.props.url)}
-          style={{
-            width: block.props.previewWidth
-              ? block.props.previewWidth * PIXELS_PER_POINT
-              : undefined,
-          }}
+          style={imageStyle(block.props, t)}
         />
         {caption(block.props, t)}
       </View>
@@ -277,6 +280,54 @@ function file(
   );
 }
 
+function previewWidthToPoints(
+  props: Partial<DefaultProps & { previewWidth: number }>,
+): number | undefined {
+  return props.previewWidth ? props.previewWidth * PIXELS_PER_POINT : undefined;
+}
+
+// Style values can also be strings ("10pt", "5%"); the page styles set in
+// `PDFExporter` are plain numbers, so treat anything else as the fallback.
+function points(value: number | string | undefined, fallback: number): number {
+  return typeof value === "number" ? value : fallback;
+}
+
+function imageStyle(
+  props: Partial<DefaultProps & { caption: string; previewWidth: number }>,
+  exporter: any,
+): Style {
+  const page: Style =
+    (exporter as PDFExporter<any, any, any>).styles?.page ?? {};
+  return {
+    width: previewWidthToPoints(props),
+    maxWidth: "100%",
+    // Images can't break across pages, so cap the box to the usable page
+    // height (accounting for the padding `transformBlocks` adds around every
+    // block); a taller box would spill an empty page after the bitmap. If
+    // there's a caption, also reserve one line for it. Known limitations:
+    // captions long enough to wrap, and headers passed to
+    // `toReactPDFDocument` (which take flow height on every page), can still
+    // make the unbreakable image group spill.
+    maxHeight:
+      PAGE_HEIGHT -
+      points(page.paddingTop, 0) -
+      points(page.paddingBottom, 0) -
+      2 * BLOCK_VERTICAL_PADDING -
+      (props.caption ? CAPTION_FONT_SIZE * points(page.lineHeight, 1.5) : 0),
+    // `contain` leaves slack inside the box when it's clamped by `maxWidth`
+    // or `maxHeight`, so pin the bitmap to the block's alignment edge. The
+    // box itself is aligned by `blocknoteDefaultPropsToReactPDFStyle` on the
+    // wrapper.
+    objectFit: "contain",
+    objectPosition:
+      props.textAlignment === "right"
+        ? "100% 0%"
+        : props.textAlignment === "center"
+          ? "50% 0%"
+          : "0% 0%",
+  };
+}
+
 function caption(
   props: Partial<DefaultProps & { caption: string; previewWidth: number }>,
   _exporter: any,
@@ -288,10 +339,9 @@ function caption(
     <Text
       key={"caption" + props.caption}
       style={{
-        width: props.previewWidth
-          ? props.previewWidth * PIXELS_PER_POINT
-          : undefined,
-        fontSize: FONT_SIZE * 0.8 * PIXELS_PER_POINT,
+        width: previewWidthToPoints(props),
+        maxWidth: "100%",
+        fontSize: CAPTION_FONT_SIZE,
       }}
     >
       {props.caption}

--- a/packages/xl-pdf-exporter/src/pdf/pdfExporter.test.tsx
+++ b/packages/xl-pdf-exporter/src/pdf/pdfExporter.test.tsx
@@ -9,8 +9,9 @@ import {
   defaultStyleSpecs,
 } from "@blocknote/core";
 import { ColumnBlock, ColumnListBlock } from "@blocknote/xl-multi-column";
-import { Text } from "@react-pdf/renderer";
+import { renderToBuffer, Text } from "@react-pdf/renderer";
 import { testDocument } from "@shared/testDocument.js";
+import { testResolveFileUrl } from "@shared/util/testFileResolver.js";
 import reactElementToJSXString from "react-element-to-jsx-string";
 import { describe, expect, it } from "vite-plus/test";
 import { pdfDefaultSchemaMappings } from "./defaultSchema/index.js";
@@ -224,6 +225,95 @@ describe("exporter", () => {
     //   `${__dirname}/exampleWithHeaderAndFooter.pdf`
     // );
   });
+  it("should keep image alignment when the image box is clamped", async () => {
+    // `objectPosition` must follow `textAlignment`, otherwise images with
+    // slack in their box (`objectFit: "contain"` + `maxWidth` clamp) would
+    // always be pinned to the left edge.
+    const schema = BlockNoteSchema.create();
+    const exporter = new PDFExporter(schema, pdfDefaultSchemaMappings, {
+      resolveFileUrl: testResolveFileUrl,
+    });
+    const transformed = await exporter.toReactPDFDocument(
+      partialBlocksToBlocksForTesting(schema, [
+        {
+          type: "image",
+          props: {
+            url: "https://placehold.co/332x322.jpg",
+            // Wider than the page, so `maxWidth: 100%` clamps the box.
+            previewWidth: 2000,
+            textAlignment: "left",
+          },
+        },
+        {
+          type: "image",
+          props: {
+            url: "https://placehold.co/332x322.jpg",
+            previewWidth: 2000,
+            textAlignment: "center",
+          },
+        },
+        {
+          type: "image",
+          props: {
+            url: "https://placehold.co/332x322.jpg",
+            previewWidth: 2000,
+            textAlignment: "right",
+          },
+        },
+      ]),
+    );
+    const str = reactElementToJSXString(transformed);
+
+    await expect(str).toMatchFileSnapshot(
+      "__snapshots__/exampleWithAlignedImages.jsx",
+    );
+  });
+
+  it("should scale an image taller than the page instead of spilling a blank page", async () => {
+    // The image box's height comes from the bitmap's aspect ratio, and images
+    // can't break across pages, so without a `maxHeight` cap a too-tall box
+    // spills an empty trailing page.
+    const schema = BlockNoteSchema.create();
+    const exporter = new PDFExporter(schema, pdfDefaultSchemaMappings, {
+      resolveFileUrl: testResolveFileUrl,
+    });
+    const transformed = await exporter.toReactPDFDocument(
+      partialBlocksToBlocksForTesting(schema, [
+        {
+          type: "image",
+          props: { url: "https://placehold.co/400x800.jpg", previewWidth: 600 },
+        },
+      ]),
+    );
+    const pdf = (await renderToBuffer(transformed as any)).toString("latin1");
+
+    expect(pdf.match(/\/Type\s*\/Page[^s]/g)).toHaveLength(1);
+  });
+
+  it("should keep a page-height image and its caption on one page", async () => {
+    // A caption is rendered inside the same unbreakable group as the image,
+    // so the height cap must reserve a line for it.
+    const schema = BlockNoteSchema.create();
+    const exporter = new PDFExporter(schema, pdfDefaultSchemaMappings, {
+      resolveFileUrl: testResolveFileUrl,
+    });
+    const transformed = await exporter.toReactPDFDocument(
+      partialBlocksToBlocksForTesting(schema, [
+        {
+          type: "image",
+          props: {
+            url: "https://placehold.co/400x800.jpg",
+            previewWidth: 600,
+            caption: "A tall image",
+          },
+        },
+      ]),
+    );
+    const pdf = (await renderToBuffer(transformed as any)).toString("latin1");
+
+    expect(pdf.match(/\/Type\s*\/Page[^s]/g)).toHaveLength(1);
+  });
+
   it("should export a document with a multi-column block", async () => {
     const schema = BlockNoteSchema.create({
       blockSpecs: {

--- a/packages/xl-pdf-exporter/src/pdf/pdfExporter.tsx
+++ b/packages/xl-pdf-exporter/src/pdf/pdfExporter.tsx
@@ -29,6 +29,12 @@ import { Style } from "./types.js";
 const FONT_SIZE = 16;
 const PIXELS_PER_POINT = 0.75;
 
+// Height in points of the page rendered by `toReactPDFDocument`; keep in sync
+// with the `<Page size="A4">` element there.
+export const PAGE_HEIGHT = 841.89;
+// Vertical padding `transformBlocks` adds around every block.
+export const BLOCK_VERTICAL_PADDING = 3 * PIXELS_PER_POINT;
+
 type Options = ExporterOptions & {
   /**
    *
@@ -159,7 +165,7 @@ export class PDFExporter<
         <Fragment key={b.id}>
           <View
             style={{
-              paddingVertical: 3 * PIXELS_PER_POINT,
+              paddingVertical: BLOCK_VERTICAL_PADDING,
               ...this.styles.block,
               ...style,
             }}

--- a/shared/util/testFileResolver.ts
+++ b/shared/util/testFileResolver.ts
@@ -8,11 +8,11 @@
  * environments without outbound network access (`TypeError: fetch failed`).
  *
  * To keep the tests deterministic and network-independent, this module returns
- * a tiny in-memory JPEG with the exact same dimensions as the remote image
- * (332x322). Preserving the dimensions is important: the exported snapshots
- * embed the image size (e.g. `cx="3162300" cy="3067050"` = 332x322 * 9525
- * EMU/px), so any substitute must report identical dimensions to avoid
- * breaking existing snapshots.
+ * a tiny in-memory JPEG with the exact dimensions requested in the URL.
+ * Preserving the dimensions is important: the exported snapshots embed the
+ * image size (e.g. `cx="3162300" cy="3067050"` = 332x322 * 9525 EMU/px), so
+ * any substitute must report identical dimensions to avoid breaking existing
+ * snapshots.
  */
 
 // A minimal valid baseline JPEG whose SOF0 marker declares a 332x322 image.
@@ -37,18 +37,57 @@ function base64ToArrayBuffer(base64: string): ArrayBuffer {
 
 /**
  * A {@link ExporterOptions.resolveFileUrl} implementation for tests that avoids
- * any network access. It returns a local 332x322 JPEG blob for the placeholder
- * image URL used in `testDocument`, and falls back to fetching for any other
- * URL.
+ * any network access. It returns a local JPEG blob for placehold.co URLs,
+ * reporting the exact dimensions requested in the URL (`.../<width>x<height>`)
+ * by patching them into the placeholder's SOF0 marker. It falls back to
+ * fetching for any other URL.
  */
 export async function testResolveFileUrl(url: string): Promise<string | Blob> {
   if (url.includes("placehold.co")) {
-    return new Blob([base64ToArrayBuffer(PLACEHOLDER_332x322_JPEG_BASE64)], {
-      type: "image/jpeg",
-    });
+    const bytes = new Uint8Array(
+      base64ToArrayBuffer(PLACEHOLDER_332x322_JPEG_BASE64),
+    );
+    // URLs of the form `.../<width>x<height>` get the requested dimensions
+    // patched in; any other placehold.co URL keeps the original 332x322 so it
+    // still never touches the network.
+    const dimensions = url.match(/placehold\.co\/(\d+)x(\d+)/);
+    if (dimensions) {
+      patchJpegDimensions(
+        bytes,
+        parseInt(dimensions[1]),
+        parseInt(dimensions[2]),
+      );
+    }
+    return new Blob([bytes], { type: "image/jpeg" });
   }
 
   // For any non-image/unknown URL, return it unchanged so the caller can fetch
   // it. In practice exporter tests only resolve the placeholder image above.
   return url;
+}
+
+/**
+ * Writes the given dimensions into the JPEG's SOF0 segment. The SOF0 segment
+ * (FF C0) stores height and width as big-endian u16 at offsets 5 and 7 after
+ * the marker.
+ */
+function patchJpegDimensions(bytes: Uint8Array, width: number, height: number) {
+  if (width > 0xffff || height > 0xffff) {
+    throw new Error(
+      `JPEG dimensions must fit in a u16, got ${width}x${height}`,
+    );
+  }
+  for (let i = 0; i < bytes.length - 8; i++) {
+    if (bytes[i] === 0xff && bytes[i + 1] === 0xc0) {
+      bytes[i + 5] = height >> 8;
+      bytes[i + 6] = height & 0xff;
+      bytes[i + 7] = width >> 8;
+      bytes[i + 8] = width & 0xff;
+      return;
+    }
+  }
+  // Fail loudly: silently returning the unpatched 332x322 image would make
+  // dimension-dependent snapshots fail (or pass with wrong data) far away
+  // from this file.
+  throw new Error("No SOF0 (FF C0) marker found in the placeholder JPEG");
 }


### PR DESCRIPTION
Disclaimer: AI code, tested by a human, PR by a human.

# Summary

This PR modifies image handling in the pdf export so aspect ratios are preserved and no unnecessary whitespace is created.

## Rationale

Currently, images get squished, lose their resolution, or otherwise can get malformed in a pdf export. See https://github.com/TypeCellOS/BlockNote/issues/2866

## Changes

- Clamp image box height 
- Preserve aspect ratio
- Handle captions
- add basic tests

## Impact

Exported PDF documents might look slightly different. I have not found any real problematic side effects yet in my testing.

## Testing

Added automated tests. Also tested manually with images of different sizes and locations.
## Screenshots/Video


[after.pdf](https://github.com/user-attachments/files/29434826/after.pdf)
[before.pdf](https://github.com/user-attachments/files/29434827/before.pdf)

## Checklist

- [?] Code follows the project's coding standards.
- [x] Unit tests covering the new feature have been added.
- [ ] All existing tests pass. **Some regression seemingly elsewhere on my PC*
- [ ] The documentation has been updated to reflect the new feature

## Additional Notes

Fixes https://github.com/TypeCellOS/BlockNote/issues/2866

Tests now patch the jpeg sizes. Not ideal but seems to work fine. AI code might not fully match your expected code style so if you wish to use the changes in a separate commit, feel free to.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * PDF exports now handle images and captions more consistently, including better sizing, alignment, and page-fit behavior.
  * Tall images are now kept within a single page when possible, improving document layout.

* **Bug Fixes**
  * Fixed image rendering so images no longer overflow or leave extra blank pages in PDF output.
  * Improved placeholder image handling in tests to match requested dimensions more accurately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->