### PR TITLE
fix(core): prefer longest suggestion menu trigger over shadowing shor…

### DIFF
--- a/packages/core/src/extensions/SuggestionMenu/SuggestionMenu.test.ts
+++ b/packages/core/src/extensions/SuggestionMenu/SuggestionMenu.test.ts
@@ -188,4 +188,68 @@ describe("SuggestionMenu", () => {
 
     editor._tiptapEditor.destroy();
   });
+
+  it("should prefer a multi-character trigger over a shadowing single-character one", () => {
+    const editor = createEditor();
+    const sm = editor.getExtension(SuggestionMenu)!;
+
+    // Register the single-character trigger first so it would shadow the
+    // multi-character one in insertion order (mirrors the default emoji ":"
+    // menu registered before a custom "img:" menu).
+    sm.addSuggestionMenu({ triggerCharacter: ":" });
+    sm.addSuggestionMenu({ triggerCharacter: "img:" });
+
+    editor.replaceBlocks(editor.document, [
+      {
+        id: "paragraph-0",
+        type: "paragraph",
+        content: "img",
+      },
+    ]);
+
+    editor.setTextCursorPosition("paragraph-0", "end");
+
+    expect(getSuggestionPluginState(editor)).toBeUndefined();
+
+    // Typing the final ":" of "img:" should open the "img:" menu, not the ":"
+    // emoji menu.
+    const handled = simulateTextInput(editor, ":");
+
+    expect(handled).toBe(true);
+
+    const pluginState = getSuggestionPluginState(editor);
+    expect(pluginState).toBeDefined();
+    expect(pluginState.triggerCharacter).toBe("img:");
+
+    editor._tiptapEditor.destroy();
+  });
+
+  it("should match a multi-character trigger mid-line (not just at block start)", () => {
+    const editor = createEditor();
+    const sm = editor.getExtension(SuggestionMenu)!;
+
+    sm.addSuggestionMenu({ triggerCharacter: "img:" });
+
+    editor.replaceBlocks(editor.document, [
+      {
+        id: "paragraph-0",
+        type: "paragraph",
+        content: "hello img",
+      },
+    ]);
+
+    editor.setTextCursorPosition("paragraph-0", "end");
+
+    expect(getSuggestionPluginState(editor)).toBeUndefined();
+
+    const handled = simulateTextInput(editor, ":");
+
+    expect(handled).toBe(true);
+
+    const pluginState = getSuggestionPluginState(editor);
+    expect(pluginState).toBeDefined();
+    expect(pluginState.triggerCharacter).toBe("img:");
+
+    editor._tiptapEditor.destroy();
+  });
 });

--- a/packages/core/src/extensions/SuggestionMenu/SuggestionMenu.ts
+++ b/packages/core/src/extensions/SuggestionMenu/SuggestionMenu.ts
@@ -336,10 +336,19 @@ export const SuggestionMenu = createExtension(({ editor }) => {
             // only on insert
             if (from === to) {
               const doc = view.state.doc;
-              for (const [triggerChar, menuOptions] of suggestionMenus) {
+              // Match longer trigger characters first, so a multi-character
+              // trigger (e.g. "img:") wins over a single-character one (e.g.
+              // the default emoji ":") that would otherwise shadow it.
+              const orderedMenus = [...suggestionMenus].sort(
+                ([a], [b]) => b.length - a.length,
+              );
+              for (const [triggerChar, menuOptions] of orderedMenus) {
                 const snippet =
                   triggerChar.length > 1
-                    ? doc.textBetween(from - triggerChar.length, from) + text
+                    ? // The already-typed prefix is the first `length - 1`
+                      // chars; `text` is the final char being inserted now.
+                      doc.textBetween(from - (triggerChar.length - 1), from) +
+                      text
                     : text;
 
                 if (triggerChar === snippet) {


### PR DESCRIPTION
  # Summary

  Fix multi-character suggestion menu triggers (e.g. `img:`) that never opened when a shorter registered trigger (e.g. the default emoji `:`) shadowed them. Fixes https://github.com/TypeCellOS/BlockNote/issues/2905.

  ## Rationale

  `SuggestionMenuController` with `triggerCharacter="img:"` never fired. The default emoji picker registers `:`, and `handleTextInput` matched the first trigger in insertion order — so the single-char `:` always won and consumed the input before `img:` was ever checked. `img#` (no competing trigger) and `:` alone both worked, which masked the bug.

  ## Changes

  - Sort candidate triggers by length descending in `handleTextInput` so the most specific (longest) trigger matches first.
  - Fix an off-by-one in the multi-character prefix lookup: `from - triggerChar.length` grabbed one extra char, so a trigger preceded by other text on the same line (e.g. `hello img:`) never matched. Now `from - (triggerChar.length - 1)`.

  ## Impact

  - Scoped to `@blocknote/core` `SuggestionMenu.handleTextInput`.
  - Multi-char triggers that collide on their final char with a shorter trigger now resolve to the longer one.
  - Single-char triggers and programmatic menu opening are unaffected (single-char path unchanged; sort is stable for equal lengths).

  ## Testing

  - Added 2 unit tests in `SuggestionMenu.test.ts`:
    - `img:` preferred over a `:` trigger registered first (shadowing case).
    - `img:` matches mid-line (`hello img` + `:`), covering the off-by-one fix.
  - Verified both new tests fail on unfixed source and pass with the fix.
  - `pnpm lint` (full, type-aware) clean.
  - Pre-existing unrelated failures on this machine: `chatHandlers.test.ts` (needs Node 22 iterator helpers; running Node 20) and `htmlBlocks.test.ts` (needs LLM provider keys). Neither touches this change.

  ## Screenshots/Video

  N/A — non-visual logic fix.

  ## Checklist

  - [x] Code follows the project's coding standards.
  - [x] Unit tests covering the new feature have been added.
  - [x] All existing tests pass. <!-- except pre-existing Node-20 / LLM-key env failures, unrelated -->
  - [ ] The documentation has been updated to reflect the new feature <!-- N/A: bug fix, no API change -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved suggestion menu matching so longer, multi-character triggers take precedence over shorter triggers.
  * Multi-character triggers now work correctly when typed after existing text within a paragraph.
  * Prevented shorter triggers from opening the wrong suggestion menu.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->