### PR TITLE
fix(core): read `hardBreakShortcut` from block spec impl

### DIFF
--- a/packages/core/src/extensions/tiptap-extensions/KeyboardShortcuts/KeyboardShortcutsExtension.test.ts
+++ b/packages/core/src/extensions/tiptap-extensions/KeyboardShortcuts/KeyboardShortcutsExtension.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { BlockNoteSchema } from "../../../blocks/BlockNoteSchema.js";
+import { defaultBlockSpecs } from "../../../blocks/defaultBlocks.js";
+import { BlockNoteEditor } from "../../../editor/BlockNoteEditor.js";
+import { createBlockSpec } from "../../../schema/index.js";
+
+/**
+ * @vitest-environment jsdom
+ */
+
+// The `hardBreakShortcut` setting lives on the block spec's implementation
+// (`schema.blockSpecs[type].implementation.meta`), not on the block config in
+// `schema.blockSchema`. These blocks verify that the Enter / Shift-Enter
+// handlers read it from the right place — a previous regression read it from
+// `blockSchema`, which never contains `meta`, so custom settings were silently
+// ignored and every block behaved as "shift+enter".
+const createHardBreakTestBlockSpec = <
+  const T extends string,
+  const S extends "shift+enter" | "enter" | "none",
+>(
+  type: T,
+  hardBreakShortcut: S,
+) =>
+  createBlockSpec(
+    {
+      type,
+      propSchema: {},
+      content: "inline",
+    },
+    {
+      meta: {
+        hardBreakShortcut,
+      },
+      render: () => {
+        const dom = document.createElement("p");
+        return {
+          dom,
+          contentDOM: dom,
+        };
+      },
+    },
+  )();
+
+const schema = BlockNoteSchema.create({
+  blockSpecs: {
+    ...defaultBlockSpecs,
+    hardBreakEnter: createHardBreakTestBlockSpec("hardBreakEnter", "enter"),
+    hardBreakNone: createHardBreakTestBlockSpec("hardBreakNone", "none"),
+  },
+});
+
+function createEditor(
+  blockType: "paragraph" | "hardBreakEnter" | "hardBreakNone",
+) {
+  const editor = BlockNoteEditor.create({
+    schema,
+    initialContent: [
+      {
+        id: "block-0",
+        type: blockType,
+        content: "Hello world",
+      },
+    ],
+  });
+  editor.mount(document.createElement("div"));
+  editor.setTextCursorPosition("block-0", "end");
+  return editor;
+}
+
+/**
+ * Simulates a keyboard shortcut by dispatching a keydown event through the
+ * editor's `handleKeyDown` props, which is how ProseMirror invokes the
+ * keymap plugins created by `addKeyboardShortcuts`.
+ */
+function pressKeys(editor: BlockNoteEditor<any, any, any>, keys: string) {
+  editor._tiptapEditor.commands.keyboardShortcut(keys);
+}
+
+function countHardBreaks(editor: BlockNoteEditor<any, any, any>) {
+  let count = 0;
+  editor._tiptapEditor.state.doc.descendants((node) => {
+    if (node.type.name === "hardBreak") {
+      count += 1;
+    }
+  });
+  return count;
+}
+
+describe("KeyboardShortcutsExtension hardBreakShortcut", () => {
+  it("inserts a hard break on Shift-Enter by default", () => {
+    const editor = createEditor("paragraph");
+
+    pressKeys(editor, "Shift-Enter");
+
+    expect(countHardBreaks(editor)).toBe(1);
+    expect(editor.document.length).toBe(1);
+
+    editor._tiptapEditor.destroy();
+  });
+
+  it("splits the block on Enter by default", () => {
+    const editor = createEditor("paragraph");
+
+    pressKeys(editor, "Enter");
+
+    expect(countHardBreaks(editor)).toBe(0);
+    expect(editor.document.length).toBe(2);
+
+    editor._tiptapEditor.destroy();
+  });
+
+  it('inserts a hard break on Enter when hardBreakShortcut is "enter"', () => {
+    const editor = createEditor("hardBreakEnter");
+
+    pressKeys(editor, "Enter");
+
+    expect(countHardBreaks(editor)).toBe(1);
+    expect(editor.document.length).toBe(1);
+
+    editor._tiptapEditor.destroy();
+  });
+
+  it('inserts a hard break on Shift-Enter when hardBreakShortcut is "enter"', () => {
+    const editor = createEditor("hardBreakEnter");
+
+    pressKeys(editor, "Shift-Enter");
+
+    expect(countHardBreaks(editor)).toBe(1);
+    expect(editor.document.length).toBe(1);
+
+    editor._tiptapEditor.destroy();
+  });
+
+  it('does not insert a hard break on Shift-Enter when hardBreakShortcut is "none"', () => {
+    const editor = createEditor("hardBreakNone");
+
+    pressKeys(editor, "Shift-Enter");
+
+    expect(countHardBreaks(editor)).toBe(0);
+
+    editor._tiptapEditor.destroy();
+  });
+
+  it('splits the block on Enter when hardBreakShortcut is "none"', () => {
+    const editor = createEditor("hardBreakNone");
+
+    pressKeys(editor, "Enter");
+
+    expect(countHardBreaks(editor)).toBe(0);
+    expect(editor.document.length).toBe(2);
+
+    editor._tiptapEditor.destroy();
+  });
+});

--- a/packages/core/src/extensions/tiptap-extensions/KeyboardShortcuts/KeyboardShortcutsExtension.ts
+++ b/packages/core/src/extensions/tiptap-extensions/KeyboardShortcuts/KeyboardShortcutsExtension.ts
@@ -22,8 +22,8 @@ import {
   getBlockInfoFromSelection,
 } from "../../../api/getBlockInfoFromPos.js";
 import { BlockNoteEditor } from "../../../editor/BlockNoteEditor.js";
-import { FormattingToolbarExtension } from "../../FormattingToolbar/FormattingToolbar.js";
 import { FilePanelExtension } from "../../FilePanel/FilePanel.js";
+import { FormattingToolbarExtension } from "../../FormattingToolbar/FormattingToolbar.js";
 
 export const KeyboardShortcutsExtension = Extension.create<{
   editor: BlockNoteEditor<any, any, any>;
@@ -805,9 +805,9 @@ export const KeyboardShortcutsExtension = Extension.create<{
             const blockInfo = getBlockInfoFromSelection(state);
 
             const blockHardBreakShortcut =
-              this.options.editor.schema.blockSchema[
-                blockInfo.blockNoteType as keyof typeof this.options.editor.schema.blockSchema
-              ].meta?.hardBreakShortcut ?? "shift+enter";
+            this.options.editor.schema.blockSpecs[
+              blockInfo.blockNoteType
+            ]?.implementation?.meta?.hardBreakShortcut ?? "shift+enter";
 
             if (blockHardBreakShortcut === "none") {
               return false;


### PR DESCRIPTION
## Problem

The Enter / Shift-Enter handlers in `KeyboardShortcutsExtension` read `meta.hardBreakShortcut` from `schema.blockSchema[type].meta`. However, `blockSchema` only holds block *configs*, which never carry `meta` — the setting lives on the block spec's *implementation*. As a result:

- Custom blocks configured with `hardBreakShortcut: "enter"` or `"none"` were silently ignored — every block behaved as the default `"shift+enter"`.
- The unguarded lookup could throw for block types missing from the schema map.

## Fix

Read the setting from `schema.blockSpecs[type]?.implementation?.meta?.hardBreakShortcut` instead, with optional chaining so unknown types fall back to the `"shift+enter"` default.

## Tests

Added `KeyboardShortcutsExtension.test.ts` (jsdom unit tests, co-located with the extension, following the `SuggestionMenu.test.ts` pattern). It builds a schema with custom blocks for each `hardBreakShortcut` setting and drives the real keymap via tiptap's `keyboardShortcut` command:

- Default paragraph: Shift-Enter inserts a hard break; Enter splits the block.
- `"enter"` block: both Enter and Shift-Enter insert a hard break instead of splitting.
- `"none"` block: Shift-Enter inserts no hard break; Enter still splits.

Verified the two meta-driven tests fail against the previous code and all six pass with the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the Enter key behavior for hard breaks based on each block type’s configured shortcut.
  * Ensured custom block settings are respected, including support for Enter, Shift+Enter, and disabled hard-break shortcuts.

* **Tests**
  * Added coverage for default and custom block configurations, including hard-break insertion and block splitting behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->