### PR TITLE
fix(ai): operations on blocks containing comments

### DIFF
--- a/packages/core/src/yjs/comments/RESTYjsThreadStore.test.ts
+++ b/packages/core/src/yjs/comments/RESTYjsThreadStore.test.ts
@@ -1,0 +1,85 @@
+/**
+ * @vitest-environment jsdom
+ */
+import {
+  relativePositionToAbsolutePosition,
+  ySyncPluginKey,
+} from "y-prosemirror";
+import { afterEach, describe, expect, it, vi } from "vite-plus/test";
+import * as Y from "yjs";
+import { BlockNoteEditor } from "../../editor/BlockNoteEditor.js";
+import { DefaultThreadStoreAuth } from "../../comments/threadstore/DefaultThreadStoreAuth.js";
+import { withCollaboration } from "../extensions/index.js";
+import { RESTYjsThreadStore } from "./RESTYjsThreadStore.js";
+
+function createCollabEditor() {
+  const doc = new Y.Doc();
+  const fragment = doc.getXmlFragment("doc");
+  const editor = BlockNoteEditor.create(
+    withCollaboration({
+      collaboration: {
+        fragment,
+        user: { name: "Test User", color: "#FF0000" },
+        provider: undefined,
+      },
+      trailingBlock: false,
+    }),
+  );
+  editor.mount(document.createElement("div"));
+  editor.replaceBlocks(editor.document, [
+    { type: "paragraph", content: "Hello World" },
+  ]);
+  return { editor, doc, fragment };
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("RESTYjsThreadStore", () => {
+  it("sends resolvable yjs positions along with the thread", async () => {
+    const { editor, doc, fragment } = createCollabEditor();
+
+    const requests: any[] = [];
+    vi.spyOn(globalThis, "fetch").mockImplementation((async (
+      _url: any,
+      init: any,
+    ) => {
+      requests.push(JSON.parse(init.body));
+      return new Response("{}", {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }) as any);
+
+    const store = new RESTYjsThreadStore(
+      "https://example.com/threads",
+      {},
+      doc.getMap("threads"),
+      new DefaultThreadStoreAuth("user-1", "editor"),
+    );
+
+    await store.addThreadToDocument({
+      threadId: "thread-1",
+      selection: { anchor: 3, head: 8 },
+      editor,
+    });
+
+    expect(requests).toHaveLength(1);
+    const { yjs } = requests[0].selection;
+    expect(yjs).toBeDefined();
+
+    // the relative positions must resolve back to the positions we passed in
+    const state = ySyncPluginKey.getState(editor.prosemirrorState) as any;
+    const resolve = (relPos: any) =>
+      relativePositionToAbsolutePosition(
+        fragment.doc!,
+        state.binding.type,
+        Y.createRelativePositionFromJSON(relPos),
+        state.binding.mapping,
+      );
+
+    expect(resolve(yjs.anchor)).toBe(3);
+    expect(resolve(yjs.head)).toBe(8);
+  });
+});

--- a/packages/core/src/yjs/comments/RESTYjsThreadStore.ts
+++ b/packages/core/src/yjs/comments/RESTYjsThreadStore.ts
@@ -59,7 +59,13 @@ export class RESTYjsThreadStore extends YjsThreadStoreBase {
   }) => {
     const { threadId, selection } = options;
 
-    const binding = ySyncPluginKey.getState(options.editor.prosemirrorState);
+    // Note: the positions have to be resolved against the *binding's* type and
+    // mapping. The plugin state has a `type` of its own, but no `mapping`, and
+    // its `type` can go stale (e.g. while the doc is forked, see
+    // `ForkYDocExtension`).
+    const binding = ySyncPluginKey.getState(
+      options.editor.prosemirrorState,
+    )?.binding;
     const yjsSelection = binding
       ? {
           head: absolutePositionToRelativePosition(

--- a/packages/xl-ai/src/api/formats/html-blocks/commentedContent.test.ts
+++ b/packages/xl-ai/src/api/formats/html-blocks/commentedContent.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Regression test for https://github.com/TypeCellOS/BlockNote/issues/2947
+ *
+ * Comment marks are `blocknoteIgnore` marks: they're not part of the BlockNote
+ * document model and don't survive an HTML round-trip. The HTML rebase tool
+ * used to treat that as a fatal "html diff", which made every AI operation on a
+ * block containing a comment fail.
+ *
+ * Runs fully offline (no LLM call): tool calls are fed straight into the
+ * executor.
+ */
+import { BlockNoteEditor, createExtension } from "@blocknote/core";
+import { CommentMark } from "@blocknote/core/comments";
+import { describe, expect, it } from "vite-plus/test";
+
+import { AIExtension } from "../../../AIExtension.js";
+import { StreamToolExecutor } from "../../../streamTool/StreamToolExecutor.js";
+import { StreamTool } from "../../../streamTool/streamTool.js";
+import { tools } from "./tools/index.js";
+import { createHTMLRebaseTool } from "./tools/rebaseTool.js";
+
+/**
+ * Registers just the comment mark. The full `CommentsExtension` needs a thread
+ * store and user resolver, neither of which affects the document model.
+ */
+const CommentMarkExtension = createExtension(() => ({
+  key: "commentMarkOnly",
+  tiptapExtensions: [CommentMark],
+}));
+
+function createEditorWithComment() {
+  const editor = BlockNoteEditor.create({
+    initialContent: [
+      { id: "ref1", type: "paragraph", content: "Hello, world!" },
+      { id: "ref2", type: "paragraph", content: "How are you?" },
+    ],
+    trailingBlock: false,
+    extensions: [AIExtension(), CommentMarkExtension()],
+  });
+  editor.mount(document.createElement("div"));
+
+  // comment on "Hello" in the first block
+  editor.transact((tr) =>
+    tr.addMark(
+      3,
+      8,
+      editor.pmSchema.marks.comment.create({
+        threadId: "thread-1",
+        orphan: false,
+      }),
+    ),
+  );
+
+  return editor;
+}
+
+function commentedRanges(editor: BlockNoteEditor<any, any, any>) {
+  const ranges: { text: string; threadId: string }[] = [];
+  editor.prosemirrorState.doc.descendants((node) => {
+    const mark = node.marks.find((m) => m.type.name === "comment");
+    if (mark) {
+      ranges.push({ text: node.text!, threadId: mark.attrs.threadId });
+    }
+  });
+  return ranges;
+}
+
+async function runUpdate(
+  editor: BlockNoteEditor<any, any, any>,
+  id: string,
+  html: string,
+) {
+  const streamTools = [
+    tools.update(editor, { idsSuffixed: false, withDelays: false }),
+  ] as StreamTool<any>[];
+
+  await new StreamToolExecutor(streamTools).execute(
+    (async function* () {
+      yield {
+        operation: { type: "update" as const, id, block: html },
+        isUpdateToPreviousOperation: false,
+        isPossiblyPartial: false,
+        metadata: undefined,
+      };
+    })(),
+  );
+}
+
+describe("blocks containing comments", () => {
+  it("can build a rebase tool for a commented block", () => {
+    const editor = createEditorWithComment();
+
+    expect(() => createHTMLRebaseTool("ref1", editor)).not.toThrow();
+  });
+
+  it("updates a block that contains a comment", async () => {
+    const editor = createEditorWithComment();
+
+    await runUpdate(editor, "ref1", "<p>Hello, universe!</p>");
+
+    editor.getExtension(AIExtension)?.acceptChanges();
+    expect((editor.document[0] as any).content[0].text).toBe(
+      "Hello, universe!",
+    );
+    // the untouched part of the comment is still anchored
+    expect(commentedRanges(editor)).toEqual([
+      { text: "Hello", threadId: "thread-1" },
+    ]);
+  });
+
+  it("updates a sibling block while another block has a comment", async () => {
+    const editor = createEditorWithComment();
+
+    await runUpdate(editor, "ref2", "<p>How do you do?</p>");
+
+    editor.getExtension(AIExtension)?.acceptChanges();
+    expect((editor.document[1] as any).content[0].text).toBe("How do you do?");
+    expect(commentedRanges(editor)).toEqual([
+      { text: "Hello", threadId: "thread-1" },
+    ]);
+  });
+});

--- a/packages/xl-ai/src/api/formats/html-blocks/tools/rebaseTool.ts
+++ b/packages/xl-ai/src/api/formats/html-blocks/tools/rebaseTool.ts
@@ -1,4 +1,5 @@
 import { BlockNoteEditor, getBlock } from "@blocknote/core";
+import { Mapping } from "prosemirror-transform";
 import { updateToReplaceSteps } from "../../../../prosemirror/changeset.js";
 import {
   getApplySuggestionsTr,
@@ -47,13 +48,24 @@ export function createHTMLRebaseTool(
     tr.doc,
   );
 
-  if (steps.length) {
-    throw new Error("html diff", {
-      cause: {
-        html,
-        htmlBlock,
-      },
-    });
+  // The HTML round-trip isn't always lossless: marks that aren't part of the
+  // BlockNote document model (`blocknoteIgnore`, e.g. comments) don't survive
+  // it. Apply the difference to the projection, so operations are applied to
+  // the document as the HTML format sees it, and are then rebased onto the
+  // actual document (same as `createMDRebaseTool` does for markdown).
+  const stepMapping = new Mapping();
+  for (const step of steps) {
+    const mapped = step.map(stepMapping);
+    if (!mapped) {
+      throw new Error("html diff", {
+        cause: {
+          html,
+          htmlBlock,
+        },
+      });
+    }
+    tr.step(mapped);
+    stepMapping.appendMap(mapped.getMap());
   }
 
   return rebaseTool(editor, tr);


### PR DESCRIPTION
# Summary

Fixes #2947

Running the AI on a block that contains a comment fails with `Error: html diff`.

## Rationale

Comment marks are tagged `blocknoteIgnore` (`packages/core/src/comments/mark.ts`), so they're deliberately excluded from the BlockNote document model. `blocksToHTMLLossy` therefore emits `<p>Hello, world!</p>` with no `span.bn-thread-mark`, and parsing that back gives a block without the mark.

`createHTMLRebaseTool` round-trips the target block through exactly that path and threw if the result differed from the document. For a block containing a comment it always differs, so the operation failed before the LLM's response could be applied. Blocks are only affected if they carry a comment themselves — editing a sibling block worked, which matches the video in the issue.

The rebase tool exists precisely to handle formats that can't express everything in the document: apply the operation to a "clean" projection, then rebase the result onto the real document through the invert map. `createMDRebaseTool` already does this for markdown; the HTML version asserted losslessness instead of building the projection.

## Changes

- `createHTMLRebaseTool`: apply the round-trip difference to the projection rather than throwing, matching `createMDRebaseTool`. The `blocks.length !== 1` guard is unchanged, and an unmappable step still throws.
- `RESTYjsThreadStore.addThreadToDocument`: use the `ySync` binding's `type`/`mapping` instead of the plugin state.

## Impact

The second fix is a separate bug found while tracing the first, in the same area (comments + Yjs). `addThreadToDocument` passed the `ySync` plugin state where a binding was expected. The plugin state has a `type` but no `mapping`, so passing `undefined` as the mapping threw as soon as `absolutePositionToRelativePosition` reached a non-`XmlText` node:

```
TypeError: Cannot read properties of undefined (reading 'get')
  at absolutePositionToRelativePosition (y-prosemirror/src/lib.js:83)
  at RESTYjsThreadStore.addThreadToDocument (RESTYjsThreadStore.ts:65)
```

A BlockNote document starts with a `blockGroup` element, so this threw on every call — the Yjs positions were never actually sent. It can be dropped from this PR if you'd rather keep the two separate.

## Testing

- `commentedContent.test.ts`: building a rebase tool for a commented block, updating a commented block, and updating a sibling while another block has a comment. The first two fail on `main` with `html diff`. Asserts the comment stays anchored to `"Hello"` after `"Hello, world!"` is rewritten to `"Hello, universe!"`, so the fix isn't just "stops throwing". Runs fully offline — tool calls are fed straight into `StreamToolExecutor`, no LLM.
- `RESTYjsThreadStore.test.ts`: stubs `fetch` and asserts the emitted relative positions resolve back to the positions passed in, so a silently-wrong mapping fails it too.

`packages/core` 716 passed / 9 skipped, `packages/xl-ai` 204 passed / 260 skipped (skips are the API-key-gated model suites, unchanged).

## Checklist

- [x] Code follows the project's coding standards.
- [x] Unit tests covering the new feature have been added.
- [x] All existing tests pass.
- [ ] The documentation has been updated to reflect the new feature

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved comment positioning when adding threads to collaborative documents.
  * Preserved comment anchors when updating HTML blocks or nearby sibling blocks.
  * Improved handling of document changes during HTML updates, with clearer errors when changes cannot be applied.

* **Tests**
  * Added regression coverage for collaborative comment positions and HTML block updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->