### PR TITLE
fix: ignore useless block/inline content mutations (BLO-1224)

### DIFF
--- a/packages/core/src/schema/blocks/createSpec.ts
+++ b/packages/core/src/schema/blocks/createSpec.ts
@@ -7,6 +7,7 @@ import {
 } from "@tiptap/pm/model";
 import { NodeView } from "@tiptap/pm/view";
 import { mergeParagraphs } from "../../blocks/defaultBlockHelpers.js";
+import { ignoreNonContentMutations } from "../nodeViewMutations.js";
 import {
   Extension,
   ExtensionFactoryInstance,
@@ -270,6 +271,11 @@ export function addNodeAndExtensionsToSpec<
           if (blockImplementation.meta?.selectable === false) {
             applyNonSelectableBlockFix(typedNodeView, this.editor);
           }
+
+          // Ignores DOM mutations that don't affect the block's content, so
+          // that browser extensions which rewrite the DOM (e.g. Dark Reader)
+          // can't trigger an infinite re-render loop that freezes the tab.
+          ignoreNonContentMutations(typedNodeView);
 
           // See explanation for why `update` is not implemented for NodeViews
           // https://github.com/TypeCellOS/BlockNote/pull/1904#discussion_r2313461464

--- a/packages/core/src/schema/inlineContent/createSpec.ts
+++ b/packages/core/src/schema/inlineContent/createSpec.ts
@@ -4,6 +4,7 @@ import { TagParseRule } from "@tiptap/pm/model";
 import { inlineContentToNodes } from "../../api/nodeConversions/blockToNode.js";
 import { nodeToCustomInlineContent } from "../../api/nodeConversions/nodeToBlock.js";
 import type { BlockNoteEditor } from "../../editor/BlockNoteEditor.js";
+import { ignoreNonContentMutations } from "../nodeViewMutations.js";
 import { propsToAttributes } from "../blocks/internal.js";
 import { Props } from "../propTypes.js";
 import { StyleSchema } from "../styles/types.js";
@@ -208,12 +209,19 @@ export function createInlineContentSpec<
           editor,
         );
 
-        return addInlineContentAttributes(
+        const nodeView = addInlineContentAttributes(
           output,
           inlineContentConfig.type,
           node.attrs as Props<T["propSchema"]>,
           inlineContentConfig.propSchema,
         );
+
+        // Ignores DOM mutations that don't affect the inline content, so that
+        // browser extensions which rewrite the DOM (e.g. Dark Reader) can't
+        // trigger an infinite re-render loop that freezes the tab.
+        ignoreNonContentMutations(nodeView);
+
+        return nodeView;
       };
     },
   });

--- a/packages/core/src/schema/nodeViewMutations.test.ts
+++ b/packages/core/src/schema/nodeViewMutations.test.ts
@@ -1,0 +1,121 @@
+import { NodeView, ViewMutationRecord } from "@tiptap/pm/view";
+import { describe, expect, it } from "vite-plus/test";
+
+import {
+  ignoreNonContentMutations,
+  isNonContentMutation,
+} from "./nodeViewMutations.js";
+
+function attributeMutation(target: Node): ViewMutationRecord {
+  return {
+    type: "attributes",
+    target,
+    attributeName: "style",
+  } as unknown as ViewMutationRecord;
+}
+
+function childListMutation(target: Node): ViewMutationRecord {
+  return {
+    type: "childList",
+    target,
+    addedNodes: [] as any,
+    removedNodes: [] as any,
+  } as unknown as ViewMutationRecord;
+}
+
+const selectionMutation = { type: "selection" } as ViewMutationRecord;
+
+describe("isNonContentMutation", () => {
+  it("never ignores selection mutations", () => {
+    expect(isNonContentMutation(selectionMutation, null)).toBe(false);
+    expect(
+      isNonContentMutation(selectionMutation, document.createElement("div")),
+    ).toBe(false);
+  });
+
+  it("ignores everything for a node view without content", () => {
+    const target = document.createElement("span");
+    expect(isNonContentMutation(attributeMutation(target), null)).toBe(true);
+    expect(isNonContentMutation(childListMutation(target), null)).toBe(true);
+  });
+
+  it("ignores attribute mutations even inside the content DOM", () => {
+    const contentDOM = document.createElement("div");
+    const span = document.createElement("span");
+    contentDOM.appendChild(span);
+
+    // e.g. Dark Reader rewriting the inline style of a highlight span.
+    expect(isNonContentMutation(attributeMutation(span), contentDOM)).toBe(
+      true,
+    );
+    expect(
+      isNonContentMutation(attributeMutation(contentDOM), contentDOM),
+    ).toBe(true);
+  });
+
+  it("reads content mutations inside the content DOM", () => {
+    const contentDOM = document.createElement("div");
+    const textNode = document.createTextNode("hello");
+    contentDOM.appendChild(textNode);
+
+    // childList directly on the content DOM (e.g. a node inserted while typing).
+    expect(
+      isNonContentMutation(childListMutation(contentDOM), contentDOM),
+    ).toBe(false);
+    // characterData-style mutation on a text node inside the content DOM.
+    expect(isNonContentMutation(childListMutation(textNode), contentDOM)).toBe(
+      false,
+    );
+  });
+
+  it("ignores content mutations outside the content DOM (node view chrome)", () => {
+    const dom = document.createElement("div");
+    const contentDOM = document.createElement("div");
+    const chrome = document.createElement("button"); // e.g. toggle button
+    dom.append(chrome, contentDOM);
+
+    expect(isNonContentMutation(childListMutation(dom), contentDOM)).toBe(true);
+    expect(isNonContentMutation(childListMutation(chrome), contentDOM)).toBe(
+      true,
+    );
+  });
+});
+
+describe("ignoreNonContentMutations", () => {
+  it("ignores non-content mutations while reading content ones", () => {
+    const contentDOM = document.createElement("div");
+    const span = document.createElement("span");
+    contentDOM.appendChild(span);
+    const nodeView: NodeView = {
+      dom: document.createElement("div"),
+      contentDOM,
+    };
+
+    ignoreNonContentMutations(nodeView);
+
+    // Non-content (attribute) mutation is ignored...
+    expect(nodeView.ignoreMutation!(attributeMutation(span))).toBe(true);
+    // ...content mutation is read...
+    expect(nodeView.ignoreMutation!(childListMutation(contentDOM))).toBe(false);
+    // ...and selection is read.
+    expect(nodeView.ignoreMutation!(selectionMutation)).toBe(false);
+  });
+
+  it("still defers to an existing ignoreMutation for content mutations", () => {
+    const contentDOM = document.createElement("div");
+    const nodeView: NodeView = {
+      dom: document.createElement("div"),
+      contentDOM,
+      // Pretend this node view wants to ignore all of its content mutations.
+      ignoreMutation: () => true,
+    };
+
+    ignoreNonContentMutations(nodeView);
+
+    // A content mutation the filter would read is still ignored by the
+    // original `ignoreMutation`.
+    expect(nodeView.ignoreMutation!(childListMutation(contentDOM))).toBe(true);
+    // Non-content mutations are ignored by the filter regardless.
+    expect(nodeView.ignoreMutation!(attributeMutation(contentDOM))).toBe(true);
+  });
+});

--- a/packages/core/src/schema/nodeViewMutations.ts
+++ b/packages/core/src/schema/nodeViewMutations.ts
@@ -1,0 +1,46 @@
+import { NodeView, ViewMutationRecord } from "@tiptap/pm/view";
+
+// Ignores all mutations, except those which modify content. ProseMirror by default allows for
+// bidirectional updates between state & view i.e., mutating the view can cause a state update.
+// This means that basically any DOM mutation in a node view will trigger a re-render, which can
+// cause issues with certain browser extensions and interactive elements which aren't linked to
+// the node or editor state.
+export function isNonContentMutation(
+  mutation: ViewMutationRecord,
+  contentDOM: HTMLElement | null | undefined,
+): boolean {
+  // Let ProseMirror handle selection changes.
+  if (mutation.type === "selection") {
+    return false;
+  }
+
+  // Ignore all mutations for nodes without content.
+  if (!contentDOM) {
+    return true;
+  }
+
+  // Ignore all changes to DOM attributes. If a DOM attribute value depends on the value of a
+  // ProseMirror node's attribute, the change should be made to the ProseMirror node directly,
+  // which will trigger a re-render. We don't propagate changes to the DOM back to the node.
+  if (mutation.type === "attributes") {
+    return true;
+  }
+
+  // Everything left is a `childList` or `characterData` mutation (i.e., a content mutation). Only
+  // those inside the content DOM are actual content edits that ProseMirror needs to read.
+  return !contentDOM.contains(mutation.target);
+}
+
+export function ignoreNonContentMutations(nodeView: NodeView): void {
+  const originalIgnoreMutation = nodeView.ignoreMutation?.bind(nodeView);
+  const contentDOM = nodeView.contentDOM;
+
+  nodeView.ignoreMutation = (mutation: ViewMutationRecord) => {
+    if (isNonContentMutation(mutation, contentDOM)) {
+      return true;
+    }
+
+    // Defer to the node view's own `ignoreMutation` for additional filtering.
+    return originalIgnoreMutation ? originalIgnoreMutation(mutation) : false;
+  };
+}


### PR DESCRIPTION
# Summary

<!-- Briefly describe the feature being introduced. -->

This PR makes blocks & inline content ignore all mutations which don't modify the block/inline content's content. By default, ProseMirror handles all DOM mutations to a node. This is to allow changes in the view to propagate to the state. For BlockNote, this isn't really needed - you're expected to update the state (e.g. by updating a block's props) and let those changes trigger a re-render to propagate them to the view.

This has a number of benefits. For one, interactive elements that are view-only and aren't tied to e.g. a block's props won't cause re-renders. Also, browser extensions may modify inline styles on elements in the editor. Because these are DOM mutations, ProseMirror picks them up and triggers a re-render, and ends up causing an infinite re-render loop.

Closes #2818 

## Rationale

<!-- Explain the reasoning behind this feature and its benefits to the project. -->

We expect most people to create custom blocks using React, so these changes don't really apply there. So this PR is mostly to prevent issues with browser extensions like DarkReader.

## Changes

<!-- List the major changes made in this pull request. -->

- Added `ignoreNonContentMutations`.

## Impact

<!-- Discuss any potential impacts this feature may have on existing functionalities. -->

N/A

## Testing

<!-- Describe how the feature has been tested, including both automated and manual testing strategies. -->

Added unit tests.

## Screenshots/Video

<!-- Include screenshots or video demonstrating the new feature, if applicable. -->

N/A

## Checklist

- [X] Code follows the project's coding standards.
- [X] Unit tests covering the new feature have been added.
- [X] All existing tests pass.
- [ ] The documentation has been updated to reflect the new feature

## Additional Notes

<!-- Any additional information or context relevant to this PR. -->

N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced unnecessary editor re-renders caused by irrelevant DOM changes in block and inline content views.
  * Improved compatibility with browser extensions and other tools that rewrite DOM attributes or structure.
  * Preserved updates to actual content and selection changes while ignoring unrelated mutations.

* **Tests**
  * Added coverage for content, selection, attribute, and non-content DOM mutations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->