### PR TITLE
fix(core): guard getBlock() calls to prevent TypeError on stale blocks

### DIFF
--- a/packages/core/src/api/clipboard/fromClipboard/handleFileInsertion.ts
+++ b/packages/core/src/api/clipboard/fromClipboard/handleFileInsertion.ts
@@ -170,9 +170,14 @@ export async function handleFileInsertion<
 
           const blockRect = blockElement?.getBoundingClientRect();
 
+          const existingBlock = editor.getBlock(id);
+          if (!existingBlock) {
+            return;
+          }
+
           return insertOrUpdateBlock(
             editor,
-            editor.getBlock(id)!,
+            existingBlock,
             fileBlock,
             blockRect && (blockRect.top + blockRect.bottom) / 2 > coords.top
               ? "before"
@@ -180,6 +185,10 @@ export async function handleFileInsertion<
           );
         });
       } else {
+        return;
+      }
+
+      if (!insertedBlockId) {
         return;
       }
 

--- a/packages/core/src/blocks/ToggleWrapper/createToggleWrapper.ts
+++ b/packages/core/src/blocks/ToggleWrapper/createToggleWrapper.ts
@@ -50,20 +50,25 @@ export const createToggleWrapper = (
   const toggleButtonOnClick = () => {
     // Toggles visibility of child blocks. Also adds/removes the "add block"
     // button if there are no child blocks.
+    const currentBlock = editor.getBlock(block);
+    if (!currentBlock) {
+      return;
+    }
+
     if (toggleWrapper.getAttribute("data-show-children") === "true") {
       toggleWrapper.setAttribute("data-show-children", "false");
-      toggledState.set(editor.getBlock(block)!, false);
+      toggledState.set(currentBlock, false);
 
       if (dom.contains(toggleAddBlockButton)) {
         dom.removeChild(toggleAddBlockButton);
       }
     } else {
       toggleWrapper.setAttribute("data-show-children", "true");
-      toggledState.set(editor.getBlock(block)!, true);
+      toggledState.set(currentBlock, true);
 
       if (
         editor.isEditable &&
-        editor.getBlock(block)?.children.length === 0 &&
+        currentBlock.children.length === 0 &&
         !dom.contains(toggleAddBlockButton)
       ) {
         dom.appendChild(toggleAddBlockButton);
@@ -111,7 +116,10 @@ export const createToggleWrapper = (
       // If a child block is added while children are hidden, show children.
       if (toggleWrapper.getAttribute("data-show-children") === "false") {
         toggleWrapper.setAttribute("data-show-children", "true");
-        toggledState.set(editor.getBlock(block)!, true);
+        const currentBlock = editor.getBlock(block);
+        if (currentBlock) {
+          toggledState.set(currentBlock, true);
+        }
       }
 
       // Remove the "add block" button as we want to show child blocks and
@@ -124,7 +132,10 @@ export const createToggleWrapper = (
       // children.
       if (toggleWrapper.getAttribute("data-show-children") === "true") {
         toggleWrapper.setAttribute("data-show-children", "false");
-        toggledState.set(editor.getBlock(block)!, false);
+        const currentBlock = editor.getBlock(block);
+        if (currentBlock) {
+          toggledState.set(currentBlock, false);
+        }
       }
 
       // Remove the "add block" button as we want to hide child blocks,

--- a/packages/core/src/extensions/SideMenu/SideMenu.ts
+++ b/packages/core/src/extensions/SideMenu/SideMenu.ts
@@ -241,6 +241,12 @@ export class SideMenuView<
     if (this.editor.isEditable) {
       const blockContentBoundingBox = block.node.getBoundingClientRect();
       const column = block.node.closest("[data-node-type=column]");
+      const sideMenuBlock = this.editor.getBlock(
+        this.hoveredBlock!.getAttribute("data-id")!,
+      );
+      if (!sideMenuBlock) {
+        return;
+      }
       this.state = {
         show: true,
         referencePos: new DOMRect(
@@ -257,9 +263,7 @@ export class SideMenuView<
           blockContentBoundingBox.width,
           blockContentBoundingBox.height,
         ),
-        block: this.editor.getBlock(
-          this.hoveredBlock!.getAttribute("data-id")!,
-        )!,
+        block: sideMenuBlock,
       };
       this.updateState(this.state);
     }

--- a/packages/core/src/extensions/SideMenu/SideMenu.ts
+++ b/packages/core/src/extensions/SideMenu/SideMenu.ts
@@ -245,6 +245,11 @@ export class SideMenuView<
         this.hoveredBlock!.getAttribute("data-id")!,
       );
       if (!sideMenuBlock) {
+        if (this.state?.show) {
+          this.state.show = false;
+          this.hoveredBlock = undefined;
+          this.emitUpdate(this.state);
+        }
         return;
       }
       this.state = {

--- a/packages/core/src/extensions/TableHandles/TableHandles.ts
+++ b/packages/core/src/extensions/TableHandles/TableHandles.ts
@@ -533,10 +533,10 @@ export class TableHandlesView implements PluginView {
     }
 
     // Hide handles if the table block has been removed.
-    this.state.block = this.editor.getBlock(this.state.block.id) as any;
+    const refreshedBlock = this.editor.getBlock(this.state.block.id);
     if (
-      !this.state.block ||
-      this.state.block.type !== "table" ||
+      !refreshedBlock ||
+      refreshedBlock.type !== "table" ||
       // when collaborating, the table element might be replaced and out of date
       // because yjs replaces the element when for example you change the color via the side menu
       !this.tableElement?.isConnected
@@ -548,6 +548,7 @@ export class TableHandlesView implements PluginView {
 
       return;
     }
+    this.state.block = refreshedBlock as typeof this.state.block;
 
     const { height: rowCount, width: colCount } = getDimensionsOfTable(
       this.state.block,

--- a/packages/core/src/extensions/TableHandles/TableHandles.ts
+++ b/packages/core/src/extensions/TableHandles/TableHandles.ts
@@ -533,7 +533,7 @@ export class TableHandlesView implements PluginView {
     }
 
     // Hide handles if the table block has been removed.
-    this.state.block = this.editor.getBlock(this.state.block.id)!;
+    this.state.block = this.editor.getBlock(this.state.block.id) as any;
     if (
       !this.state.block ||
       this.state.block.type !== "table" ||

--- a/packages/react/src/blocks/ToggleWrapper/ToggleWrapper.tsx
+++ b/packages/react/src/blocks/ToggleWrapper/ToggleWrapper.tsx
@@ -58,10 +58,11 @@ export const ToggleWrapper = (
   );
 
   const handleToggle = (block: Block<any, any, any>) => {
-    (toggledState || defaultToggledState).set(
-      editor.getBlock(block)!,
-      !showChildren,
-    );
+    const currentBlock = editor.getBlock(block);
+    if (!currentBlock) {
+      return;
+    }
+    (toggledState || defaultToggledState).set(currentBlock, !showChildren);
     dispatch({
       type: "toggled",
     });
@@ -91,7 +92,10 @@ export const ToggleWrapper = (
         return 0;
       }
 
-      const newBlock = editor.getBlock(block)!;
+      const newBlock = editor.getBlock(block);
+      if (!newBlock) {
+        return 0;
+      }
       const newChildCount = newBlock.children.length || 0;
 
       if (newChildCount > childCount) {
@@ -122,7 +126,7 @@ export const ToggleWrapper = (
           className="bn-toggle-button"
           type="button"
           onMouseDown={(event) => event.preventDefault()}
-          onClick={() => handleToggle(editor.getBlock(block)!)}
+          onClick={() => handleToggle(block)}
         >
           <svg
             xmlns="http://www.w3.org/2000/svg"

--- a/packages/react/src/components/FilePanel/DefaultTabs/EmbedTab.tsx
+++ b/packages/react/src/components/FilePanel/DefaultTabs/EmbedTab.tsx
@@ -41,6 +41,9 @@ export const EmbedTab = <
     (event: KeyboardEvent) => {
       if (event.key === "Enter" && !event.nativeEvent.isComposing) {
         event.preventDefault();
+        if (!editor.getBlock(props.blockId)) {
+          return;
+        }
         editor.updateBlock(props.blockId, {
           props: {
             name: filenameFromURL(currentURL),
@@ -53,6 +56,9 @@ export const EmbedTab = <
   );
 
   const handleURLClick = useCallback(() => {
+    if (!editor.getBlock(props.blockId)) {
+      return;
+    }
     editor.updateBlock(props.blockId, {
       props: {
         name: filenameFromURL(currentURL),

--- a/packages/react/src/components/FilePanel/DefaultTabs/EmbedTab.tsx
+++ b/packages/react/src/components/FilePanel/DefaultTabs/EmbedTab.tsx
@@ -26,7 +26,7 @@ export const EmbedTab = <
 
   const editor = useBlockNoteEditor<B, I, S>();
 
-  const block = editor.getBlock(props.blockId)!;
+  const block = editor.getBlock(props.blockId);
 
   const [currentURL, setCurrentURL] = useState<string>("");
 
@@ -41,7 +41,7 @@ export const EmbedTab = <
     (event: KeyboardEvent) => {
       if (event.key === "Enter" && !event.nativeEvent.isComposing) {
         event.preventDefault();
-        editor.updateBlock(block.id, {
+        editor.updateBlock(props.blockId, {
           props: {
             name: filenameFromURL(currentURL),
             url: currentURL,
@@ -49,17 +49,21 @@ export const EmbedTab = <
         });
       }
     },
-    [editor, block.id, currentURL],
+    [editor, props.blockId, currentURL],
   );
 
   const handleURLClick = useCallback(() => {
-    editor.updateBlock(block.id, {
+    editor.updateBlock(props.blockId, {
       props: {
         name: filenameFromURL(currentURL),
         url: currentURL,
       } as any,
     });
-  }, [editor, block.id, currentURL]);
+  }, [editor, props.blockId, currentURL]);
+
+  if (!block) {
+    return null;
+  }
 
   return (
     <Components.FilePanel.TabPanel className={"bn-tab-panel"}>

--- a/packages/react/src/components/FilePanel/DefaultTabs/UploadTab.tsx
+++ b/packages/react/src/components/FilePanel/DefaultTabs/UploadTab.tsx
@@ -53,6 +53,9 @@ export const UploadTab = <
         if (editor.uploadFile !== undefined) {
           try {
             let updateData = await editor.uploadFile(file, props.blockId);
+            if (!editor.getBlock(props.blockId)) {
+              return;
+            }
             if (typeof updateData === "string") {
               // received a url
               updateData = {

--- a/packages/react/src/components/FilePanel/DefaultTabs/UploadTab.tsx
+++ b/packages/react/src/components/FilePanel/DefaultTabs/UploadTab.tsx
@@ -29,7 +29,7 @@ export const UploadTab = <
 
   const editor = useBlockNoteEditor<B, I, S>();
 
-  const block = editor.getBlock(props.blockId)!;
+  const block = editor.getBlock(props.blockId);
 
   const [uploadFailed, setUploadFailed] = useState<boolean>(false);
 
@@ -75,6 +75,10 @@ export const UploadTab = <
     },
     [props.blockId, editor, setLoading],
   );
+
+  if (!block) {
+    return null;
+  }
 
   const spec = editor.schema.blockSpecs[block.type];
   const accept = spec.implementation.meta?.fileBlockAccept?.length

--- a/packages/xl-ai/src/api/formats/markdown-blocks/tools/rebaseTool.ts
+++ b/packages/xl-ai/src/api/formats/markdown-blocks/tools/rebaseTool.ts
@@ -11,7 +11,11 @@ export function createMDRebaseTool(
   editor: BlockNoteEditor<any, any, any>,
 ) {
   const tr = getApplySuggestionsTr(editor);
-  const md = editor.blocksToMarkdownLossy([getBlock(tr.doc, id)!]);
+  const block = getBlock(tr.doc, id);
+  if (!block) {
+    throw new Error("block not found");
+  }
+  const md = editor.blocksToMarkdownLossy([block]);
   const blocks = editor.tryParseMarkdownToBlocks(md);
 
   const steps = updateToReplaceSteps(


### PR DESCRIPTION
# Summary

Guard all unguarded `editor.getBlock()!` non-null assertions across the codebase to prevent uncaught `TypeError`s when blocks are removed from the document while closures still reference them.

## Rationale

When a block is removed (via undo, collaborative editing, `replaceBlocks`, or menu actions that recreate the block), closed-over block references become stale and `getBlock()` returns `undefined`. The non-null assertion (`!`) lets `undefined` pass through, causing uncaught `TypeError: Cannot read properties of undefined (reading 'id')` in DOM event handlers and React callbacks. These errors escape React error boundaries and land in `window.onerror`, making them indistinguishable from real crashes in error monitoring. This is the same class of bug previously fixed in TableHandles (#2821/#2847).

## Changes

- **`createToggleWrapper.ts`**: Guard 4 `getBlock(block)!` calls — early-return in click handler, conditional guard in `onChange` callback.
- **`ToggleWrapper.tsx`** (React): Guard 3 `getBlock(block)!` calls — early-return in `handleToggle`, return 0 in `useEditorState` selector, pass `block` directly to click handler.
- **`SideMenu.ts`**: Extract `getBlock()` into a variable and guard before state assignment.
- **`TableHandles.ts`**: Remove misleading `!` assertion (line already has a null check on the next line).
- **`handleFileInsertion.ts`**: Guard `getBlock(id)!` and downstream `insertedBlockId` usage.
- **`rebaseTool.ts`** (markdown): Add guard matching the HTML counterpart's existing pattern.
- **`EmbedTab.tsx`** / **`UploadTab.tsx`**: Remove `!`, add null guard after hooks (respecting React rules of hooks).

## Impact

No functional changes for the happy path. Stale block references now silently bail out instead of throwing uncaught errors. This matches the existing guarded patterns already used elsewhere in the codebase (optional chaining on the same `getBlock()` calls, the #2821 TableHandles fix).

## Testing

- `vp run lint` passes with 0 errors.
- `vp run build` succeeds across all packages.
- `vp run test` passes all 695+ unit tests across all packages.

## Checklist

- [x] Code follows the project's coding standards.
- [ ] Unit tests covering the new feature have been added.
- [x] All existing tests pass.
- [ ] The documentation has been updated to reflect the new feature

## Additional Notes

No unit tests added — the bug requires a stale block reference from a removed DOM node, which is difficult to reproduce deterministically (the issue reporter also could not find reliable manual repro steps). The fix is a defensive guard pattern consistent with existing code.

Fixes #2907

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability when blocks are deleted or unavailable during file uploads, embeds, toggles, table interactions, and side-menu actions.
  * Prevented invalid updates and UI errors when referenced blocks no longer exist.
  * Added clearer handling for unavailable blocks during Markdown-related operations.
  * Upload and embed panels now safely stop rendering when their associated block cannot be found.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->