### PR TITLE
fix(core): handle backspace on Android IMEs that send no key events

### DIFF
--- a/packages/core/src/extensions/tiptap-extensions/KeyboardShortcuts/KeyboardShortcutsExtension.test.ts
+++ b/packages/core/src/extensions/tiptap-extensions/KeyboardShortcuts/KeyboardShortcutsExtension.test.ts
@@ -1,0 +1,112 @@
+import { afterAll, beforeAll, describe, expect, it } from "vite-plus/test";
+
+import { PartialBlock } from "../../../blocks/defaultBlocks.js";
+import { BlockNoteEditor } from "../../../editor/BlockNoteEditor.js";
+
+/**
+ * Android virtual keyboards don't dispatch regular `Backspace` key events
+ * (they use keyCode 229), so backspace presses only surface as `beforeinput`
+ * events with the `deleteContentBackward` input type. These tests simulate
+ * that by dispatching such events without a preceding `Backspace` key event.
+ */
+function setupTestEnv() {
+  let editor: BlockNoteEditor;
+  const div = document.createElement("div");
+
+  beforeAll(() => {
+    editor = BlockNoteEditor.create();
+    editor.mount(div);
+  });
+
+  afterAll(() => {
+    editor._tiptapEditor.destroy();
+    editor = undefined as any;
+  });
+
+  return (doc: PartialBlock[]) => {
+    editor.replaceBlocks(editor.document, doc);
+    return editor;
+  };
+}
+
+const withEditor = setupTestEnv();
+
+function dispatchDeleteContentBackward(editor: BlockNoteEditor) {
+  const event = new InputEvent("beforeinput", {
+    inputType: "deleteContentBackward",
+    bubbles: true,
+    cancelable: true,
+  });
+  editor.prosemirrorView!.dom.dispatchEvent(event);
+  return event;
+}
+
+describe("deleteContentBackward input events (Android backspace)", () => {
+  it("converts a bullet list item to a paragraph at the start of the block", () => {
+    const editor = withEditor([
+      {
+        id: "bullet-0",
+        type: "bulletListItem",
+        content: "List item 0",
+      },
+      {
+        id: "bullet-1",
+        type: "bulletListItem",
+        content: "List item 1",
+      },
+    ]);
+    editor.setTextCursorPosition("bullet-1", "start");
+
+    const event = dispatchDeleteContentBackward(editor);
+
+    expect(event.defaultPrevented).toBe(true);
+    expect(editor.getBlock("bullet-1")!.type).toBe("paragraph");
+    expect(editor.getBlock("bullet-1")!.content).toEqual([
+      { type: "text", text: "List item 1", styles: {} },
+    ]);
+  });
+
+  it("lifts a nested block at the start of the block", () => {
+    const editor = withEditor([
+      {
+        id: "paragraph-0",
+        type: "paragraph",
+        content: "Paragraph 0",
+        children: [
+          {
+            id: "nested-paragraph-0",
+            type: "paragraph",
+            content: "Nested Paragraph 0",
+          },
+        ],
+      },
+    ]);
+    editor.setTextCursorPosition("nested-paragraph-0", "start");
+
+    const event = dispatchDeleteContentBackward(editor);
+
+    expect(event.defaultPrevented).toBe(true);
+    expect(editor.getBlock("paragraph-0")!.children).toEqual([]);
+    expect(editor.getBlock("nested-paragraph-0")).toBeDefined();
+  });
+
+  it("does not prevent the default behavior in the middle of a block", () => {
+    const editor = withEditor([
+      {
+        id: "paragraph-0",
+        type: "paragraph",
+        content: "Paragraph 0",
+      },
+    ]);
+    editor.setTextCursorPosition("paragraph-0", "end");
+
+    const event = dispatchDeleteContentBackward(editor);
+
+    // The browser's native behavior (deleting a character) should be left
+    // alone, as it matches what a `Backspace` key press would do.
+    expect(event.defaultPrevented).toBe(false);
+    expect(editor.getBlock("paragraph-0")!.content).toEqual([
+      { type: "text", text: "Paragraph 0", styles: {} },
+    ]);
+  });
+});

--- a/packages/core/src/extensions/tiptap-extensions/KeyboardShortcuts/KeyboardShortcutsExtension.ts
+++ b/packages/core/src/extensions/tiptap-extensions/KeyboardShortcuts/KeyboardShortcutsExtension.ts
@@ -1,6 +1,6 @@
 import { Extension } from "@tiptap/core";
 import { Fragment, Node } from "prosemirror-model";
-import { TextSelection } from "prosemirror-state";
+import { Plugin, TextSelection } from "prosemirror-state";
 
 import {
   getBottomNestedBlockInfo,
@@ -978,5 +978,48 @@ export const KeyboardShortcutsExtension = Extension.create<{
       "Mod-y": () => this.options.editor.redo(),
       "Shift-Mod-z": () => this.options.editor.redo(),
     };
+  },
+
+  addProseMirrorPlugins() {
+    return [
+      new Plugin({
+        props: {
+          handleDOMEvents: {
+            // Some Android IMEs (e.g. Firefox for Android) don't fire real
+            // `Backspace` key events, so the keymap never runs and the browser
+            // deletes content natively instead of lifting/merging blocks.
+            // ProseMirror only works around this on Chrome, so we route
+            // `deleteContentBackward` through the keymap like a real Backspace.
+            beforeinput: (view, event) => {
+              if (
+                event.inputType !== "deleteContentBackward" ||
+                !event.cancelable ||
+                view.composing ||
+                event.isComposing
+              ) {
+                return false;
+              }
+
+              const handled = view.someProp("handleKeyDown", (handler) =>
+                handler(
+                  view,
+                  new KeyboardEvent("keydown", {
+                    key: "Backspace",
+                    keyCode: 8,
+                  }),
+                ),
+              );
+
+              if (handled) {
+                event.preventDefault();
+                return true;
+              }
+
+              return false;
+            },
+          },
+        },
+      }),
+    ];
   },
 });


### PR DESCRIPTION
Some Android keyboards (e.g. FUTO, AOSP LatinIME) don't dispatch a real Backspace keydown, only a beforeinput event with inputType deleteContentBackward, so keymap-based backspace handling (lifting list items, merging blocks) never runs and the browser's native deletion takes over. ProseMirror only works around this on Chrome for Android, leaving Firefox broken.

Route deleteContentBackward input events through the keymap as a synthetic Backspace key press, preventing the default only when a handler acts on it so plain character deletion stays native.

Fixes #2889

# Summary

<!-- Briefly describe the feature being introduced. -->

## Rationale

<!-- Explain the reasoning behind this feature and its benefits to the project. -->

## Changes

<!-- List the major changes made in this pull request. -->

## Impact

<!-- Discuss any potential impacts this feature may have on existing functionalities. -->

## Testing

<!-- Describe how the feature has been tested, including both automated and manual testing strategies. -->

## Screenshots/Video

<!-- Include screenshots or video demonstrating the new feature, if applicable. -->

## Checklist

- [x] Code follows the project's coding standards.
- [x] Unit tests covering the new feature have been added.
- [ ] All existing tests pass.
- [ ] The documentation has been updated to reflect the new feature

## Additional Notes

<!-- Any additional information or context relevant to this PR. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved backspace handling for Android-style virtual keyboards by intercepting cancelable delete-backward `beforeinput` events.
  * When deleting at the start of list and nested blocks, content now falls back to the correct ProseMirror behavior (e.g., converting/lifting blocks as needed).
  * Standard deletion in the middle of text remains unchanged.

* **Tests**
  * Added a new test suite that simulates Android backspace via `beforeinput` and verifies prevention and block-editing outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->