### PR TITLE
fix: suggestion menu behaviour (BLO-1283, BLO-955)

### DIFF
--- a/docs/content/docs/react/components/suggestion-menus.mdx
+++ b/docs/content/docs/react/components/suggestion-menus.mdx
@@ -136,6 +136,8 @@ Now, we also pass a component to its `suggestionMenuComponent` prop. The `sugges
 
 You can add additional Suggestion Menus to the editor, which can use any trigger character. The demo below adds an example Suggestion Menu for mentions, which opens with the `@` character.
 
+Typically, suggestion menus are meant to be triggered using a single character. However, longer triggers are also supported, like `img:` or `ref:`.
+
 <Example name="custom-schema/suggestion-menus-mentions" />
 
 Changing the items in the new Suggestion Menu, or the component used to render it, is done the same way as for the [Slash Menu](/docs/react/components/suggestion-menus#slash-menu). For more information about how the mentions elements work, see [Custom Inline Content](/docs/features/custom-schemas/custom-inline-content).

--- a/packages/core/src/extensions/SuggestionMenu/SuggestionMenu.test.ts
+++ b/packages/core/src/extensions/SuggestionMenu/SuggestionMenu.test.ts
@@ -140,6 +140,124 @@ describe("SuggestionMenu", () => {
     editor._tiptapEditor.destroy();
   });
 
+  it("should open a suggestion menu with a multi-character trigger", () => {
+    const editor = createEditor();
+    const sm = editor.getExtension(SuggestionMenu)!;
+
+    sm.addSuggestionMenu({ triggerCharacter: "img:" });
+
+    editor.replaceBlocks(editor.document, [
+      {
+        id: "paragraph-0",
+        type: "paragraph",
+        content: "img",
+      },
+    ]);
+
+    editor.setTextCursorPosition("paragraph-0", "end");
+
+    expect(getSuggestionPluginState(editor)).toBeUndefined();
+
+    // Typing the final ":" completes the "img:" trigger.
+    const handled = simulateTextInput(editor, ":");
+
+    expect(handled).toBe(true);
+
+    const pluginState = getSuggestionPluginState(editor);
+    expect(pluginState).toBeDefined();
+    expect(pluginState.triggerCharacter).toBe("img:");
+
+    editor._tiptapEditor.destroy();
+  });
+
+  it("should match a multi-character trigger that is preceded by other text", () => {
+    const editor = createEditor();
+    const sm = editor.getExtension(SuggestionMenu)!;
+
+    sm.addSuggestionMenu({ triggerCharacter: "img:" });
+
+    editor.replaceBlocks(editor.document, [
+      {
+        id: "paragraph-0",
+        type: "paragraph",
+        content: "hello img",
+      },
+    ]);
+
+    editor.setTextCursorPosition("paragraph-0", "end");
+
+    expect(getSuggestionPluginState(editor)).toBeUndefined();
+
+    const handled = simulateTextInput(editor, ":");
+
+    expect(handled).toBe(true);
+
+    const pluginState = getSuggestionPluginState(editor);
+    expect(pluginState).toBeDefined();
+    expect(pluginState.triggerCharacter).toBe("img:");
+
+    editor._tiptapEditor.destroy();
+  });
+
+  it("should prefer a longer trigger over a shorter one that would shadow it", () => {
+    const editor = createEditor();
+    const sm = editor.getExtension(SuggestionMenu)!;
+
+    // Register the shorter ":" trigger first so it would win in insertion
+    // order, then the longer "img:" trigger that ends in the same character.
+    sm.addSuggestionMenu({ triggerCharacter: ":" });
+    sm.addSuggestionMenu({ triggerCharacter: "img:" });
+
+    editor.replaceBlocks(editor.document, [
+      {
+        id: "paragraph-0",
+        type: "paragraph",
+        content: "img",
+      },
+    ]);
+
+    editor.setTextCursorPosition("paragraph-0", "end");
+
+    const handled = simulateTextInput(editor, ":");
+
+    expect(handled).toBe(true);
+
+    const pluginState = getSuggestionPluginState(editor);
+    expect(pluginState).toBeDefined();
+    expect(pluginState.triggerCharacter).toBe("img:");
+
+    editor._tiptapEditor.destroy();
+  });
+
+  it("should fall back to the shorter trigger when the longer one does not match", () => {
+    const editor = createEditor();
+    const sm = editor.getExtension(SuggestionMenu)!;
+
+    sm.addSuggestionMenu({ triggerCharacter: ":" });
+    sm.addSuggestionMenu({ triggerCharacter: "img:" });
+
+    editor.replaceBlocks(editor.document, [
+      {
+        id: "paragraph-0",
+        type: "paragraph",
+        content: "hello",
+      },
+    ]);
+
+    editor.setTextCursorPosition("paragraph-0", "end");
+
+    // "hello" + ":" doesn't complete "img:", so the bare ":" trigger wins.
+    const handled = simulateTextInput(editor, ":");
+
+    expect(handled).toBe(true);
+
+    const pluginState = getSuggestionPluginState(editor);
+    expect(pluginState).toBeDefined();
+    expect(pluginState.triggerCharacter).toBe(":");
+
+    editor._tiptapEditor.destroy();
+  });
+
   it("should still allow suggestion menus without shouldTrigger in table content", () => {
     const editor = createEditor();
     const sm = editor.getExtension(SuggestionMenu)!;

--- a/packages/core/src/extensions/SuggestionMenu/SuggestionMenu.ts
+++ b/packages/core/src/extensions/SuggestionMenu/SuggestionMenu.ts
@@ -338,44 +338,41 @@ export const SuggestionMenu = createExtension(({ editor }) => {
         },
 
         props: {
-          handleTextInput(view, from, to, text) {
-            // only on insert
-            if (from === to) {
-              const doc = view.state.doc;
-              // Sort triggers by length (longest first) so that a more specific
-              // multi-character trigger (e.g. "img:") is preferred over a shorter
-              // one (e.g. ":") that would otherwise shadow it by matching first.
-              const triggers = [...suggestionMenus.entries()].sort(
-                ([a], [b]) => b.length - a.length,
-              );
-              for (const [trigger, menuOptions] of triggers) {
-                const input =
-                  doc.textBetween(
-                    // If the cursor is at the very start of the document, and we are checking if
-                    // an n-character trigger has been entered (e.g. "img:"), we need to get the n
-                    // characters before the text cursor to compare do so. However, the text cursor
-                    // may be near the start of the document and not have n characters before it.
-                    Math.max(0, from - trigger.length - text.length),
-                    from,
-                  ) + text;
-                if (trigger === input) {
-                  // Check the per-suggestion-menu filter before activating.
-                  if (
-                    menuOptions.shouldOpen &&
-                    !menuOptions.shouldOpen(view.state.tr)
-                  ) {
-                    continue;
-                  }
-                  view.dispatch(view.state.tr.insertText(text));
-                  view.dispatch(
-                    view.state.tr
-                      .setMeta(suggestionMenuPluginKey, {
-                        triggerCharacter: input,
-                      })
-                      .scrollIntoView(),
-                  );
-                  return true;
+          handleTextInput(view, from, _to, text) {
+            const doc = view.state.doc;
+            // Sort triggers by length (longest first) so that a more specific
+            // multi-character trigger (e.g. "img:") is preferred over a shorter
+            // one (e.g. ":") that would otherwise shadow it by matching first.
+            const triggers = [...suggestionMenus.entries()].sort(
+              ([a], [b]) => b.length - a.length,
+            );
+            for (const [trigger, menuOptions] of triggers) {
+              const input =
+                doc.textBetween(
+                  // If the cursor is at the very start of the document, and we are checking if
+                  // an n-character trigger has been entered (e.g. "img:"), we need to get the n
+                  // characters before the text cursor to compare do so. However, the text cursor
+                  // may be near the start of the document and not have n characters before it.
+                  Math.max(0, from - (trigger.length - text.length)),
+                  from,
+                ) + text;
+              if (trigger === input) {
+                // Check the per-suggestion-menu filter before activating.
+                if (
+                  menuOptions.shouldOpen &&
+                  !menuOptions.shouldOpen(view.state.tr)
+                ) {
+                  continue;
                 }
+                view.dispatch(view.state.tr.insertText(text));
+                view.dispatch(
+                  view.state.tr
+                    .setMeta(suggestionMenuPluginKey, {
+                      triggerCharacter: input,
+                    })
+                    .scrollIntoView(),
+                );
+                return true;
               }
             }
             return false;

--- a/packages/core/src/extensions/SuggestionMenu/SuggestionMenu.ts
+++ b/packages/core/src/extensions/SuggestionMenu/SuggestionMenu.ts
@@ -336,13 +336,23 @@ export const SuggestionMenu = createExtension(({ editor }) => {
             // only on insert
             if (from === to) {
               const doc = view.state.doc;
-              for (const [triggerChar, menuOptions] of suggestionMenus) {
-                const snippet =
-                  triggerChar.length > 1
-                    ? doc.textBetween(from - triggerChar.length, from) + text
-                    : text;
-
-                if (triggerChar === snippet) {
+              // Sort triggers by length (longest first) so that a more specific
+              // multi-character trigger (e.g. "img:") is preferred over a shorter
+              // one (e.g. ":") that would otherwise shadow it by matching first.
+              const triggers = [...suggestionMenus.entries()].sort(
+                ([a], [b]) => b.length - a.length,
+              );
+              for (const [trigger, menuOptions] of triggers) {
+                const input =
+                  doc.textBetween(
+                    // If the cursor is at the very start of the document, and we are checking if
+                    // an n-character trigger has been entered (e.g. "img:"), we need to get the n
+                    // characters before the text cursor to compare do so. However, the text cursor
+                    // may be near the start of the document and not have n characters before it.
+                    Math.max(0, from - trigger.length - text.length),
+                    from,
+                  ) + text;
+                if (trigger === input) {
                   // Check the per-suggestion-menu filter before activating.
                   if (
                     menuOptions.shouldOpen &&
@@ -354,7 +364,7 @@ export const SuggestionMenu = createExtension(({ editor }) => {
                   view.dispatch(
                     view.state.tr
                       .setMeta(suggestionMenuPluginKey, {
-                        triggerCharacter: snippet,
+                        triggerCharacter: input,
                       })
                       .scrollIntoView(),
                   );

--- a/packages/core/src/extensions/SuggestionMenu/SuggestionMenu.ts
+++ b/packages/core/src/extensions/SuggestionMenu/SuggestionMenu.ts
@@ -150,6 +150,12 @@ type SuggestionPluginState =
   | undefined;
 
 export type SuggestionMenuOptions = {
+  /**
+   * The string that opens the suggestion menu when typed. Usually a single
+   * character (e.g. `"/"` or `"@"`), but multi-character strings such as
+   * `"img:"` are also supported. When multiple triggers could match the typed
+   * text, the longest one takes precedence.
+   */
   triggerCharacter: string;
   /**
    * Optional callback to determine whether the suggestion menu should be


### PR DESCRIPTION
# Summary

Thanks to @Gxrvish for much of the code in this PR, originally from #2918!

<!-- Briefly describe the feature being introduced. -->

This PR fixes 2 issues r.e. suggestion menus:

1. Suggestion menus with multi-character triggers don't work properly. There is no prioritization of longer triggers, so given e.g. triggers `:` and `img:`, when `img:` is typed by the user, the `:` trigger suggestion menu may prioritized with no way to control this behaviour. Also, for longer triggers, checking if they are entered while the text cursor is at the start of the document will throw errors.
2. Inputting a suggestion menu trigger while a selection is active clears the selection but doesn't open the suggestion menu.

Issue 1 is fixed using basically the same code as proposed in #2918. Issue 2 is fixed by removing a check which ensures the selection is empty before opening a suggestion menu. Given that this was an intentional check we were making, this is more a change in behaviour rather than a bug fix.

Both issues are included in this PR as they touch basically the exact same snippet of code.

Closes #2905 
Closes #2090 

## Rationale

<!-- Explain the reasoning behind this feature and its benefits to the project. -->

While a suggestion menu's `triggerCharacter` suggests that a single character should be used, there is not much added complexity to make longer strings work.

As for the suggestion menu opening while a selection is active, this seems to be more in-line with the behaviour of other products.

## Changes

<!-- List the major changes made in this pull request. -->

- Removed check for empty selection when determining if a suggestion menu should be opened.
- Made suggestion menu triggers get ordered by length when determining if a suggestion menu should be opened.
- Added handling for edge case when a suggestion menu trigger is longer than the text before the cursor, so that we don't attempt to fetch text from an invalid position.
- Made a small update to docs to note that `triggerCharacter` also accepts longer strings.

## Impact

<!-- Discuss any potential impacts this feature may have on existing functionalities. -->

N/A

## Testing

<!-- Describe how the feature has been tested, including both automated and manual testing strategies. -->

Added unit tests.

## Screenshots/Video

<!-- Include screenshots or video demonstrating the new feature, if applicable. -->

N/A

## Checklist

- [X] Code follows the project's coding standards.
- [X] Unit tests covering the new feature have been added.
- [X] All existing tests pass.
- [X] The documentation has been updated to reflect the new feature

## Additional Notes

<!-- Any additional information or context relevant to this PR. -->

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Suggestion menus now support multi-character triggers such as `img:` and `ref:`.
  - Longer matching triggers take precedence over shorter overlapping triggers.
  - Shorter triggers remain available when a longer trigger does not match the surrounding text.

- **Documentation**
  - Updated guidance to explain multi-character suggestion-menu triggers and matching behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->