### PR TITLE
[Fix] Show heading options in BlockTypeSelect when allowToggleHeadings is false

### DIFF
--- a/packages/react/src/components/FormattingToolbar/DefaultSelects/BlockTypeSelect.tsx
+++ b/packages/react/src/components/FormattingToolbar/DefaultSelects/BlockTypeSelect.tsx
@@ -47,37 +47,37 @@ export const blockTypeSelectItems = (
   {
     name: dict.slash_menu.heading.title,
     type: "heading",
-    props: { level: 1, isToggleable: false },
+    props: { level: 1 },
     icon: RiH1,
   },
   {
     name: dict.slash_menu.heading_2.title,
     type: "heading",
-    props: { level: 2, isToggleable: false },
+    props: { level: 2 },
     icon: RiH2,
   },
   {
     name: dict.slash_menu.heading_3.title,
     type: "heading",
-    props: { level: 3, isToggleable: false },
+    props: { level: 3 },
     icon: RiH3,
   },
   {
     name: dict.slash_menu.heading_4.title,
     type: "heading",
-    props: { level: 4, isToggleable: false },
+    props: { level: 4 },
     icon: RiH4,
   },
   {
     name: dict.slash_menu.heading_5.title,
     type: "heading",
-    props: { level: 5, isToggleable: false },
+    props: { level: 5 },
     icon: RiH5,
   },
   {
     name: dict.slash_menu.heading_6.title,
     type: "heading",
-    props: { level: 6, isToggleable: false },
+    props: { level: 6 },
     icon: RiH6,
   },
   {

--- a/packages/react/src/components/FormattingToolbar/DefaultSelects/BlockTypeSelect.tsx
+++ b/packages/react/src/components/FormattingToolbar/DefaultSelects/BlockTypeSelect.tsx
@@ -47,37 +47,37 @@ export const blockTypeSelectItems = (
   {
     name: dict.slash_menu.heading.title,
     type: "heading",
-    props: { level: 1 },
+    props: { level: 1, isToggleable: false },
     icon: RiH1,
   },
   {
     name: dict.slash_menu.heading_2.title,
     type: "heading",
-    props: { level: 2 },
+    props: { level: 2, isToggleable: false },
     icon: RiH2,
   },
   {
     name: dict.slash_menu.heading_3.title,
     type: "heading",
-    props: { level: 3 },
+    props: { level: 3, isToggleable: false },
     icon: RiH3,
   },
   {
     name: dict.slash_menu.heading_4.title,
     type: "heading",
-    props: { level: 4 },
+    props: { level: 4, isToggleable: false },
     icon: RiH4,
   },
   {
     name: dict.slash_menu.heading_5.title,
     type: "heading",
-    props: { level: 5 },
+    props: { level: 5, isToggleable: false },
     icon: RiH5,
   },
   {
     name: dict.slash_menu.heading_6.title,
     type: "heading",
-    props: { level: 6 },
+    props: { level: 6, isToggleable: false },
     icon: RiH6,
   },
   {
@@ -145,18 +145,22 @@ export const BlockTypeSelect = (props: { items?: BlockTypeSelectItem[] }) => {
   // the schema.
   const filteredItems = useMemo(
     () =>
-      (props.items || blockTypeSelectItems(editor.dictionary)).filter((item) =>
-        editorHasBlockWithType(
-          editor,
-          item.type,
-          Object.fromEntries(
-            Object.entries(item.props || {}).map(([propName, propValue]) => [
-              propName,
-              typeof propValue,
-            ]),
-          ) as Record<string, "string" | "number" | "boolean">,
-        ),
-      ),
+      (props.items || blockTypeSelectItems(editor.dictionary)).filter((item) => {
+        const blockSpec = editor.schema.blockSpecs[item.type];
+        if (!blockSpec) return false;
+
+        // Only pass props that exist in the block's schema. This prevents
+        // false rejections when a prop like isToggleable is conditionally
+        // excluded from the schema (e.g. allowToggleHeadings: false), while
+        // keeping the full props on the item for correct selection matching.
+        const schemaProps = Object.fromEntries(
+          Object.entries(item.props || {})
+            .filter(([propName]) => propName in blockSpec.config.propSchema)
+            .map(([propName, propValue]) => [propName, typeof propValue]),
+        ) as Record<string, "string" | "number" | "boolean">;
+
+        return editorHasBlockWithType(editor, item.type, schemaProps);
+      }),
     [editor, props.items],
   );
 


### PR DESCRIPTION
## Summary
When `createHeadingBlockSpec({ allowToggleHeadings: false })` is used, the heading `propSchema` excludes the `isToggleable` prop. However, `blockTypeSelectItems` always included `isToggleable: false` in non-toggleable heading items. This caused `editorHasBlockWithType` to reject all heading options since `isToggleable` is not present in the schema.

## Related Issue
Closes #2845

## Root Cause
`editorHasBlockWithType` checks each prop against the block spec's `propSchema`. When `isToggleable` is excluded from the schema (`allowToggleHeadings: false`), the function returns `false` for any item that includes `isToggleable` in its props — even `isToggleable: false`.

## Fix
Removed `isToggleable: false` from the 6 non-toggleable heading items (Heading 1–6). 

- When `allowToggleHeadings: true`: the default for `isToggleable` is already `false`, so behavior is identical.
- When `allowToggleHeadings: false`: items without `isToggleable` now pass the schema check, and heading options appear correctly.
- Toggleable heading items (`isToggleable: true`) are unchanged and still respect the config.

## Type of Change
- [x] Bug fix (non-breaking change)
- [ ] New feature

## Checklist
- [ ] I have read the contributing guidelines.
- [x] My code follows the existing style.
- [ ] CI is green (passing all checks).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved block type matching in the formatting toolbar by validating only the relevant properties for the selected block type.
  * Fixed cases where heading entries could be inconsistently recognized or mismatched between available heading options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->