### PR TITLE
fix(ai): operations on collaborative documents

### DIFF
--- a/packages/core/src/yjs/extensions/ForkYDoc.test.ts
+++ b/packages/core/src/yjs/extensions/ForkYDoc.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it } from "vite-plus/test";
+import { trackPosition } from "../../api/positionMapping.js";
 import * as Y from "yjs";
 import { Awareness } from "y-protocols/awareness";
 import { BlockNoteEditor } from "../../index.js";
@@ -212,5 +213,41 @@ describe("ForkYDocExtension", () => {
     // Merge and keep changes
     forkYDoc.merge({ keepChanges: true });
     expect(getEditorText(ctx.editor)).toContain("Forked modification");
+  });
+
+  // https://github.com/TypeCellOS/BlockNote/issues/2946
+  it("can track positions while forked", () => {
+    ctx = createCollabEditor();
+    setEditorText(ctx.editor, "Hello World");
+
+    const forkYDoc = ctx.editor.getExtension(ForkYDocExtension)!;
+    forkYDoc.fork();
+
+    // Store position at "Hello| World"
+    const getCursorPos = trackPosition(ctx.editor, 8);
+    expect(getCursorPos()).toBe(8);
+
+    // Insert text at the beginning of "|Hello World"
+    ctx.editor._tiptapEditor.commands.insertContentAt(3, "Test ");
+    expect(getCursorPos()).toBe(13);
+  });
+
+  // https://github.com/TypeCellOS/BlockNote/issues/2946
+  it("can track positions across fork and merge", () => {
+    ctx = createCollabEditor();
+    setEditorText(ctx.editor, "Hello World");
+
+    // Store position at "Hello| World"
+    const getCursorPos = trackPosition(ctx.editor, 8);
+
+    const forkYDoc = ctx.editor.getExtension(ForkYDocExtension)!;
+    forkYDoc.fork();
+    expect(getCursorPos()).toBe(8);
+
+    ctx.editor._tiptapEditor.commands.insertContentAt(3, "Test ");
+    expect(getCursorPos()).toBe(13);
+
+    forkYDoc.merge({ keepChanges: true });
+    expect(getCursorPos()).toBe(13);
   });
 });

--- a/packages/core/src/yjs/extensions/ForkYDoc.ts
+++ b/packages/core/src/yjs/extensions/ForkYDoc.ts
@@ -1,5 +1,6 @@
-import { yUndoPluginKey } from "y-prosemirror";
+import { ySyncPluginKey, yUndoPluginKey } from "y-prosemirror";
 import * as Y from "yjs";
+import type { BlockNoteEditor } from "../../editor/BlockNoteEditor.js";
 import {
   createExtension,
   createStore,
@@ -10,6 +11,26 @@ import { YCursorExtension } from "./YCursorPlugin.js";
 import { YSyncExtension } from "./YSync.js";
 import { YUndoExtension } from "./YUndo.js";
 import { findTypeInOtherYdoc } from "../utils.js";
+
+/**
+ * Point the `ySync` plugin state at `fragment`.
+ *
+ * Swapping the `ySync` plugin reconfigures the ProseMirror state, and
+ * ProseMirror carries over the state of plugins that share a key instead of
+ * re-initializing them. So the new plugin's `binding` (which is set from its
+ * view, via a transaction) ends up on the new fragment, while `type` and `doc`
+ * still point at the fragment the editor was bound to before. Anything reading
+ * those (e.g. `RelativePositionMappingExtension`) would then mix up the two
+ * Y.Docs, so we set them explicitly here.
+ */
+function bindYSyncPluginStateTo(
+  editor: BlockNoteEditor<any, any, any>,
+  fragment: Y.XmlFragment,
+) {
+  editor.transact((tr) =>
+    tr.setMeta(ySyncPluginKey, { type: fragment, doc: fragment.doc }),
+  );
+}
 
 export const ForkYDocExtension = createExtension(
   ({ editor, options }: ExtensionOptions<CollaborationOptions>) => {
@@ -84,6 +105,8 @@ export const ForkYDocExtension = createExtension(
           ],
         );
 
+        bindYSyncPluginStateTo(editor, forkedFragment);
+
         // Tell the store that the editor is now forked
         store.setState({ isForked: true });
       },
@@ -109,6 +132,8 @@ export const ForkYDocExtension = createExtension(
             YUndoExtension(),
           ],
         );
+
+        bindYSyncPluginStateTo(editor, originalFragment);
 
         // Reset the undo stack to the original undo stack
         yUndoPluginKey.getState(

--- a/packages/core/src/yjs/extensions/RelativePositionMapping.ts
+++ b/packages/core/src/yjs/extensions/RelativePositionMapping.ts
@@ -51,9 +51,15 @@ export const RelativePositionMappingExtension = createExtension(
           const curYSyncPluginState = ySyncPluginKey.getState(
             editor.prosemirrorState,
           ) as typeof ySyncPluginState;
+          // Resolve against the doc that owns the currently bound type, and not
+          // against `curYSyncPluginState.doc`. Those can point at different
+          // Y.Docs (e.g. right after forking the doc, see `ForkYDocExtension`),
+          // in which case the resolved type wouldn't be part of the bound
+          // fragment and the position would be reported as "not found".
+          const boundType = curYSyncPluginState.binding.type;
           const pos = relativePositionToAbsolutePosition(
-            curYSyncPluginState.doc,
-            curYSyncPluginState.binding.type,
+            boundType.doc,
+            boundType,
             relativePosition,
             curYSyncPluginState.binding.mapping,
           );

--- a/packages/xl-ai/package.json
+++ b/packages/xl-ai/package.json
@@ -114,7 +114,8 @@
     "typescript": "^5.9.3",
     "undici": "^6.22.0",
     "vite-plugin-externalize-deps": "^0.10.0",
-    "vite-plus": "catalog:"
+    "vite-plus": "catalog:",
+    "yjs": "^13.6.27"
   },
   "peerDependencies": {
     "react": "^18.0 || ^19.0 || >= 19.0.0-rc",

--- a/packages/xl-ai/src/api/formats/html-blocks/collabUpdate.test.ts
+++ b/packages/xl-ai/src/api/formats/html-blocks/collabUpdate.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Regression test for https://github.com/TypeCellOS/BlockNote/issues/2946
+ *
+ * Runs the `update` stream tool against a Yjs-collaborative editor, fully
+ * offline (no LLM call): the tool call is fed straight into the executor.
+ *
+ * `AIExtension.invokeAI` forks the Y.Doc before the request starts, so the
+ * fork is part of the setup here.
+ */
+import {
+  BlockNoteEditor,
+  expandPMRangeToWords,
+  getBlockInfo,
+  getNodeById,
+} from "@blocknote/core";
+import type { ForkYDocExtension } from "@blocknote/core/yjs";
+import { withCollaboration } from "@blocknote/core/yjs";
+import { TextSelection } from "prosemirror-state";
+import { describe, expect, it } from "vite-plus/test";
+import * as Y from "yjs";
+
+import { AIExtension } from "../../../AIExtension.js";
+import { StreamToolExecutor } from "../../../streamTool/StreamToolExecutor.js";
+import { StreamTool } from "../../../streamTool/streamTool.js";
+import { tools } from "./tools/index.js";
+
+function createLocalEditor(text: string) {
+  const editor = BlockNoteEditor.create({
+    initialContent: [{ type: "paragraph", content: text }],
+    trailingBlock: false,
+    extensions: [AIExtension()],
+  });
+  editor.mount(document.createElement("div"));
+
+  return { editor, fork: () => undefined };
+}
+
+function createCollabEditor(text: string) {
+  const ydoc = new Y.Doc();
+  const editor = BlockNoteEditor.create(
+    withCollaboration({
+      collaboration: {
+        fragment: ydoc.getXmlFragment("doc"),
+        user: { color: "#ff0000", name: "Local User" },
+        provider: undefined,
+      },
+      trailingBlock: false,
+      extensions: [AIExtension()],
+    }),
+  );
+  editor.mount(document.createElement("div"));
+
+  editor.replaceBlocks(editor.document, [{ type: "paragraph", content: text }]);
+
+  return {
+    editor,
+    fork: () =>
+      editor.getExtension<typeof ForkYDocExtension>("yForkDoc")?.fork(),
+  };
+}
+
+/**
+ * Selects the full content of the first block, mirroring what the AI menu does
+ * (`buildAIRequest` -> `expandPMRangeToWords`)
+ */
+function selectWholeFirstBlock(editor: BlockNoteEditor<any, any, any>) {
+  const id = editor.document[0].id;
+  const info = getBlockInfo(getNodeById(id, editor.prosemirrorState.doc)!);
+  if (!info.isBlockContainer) {
+    throw new Error("not a block container");
+  }
+  const from = info.blockContent.beforePos + 1;
+  const to = info.blockContent.afterPos - 1;
+
+  editor.transact((tr) => {
+    tr.setSelection(TextSelection.create(tr.doc, from, to));
+  });
+
+  return expandPMRangeToWords(editor.prosemirrorState.doc, {
+    $from: editor.prosemirrorState.doc.resolve(from),
+    $to: editor.prosemirrorState.doc.resolve(to),
+  });
+}
+
+async function runUpdate(
+  editor: BlockNoteEditor<any, any, any>,
+  id: string,
+  html: string,
+  selection?: { from: number; to: number },
+) {
+  const streamTools = [
+    tools.update(editor, {
+      idsSuffixed: false,
+      withDelays: false,
+      updateSelection: selection,
+    }),
+  ] as StreamTool<any>[];
+
+  await new StreamToolExecutor(streamTools).execute(
+    (async function* () {
+      yield {
+        operation: { type: "update" as const, id, block: html },
+        isUpdateToPreviousOperation: false,
+        isPossiblyPartial: false,
+        metadata: undefined,
+      };
+    })(),
+  );
+}
+
+describe.each([
+  ["local", createLocalEditor],
+  ["collaborative", createCollabEditor],
+])("update tool (%s)", (_name, createEditor) => {
+  it("updates a selected paragraph", async () => {
+    const { editor, fork } = createEditor("Bonjour le monde");
+    fork();
+    const id = editor.document[0].id;
+    const selection = selectWholeFirstBlock(editor);
+
+    await runUpdate(editor, id, "<p>Bonjour à tous</p>", selection);
+
+    editor.getExtension(AIExtension)?.acceptChanges();
+    expect((editor.document[0] as any).content[0].text).toBe("Bonjour à tous");
+  });
+
+  it("updates a paragraph without a selection", async () => {
+    const { editor, fork } = createEditor("Bonjour le monde");
+    fork();
+    const id = editor.document[0].id;
+
+    await runUpdate(editor, id, "<p>Bonjour à tous</p>");
+
+    editor.getExtension(AIExtension)?.acceptChanges();
+    expect((editor.document[0] as any).content[0].text).toBe("Bonjour à tous");
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5503,6 +5503,9 @@ importers:
       vite-plus:
         specifier: 'catalog:'
         version: 0.1.24(@opentelemetry/api@1.9.1)(@types/node@22.13.13)(esbuild@0.27.5)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.0.1)(canvas@3.1.0))(terser@5.46.2)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0)
+      yjs:
+        specifier: ^13.6.27
+        version: 13.6.30
 
   packages/xl-ai-server:
     dependencies:


### PR DESCRIPTION
# Summary

Fixes #2946

Running any AI request on a selection in a Yjs-collaborative document fails with `Position not found, cannot track positions`.

## Rationale

`AIExtension.invokeAI` forks the Y.Doc before a request starts, so AI changes don't reach other collaborators until they're accepted. Forking swaps the `ySync` plugin, which reconfigures the ProseMirror state — and ProseMirror carries over the state of plugins that share a key instead of re-initializing them.

The new plugin's `binding` still ends up on the forked fragment (it's set from the plugin's view, via a transaction), but `type` and `doc` keep pointing at the fragment the editor was bound to before. The plugin state ends up split across two Y.Docs:

```js
ySyncPluginKey.getState(state)
// { type: originalFragment, doc: originalDoc, binding: newBinding(forkedFragment) }
```

`RelativePositionMappingExtension.mapPosition` then resolved with the stale `doc` and the new `binding.type`. y-prosemirror decodes the position against `doc`, notices the resulting type isn't part of `documentType`, and returns `null` — every single lookup, not just garbage-collected ones.

`createUpdateBlockTool` calls `trackPosition` for `updateSelection.from`/`to` to follow the selection across the LLM round-trip, so it threw on the first chunk of the response. The LLM call itself succeeded (`chat.status === "ready"`), which is why the AI menu showed a generic error despite a perfectly valid tool call.

## Changes

- `ForkYDocExtension`: re-point the `ySync` plugin state's `type`/`doc` at the newly bound fragment, on both `fork()` and `merge()`.
- `RelativePositionMappingExtension`: resolve relative positions against the doc that owns the currently bound type, rather than the plugin state's `doc`.

## Impact

Fixing the plugin state at the source also covers other readers of `ySyncPluginKey.getState(...).type` / `.doc` while forked, including y-prosemirror's own sync plugin, which wraps local ProseMirror changes in a transaction on `pluginState.doc`.

The mapping change is a no-op when not forked: `binding.type.doc` and `pluginState.doc` are the same Y.Doc.

Positions tracked before a fork keep resolving after it — forking copies the Y.Doc, so item IDs are preserved on both sides — which the second test below covers.

## Testing

- `ForkYDoc.test.ts`: tracking a position while forked, and tracking one across fork → edit → merge. Both fail on `main` with `Position not found, cannot track positions`.
- `collabUpdate.test.ts`: runs the `update` stream tool end-to-end against a forked collaborative editor, parameterized over local/collaborative so the two are held to the same result. Runs fully offline — the tool call is fed straight into `StreamToolExecutor`, no LLM.

`packages/core` 716 passed / 9 skipped, `packages/xl-ai` 204 passed / 260 skipped (skips are the API-key-gated model suites, unchanged).

## Checklist

- [x] Code follows the project's coding standards.
- [x] Unit tests covering the new feature have been added.
- [x] All existing tests pass.
- [ ] The documentation has been updated to reflect the new feature

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved collaborative editing when documents are forked and merged, preserving text positions and selections.
  * Prevented stale document or fragment references after switching between forked and merged content.
  * Improved position tracking for updates made within collaborative documents.
  * Fixed AI HTML updates in both local and collaborative editors, including scenarios with and without an active selection.

* **Tests**
  * Added coverage for fork/merge position tracking and AI update workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->