### PR TITLE
feat(pdf): add custom font and fontFamily options for CJK

### DIFF
--- a/packages/xl-pdf-exporter/src/pdf/index.ts
+++ b/packages/xl-pdf-exporter/src/pdf/index.ts
@@ -1,2 +1,3 @@
 export * from "./defaultSchema/index.js";
 export * from "./pdfExporter.jsx";
+export { Font } from "@react-pdf/renderer";

--- a/packages/xl-pdf-exporter/src/pdf/pdfExporter.tsx
+++ b/packages/xl-pdf-exporter/src/pdf/pdfExporter.tsx
@@ -35,6 +35,26 @@ type Options = ExporterOptions & {
    * @default uses Twemoji images from jdecked/twemoji on jsDelivr CDN
    */
   emojiSource: false | ReturnType<typeof Font.getEmojiSource>;
+  /**
+   * Additional fonts to register for PDF rendering.
+   * Each entry is passed directly to react-pdf's `Font.register()`.
+   *
+   * Useful for adding support for non-Latin scripts (e.g., CJK characters).
+   *
+   * @example
+   * fonts: [
+   *   {
+   *     family: "NotoSansSC",
+   *     src: "https://fonts.gstatic.com/s/notosanssc/...",
+   *   },
+   * ],
+   */
+  fonts?: Parameters<typeof Font.register>[0][];
+  /**
+   * Override the default font family for the PDF document.
+   * @default "Inter"
+   */
+  fontFamily?: string;
 };
 
 /**
@@ -243,6 +263,12 @@ export class PDFExporter<
       src: font,
     });
 
+    if (this.options.fonts) {
+      for (const f of this.options.fonts) {
+        Font.register(f);
+      }
+    }
+
     this.fontsRegistered = true;
   }
 
@@ -266,9 +292,13 @@ export class PDFExporter<
   ) {
     await this.registerFonts();
 
+    const pageStyle = this.options.fontFamily
+      ? { ...this.styles.page, fontFamily: this.options.fontFamily }
+      : this.styles.page;
+
     return (
       <Document>
-        <Page dpi={100} size="A4" style={this.styles.page}>
+        <Page dpi={100} size="A4" style={pageStyle}>
           {options.header && (
             <View fixed style={this.styles.header}>
               {options.header}


### PR DESCRIPTION
# Summary

Adds `fonts` and `fontFamily` options to `PDFExporter` so users can register custom fonts and override the default font family, enabling support for non-Latin scripts like CJK (Chinese, Japanese, Korean) characters.

## Rationale

The PDF exporter only registers Inter and GeistMono fonts, neither of which contain CJK glyphs. When users export documents containing Mandarin or other CJK characters, the output is corrupted/unrecognizable. There was no way for users to register additional fonts or change the default font family.

Fixes #2037

## Changes

- Added `fonts` option to `PDFExporter` constructor — accepts an array of font registrations passed directly to react-pdf's `Font.register()`
- Added `fontFamily` option to override the default `"Inter"` page font family
- User-provided fonts are registered in `registerFonts()` after the built-in defaults
- Custom `fontFamily` is applied to the page style in `toReactPDFDocument()`
- Re-exported `Font` from `@react-pdf/renderer` so users can register fonts without adding react-pdf as a direct dependency

## Impact

Fully backward compatible — both new options are optional and default to the existing behavior. No changes to the default PDF output.

## Testing

All 7 existing PDF exporter tests pass. Lint passes with no new warnings.

## Checklist

- [x] Code follows the project's coding standards.
- [ ] Unit tests covering the new feature have been added.
- [x] All existing tests pass.
- [ ] The documentation has been updated to reflect the new feature

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for registering custom fonts in exported PDFs.
  * Added an option to set the default font family for PDF documents.
  * Made the PDF font registration utility publicly available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->