### PR TITLE
fix(react): stop pulling @y/prosemirror into the default UI bundle

### DIFF
--- a/packages/react/src/components/AttributionTooltip/AttributionTooltipController.tsx
+++ b/packages/react/src/components/AttributionTooltip/AttributionTooltipController.tsx
@@ -1,8 +1,4 @@
-import {
-  AttributionExtension,
-  getReferenceClientRects,
-  getReferenceRect,
-} from "@blocknote/core/y";
+import type { AttributionExtension } from "@blocknote/core/y";
 import { flip, offset, shift, inline } from "@floating-ui/react";
 import { FC, useMemo } from "react";
 
@@ -39,22 +35,33 @@ export const AttributionTooltipController = (props: {
    */
   portalElement?: HTMLElement | null;
 }) => {
-  const state = useExtensionState(AttributionExtension, {
+  const state = useExtensionState<typeof AttributionExtension>("attribution", {
     selector: (state) => state,
   });
 
-  // Position off the hovered mark. Block-level marks are `display: contents`, so
-  // a live `getBoundingClientRect` (via `getReferenceRect`) is provided rather
-  // than relying on the wrapper's own (zero-sized) box.
   const reference = useMemo<GenericPopoverReference | undefined>(
     () =>
       state
         ? {
             element: state.anchor,
-            getBoundingClientRect: () => getReferenceRect(state.anchor),
-            // Required by the `inline()` middleware — a virtual reference has no
-            // default `getClientRects`, and `inline()` reads per-line rects.
-            getClientRects: () => getReferenceClientRects(state.anchor),
+            getBoundingClientRect: () => {
+              const content = state.anchor.firstElementChild ?? state.anchor;
+              const rect = content.getBoundingClientRect();
+              const el =
+                rect.width || rect.height
+                  ? content
+                  : (content.firstElementChild ?? content);
+              return el.getBoundingClientRect();
+            },
+            getClientRects: () => {
+              const content = state.anchor.firstElementChild ?? state.anchor;
+              const rect = content.getBoundingClientRect();
+              const el =
+                rect.width || rect.height
+                  ? content
+                  : (content.firstElementChild ?? content);
+              return el.getClientRects();
+            },
           }
         : undefined,
     [state],

--- a/packages/react/src/editor/BlockNoteDefaultUI.tsx
+++ b/packages/react/src/editor/BlockNoteDefaultUI.tsx
@@ -7,7 +7,6 @@ import {
   SuggestionMenu,
   TableHandlesExtension,
 } from "@blocknote/core/extensions";
-import { AttributionExtension } from "@blocknote/core/y";
 import { lazy, Suspense } from "react";
 
 import { FilePanelController } from "../components/FilePanel/FilePanelController.js";
@@ -162,7 +161,7 @@ export function BlockNoteDefaultUI(props: BlockNoteDefaultUIProps) {
           <FloatingThreadController portalElement={commentsPortal} />
         </Suspense>
       )}
-      {editor.getExtension(AttributionExtension) &&
+      {editor.getExtension("attribution") &&
         props.attributionTooltip !== false && (
           <AttributionTooltipController
             portalElement={attributionTooltipPortal}

--- a/packages/react/src/hooks/useExtension.ts
+++ b/packages/react/src/hooks/useExtension.ts
@@ -49,13 +49,17 @@ export function useExtensionState<
     : never,
   TSelected = NoInfer<ExtractStore<TStore>>,
 >(
-  plugin: T,
+  plugin: T | string,
   ctx?: {
     editor?: BlockNoteEditor<any, any, any>;
     selector?: (state: NoInfer<ExtractStore<TStore>>) => TSelected;
   },
 ): TSelected {
-  const { store } = useExtension(plugin, ctx);
+  const extension = useExtension(
+    plugin as ExtensionFactory | Extension | string,
+    ctx,
+  );
+  const { store } = extension;
   if (!store) {
     throw new Error("Store not found on plugin", { cause: { plugin } });
   }


### PR DESCRIPTION
# Summary

`@blocknote/react`'s default UI imported `AttributionExtension` directly from `@blocknote/core/y`, which forces bundlers to resolve `@y/prosemirror`/`@y/y` even for editors that never enable collaboration.

## Rationale

Every consumer of `BlockNoteView` (via `BlockNoteDefaultUI`) hit this import at build/runtime, causing `Could not resolve "@y/prosemirror"` errors for non-collaborative apps that don't have those optional peer dependencies installed.

## Changes

- `BlockNoteDefaultUI.tsx`: look up the attribution extension via `editor.getExtension("attribution")` (string key) instead of importing the `AttributionExtension` value.
- `AttributionTooltipController.tsx`: only `import type` from `@blocknote/core/y` (erased at build time), use the string-keyed `useExtensionState("attribution", ...)`, and inline the two small DOM helpers it previously imported.
- `useExtension.ts`: widen `useExtensionState`'s `plugin` parameter to accept a string key while still inferring the extension's state type from the generic.

## Impact

Non-collaborative editors no longer pull in `@y/prosemirror`/`@y/y` through `@blocknote/react`. No behavior change for apps using collaboration/attribution.

## Testing

- `vp run lint` — 0 errors
- `vp run test` — all tests pass
- `vp run build` — verified `@blocknote/core/y` no longer appears in `packages/react/dist/blocknote-react.js`

Fixes #2901

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved attribution tooltip positioning across different anchor elements.
  * Improved attribution tooltip availability when the attribution extension is configured by name.

* **Refactor**
  * Enhanced extension state handling to support extension names in addition to extension instances.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->