### PR TITLE
fix(xl-ai): Array.from on filtered iterator — tool calls never marked complete

### DIFF
--- a/packages/xl-ai/src/streamTool/vercelAiSdk/util/chatHandlers.ts
+++ b/packages/xl-ai/src/streamTool/vercelAiSdk/util/chatHandlers.ts
@@ -144,8 +144,8 @@ export async function setupToolCallStreaming(
   let errorSeen = false;
   // process results
   const toolCalls = Array.from(
-    toolCallStreams.values().filter((data) => data.complete),
-  );
+    toolCallStreams.values(),
+  ).filter((data) => data.complete);
   toolCalls.forEach((toolCall, index) => {
     const isErrorTool =
       toolCall.toolCallId === error?.chunk.metadata.toolCallId;


### PR DESCRIPTION
## Description

`s.values()` returns a `MapIterator` / `SetIterator`, not an array. Calling `.filter()` directly on an iterator throws `TypeError: s.values(...).filter is not a function` or silently fails depending on the runtime.

This causes **all tool calls to never be detected as complete**, meaning AI tool call suggestions never appear in the UI.

## Fix

Move `.filter()` to after `Array.from()`:

```diff
-const toolCalls = Array.from(
-    toolCallStreams.values().filter((data) => data.complete),
-);
+const toolCalls = Array.from(
+    toolCallStreams.values(),
+).filter((data) => data.complete);
```

## Related

Fixes #2933

## Testing

- [x] Existing tests should pass (built-in type check)
- No behavioral change — this is a pure bugfix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed tool-call processing so completed calls are correctly collected during AI response streaming.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->