### PR TITLE
fix(core): ignore synthetic mousemove events without coordinates in side menu

### DIFF
--- a/packages/core/src/extensions/SideMenu/SideMenu.ts
+++ b/packages/core/src/extensions/SideMenu/SideMenu.ts
@@ -600,6 +600,14 @@ export class SideMenuView<
       return;
     }
 
+    // Synthetic mousemove events created via `new Event("mousemove")` (e.g.
+    // dispatched by browser extensions) have no `clientX`/`clientY`, which
+    // would make `elementsFromPoint` throw on the resulting non-finite
+    // coordinates.
+    if (!Number.isFinite(event.clientX) || !Number.isFinite(event.clientY)) {
+      return;
+    }
+
     this.mousePos = { x: event.clientX, y: event.clientY };
 
     // We want the full area of the editor to check if the cursor is hovering


### PR DESCRIPTION
## Problem

The side menu registers a document-level capture `mousemove` listener (`SideMenuView.onMouseMove`) that stores `event.clientX`/`event.clientY` verbatim. A synthetic mousemove created via `new Event("mousemove")` — e.g. dispatched by a browser extension — is a plain `Event` with no coordinate properties, so `this.mousePos` ends up as `{ x: undefined, y: undefined }`. The coordinates then flow through `Math.max(..., undefined)` → `NaN` into `document.elementsFromPoint()`, which throws:

```
TypeError: Failed to execute 'elementsFromPoint' on 'Document': The provided double value is non-finite.
```

Stack (from a production Sentry report, @blocknote/core 0.51.4, Chrome 150):

```
SideMenu.ts getBlockFromCoords → view.root.elementsFromPoint(coords.left, coords.top)
SideMenu.ts getBlockFromMousePos
SideMenu.ts updateStateFromMousePos
SideMenu.ts onMouseMove
```

Note this also crashes **read-only** editors: the `editor.isEditable` check in `updateStateFromMousePos` runs only after the coordinate lookup.

## Fix

Early-return in `onMouseMove` when `clientX`/`clientY` are not finite numbers. Since `this.mousePos` can then never hold non-finite values, the deferred `updateStateFromMousePos()` call sites (scroll / doc update) are covered as well.

## Testing

- `pnpm lint` and `tsgo --noEmit` in `packages/core` — clean
- `pnpm test` in `packages/core` — 458 passed, 3 skipped

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved side menu stability by safely ignoring invalid or incomplete mouse movement events.
  * Prevented unnecessary editor hit-testing and state updates when pointer coordinates are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->