### PR TITLE
fix: `getCellSelection` throwing error in positions (BLO-1193)

### DIFF
--- a/packages/core/src/blocks/Table/TableExtension.test.ts
+++ b/packages/core/src/blocks/Table/TableExtension.test.ts
@@ -1,3 +1,4 @@
+import { GapCursor } from "@tiptap/pm/gapcursor";
 import { TextSelection } from "prosemirror-state";
 import { CellSelection } from "prosemirror-tables";
 import {
@@ -10,6 +11,7 @@ import {
 } from "vite-plus/test";
 
 import { BlockNoteEditor } from "../../editor/BlockNoteEditor.js";
+import { TableHandlesExtension } from "../../extensions/TableHandles/TableHandles.js";
 import type { PartialBlock } from "../defaultBlocks.js";
 
 /**
@@ -125,5 +127,105 @@ describe("Table Enter keyboard shortcut", () => {
     const before = editor.document;
     expect(() => pressEnter(editor)).not.toThrow();
     expect(editor.document).toStrictEqual(before);
+  });
+});
+
+describe("TableHandlesExtension.getCellSelection", () => {
+  let editor: BlockNoteEditor;
+  const div = document.createElement("div");
+
+  beforeAll(() => {
+    editor = BlockNoteEditor.create();
+    editor.mount(div);
+  });
+
+  afterAll(() => {
+    editor._tiptapEditor.destroy();
+    editor = undefined as any;
+  });
+
+  function getCellSelection() {
+    return editor.getExtension(TableHandlesExtension)!.getCellSelection();
+  }
+
+  it("returns undefined for a gap cursor left of a leading table without crashing", () => {
+    // A table as the first block in the document, matching the crash repro
+    // where clicking in the left margin places a gap cursor at doc start.
+    editor.replaceBlocks(editor.document, [
+      {
+        type: "table",
+        content: {
+          type: "tableContent",
+          rows: [{ cells: ["Cell 1", "Cell 2"] }],
+        },
+      },
+    ]);
+
+    editor.transact((tr) => tr.setSelection(new GapCursor(tr.doc.resolve(0))));
+
+    expect(() => getCellSelection()).not.toThrow();
+    expect(getCellSelection()).toBeUndefined();
+  });
+
+  it("returns undefined for a gap cursor next to a nested block without crashing", () => {
+    // A table as the first block, followed by a nested block. Clicking the
+    // nested block's left margin places a gap cursor that is not inside a cell.
+    editor.replaceBlocks(editor.document, [
+      {
+        type: "table",
+        content: {
+          type: "tableContent",
+          rows: [{ cells: ["Cell 1", "Cell 2"] }],
+        },
+      },
+      {
+        type: "paragraph",
+        content: "Parent",
+        children: [{ type: "paragraph", content: "Nested" }],
+      },
+    ]);
+
+    let nestedPos = -1;
+    editor.prosemirrorView.state.doc.descendants((node, pos) => {
+      if (nestedPos === -1 && node.isText && node.text === "Nested") {
+        nestedPos = pos;
+      }
+      return true;
+    });
+    editor.transact((tr) =>
+      tr.setSelection(new GapCursor(tr.doc.resolve(nestedPos - 1))),
+    );
+
+    expect(() => getCellSelection()).not.toThrow();
+    expect(getCellSelection()).toBeUndefined();
+  });
+
+  it("returns the cell indices for a text selection inside a cell", () => {
+    editor.replaceBlocks(editor.document, [
+      {
+        type: "table",
+        content: {
+          type: "tableContent",
+          rows: [
+            { cells: ["Cell 1", "Cell 2"] },
+            { cells: ["Cell 3", "Cell 4"] },
+          ],
+        },
+      },
+    ]);
+
+    let cellPos = -1;
+    editor.prosemirrorView.state.doc.descendants((node, pos) => {
+      if (cellPos === -1 && node.isText && node.text === "Cell 4") {
+        cellPos = pos;
+      }
+      return true;
+    });
+    editor.transact((tr) =>
+      tr.setSelection(TextSelection.create(tr.doc, cellPos + 1)),
+    );
+
+    expect(getCellSelection()?.from).toEqual({ row: 1, col: 1 });
+    expect(getCellSelection()?.to).toEqual({ row: 1, col: 1 });
   });
 });

--- a/packages/core/src/blocks/defaultBlockTypeGuards.ts
+++ b/packages/core/src/blocks/defaultBlockTypeGuards.ts
@@ -1,3 +1,4 @@
+import { Node } from "prosemirror-model";
 import { CellSelection } from "prosemirror-tables";
 import type { BlockNoteEditor } from "../editor/BlockNoteEditor.js";
 import { BlockConfig, PropSchema, PropSpec } from "../schema/index.js";
@@ -158,4 +159,9 @@ export function isTableCellSelection(
   selection: Selection,
 ): selection is CellSelection {
   return selection instanceof CellSelection;
+}
+
+export function isTableCellNode(node: Node): boolean {
+  const tableRole = node.type.spec.tableRole;
+  return tableRole === "cell" || tableRole === "header_cell";
 }

--- a/packages/core/src/extensions/TableHandles/TableHandles.ts
+++ b/packages/core/src/extensions/TableHandles/TableHandles.ts
@@ -28,6 +28,7 @@ import { nodeToBlock } from "../../api/nodeConversions/nodeToBlock.js";
 import { getNodeById } from "../../api/nodeUtil.js";
 import {
   editorHasBlockWithType,
+  isTableCellNode,
   isTableCellSelection,
 } from "../../blocks/defaultBlockTypeGuards.js";
 import { DefaultBlockSchema } from "../../blocks/defaultBlocks.js";
@@ -1106,15 +1107,26 @@ export const TableHandlesExtension = createExtension(({ editor }) => {
           // When the selection is a normal text selection
           // Assumes we are within a tableParagraph
           // And find the from and to cells by resolving the positions
-          $fromCell = tr.doc.resolve(
-            selection.$from.pos - selection.$from.parentOffset - 1,
-          );
-          $toCell = tr.doc.resolve(
-            selection.$to.pos - selection.$to.parentOffset - 1,
-          );
+          const fromCellPos =
+            selection.$from.pos - selection.$from.parentOffset - 1;
+          const toCellPos = selection.$to.pos - selection.$to.parentOffset - 1;
 
-          // Opt-out when the selection is not pointing into cells
-          if ($fromCell.pos === 0 || $toCell.pos === 0) {
+          // Opt-out when the selection is not pointing into cells. This happens when the selection
+          // is at the start of the table's `blockContainer` node and therefore just before the
+          // actual `table` node.
+          if (fromCellPos < 0 || toCellPos < 0) {
+            return undefined;
+          }
+
+          $fromCell = tr.doc.resolve(fromCellPos);
+          $toCell = tr.doc.resolve(toCellPos);
+
+          // Opt-out when the selection is not actually pointing into table
+          // cells (e.g. a gap cursor next to a nested block).
+          if (
+            !isTableCellNode($fromCell.parent) ||
+            !isTableCellNode($toCell.parent)
+          ) {
             return undefined;
           }
         }


### PR DESCRIPTION
# Summary

<!-- Briefly describe the feature being introduced. -->

`TableHandlesExtension.getCellSelection` throws an error when the selection is within a table block but not actually a cell selection. For example, the selection can be a gap cursor at the start of the table.

In the static formatting toolbar example, the text alignment buttons call `getCellSelection` on selection change. In this example, if a table is at the start of the document, you can move the selection to a gap cursor above the table using the up arrow key or clicking in certain places to the side of the table. The text alignment buttons call `getCellSelection` which errors.

Closes #2748 

## Rationale

<!-- Explain the reasoning behind this feature and its benefits to the project. -->

This is an uncommon error, but one that should be fixed either way.

## Changes

<!-- List the major changes made in this pull request. -->

- Added additional checks before & after resolving cell positions to ensure they actually point to cells.

## Impact

<!-- Discuss any potential impacts this feature may have on existing functionalities. -->

N/A

## Testing

<!-- Describe how the feature has been tested, including both automated and manual testing strategies. -->

Added unit tests.

## Screenshots/Video

<!-- Include screenshots or video demonstrating the new feature, if applicable. -->

N/A

## Checklist

- [X] Code follows the project's coding standards.
- [X] Unit tests covering the new feature have been added.
- [X] All existing tests pass.
- [ ] The documentation has been updated to reflect the new feature

## Additional Notes

<!-- Any additional information or context relevant to this PR. -->

It seems strange that a button in the formatting toolbar should even need the table handles extension, so we may want to fix this also.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved table selection handling for cursor positions outside table cells, including gap cursors near tables and nested blocks.
  * Prevented invalid cell selections when the cursor is not inside a table cell.

* **Tests**
  * Added coverage for valid table-cell selections and non-table cursor positions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->