### PR TITLE
refactor: vendor @tanstack/store as a first-party Store

### DIFF
--- a/docs/content/docs/getting-started/vanilla-js.mdx
+++ b/docs/content/docs/getting-started/vanilla-js.mdx
@@ -44,7 +44,7 @@ Now, you'll have a plain BlockNote instance on your page. However, it's missing 
 
 Because you can't use the built-in React [UI Components](/docs/react/components), you'll need to create and register your own UI elements.
 
-Each UI element is backed by an [extension](/docs/features/extensions). You can retrieve an extension instance from the editor with `editor.getExtension(...)`, and each one exposes a [store](https://tanstack.com/store) that holds its current state (visibility, position, and any element-specific data). The available UI element extensions are:
+Each UI element is backed by an [extension](/docs/features/extensions). You can retrieve an extension instance from the editor with `editor.getExtension(...)`, and each one exposes a store that holds its current state (visibility, position, and any element-specific data). A store is a small observable container with three members: `state` to read the current value, `setState` to update it, and `subscribe` to be notified of changes. The available UI element extensions are:
 
 | UI element         | Extension                     |
 | ------------------ | ----------------------------- |

--- a/docs/content/docs/getting-started/vanilla-js.mdx
+++ b/docs/content/docs/getting-started/vanilla-js.mdx
@@ -44,7 +44,7 @@ Now, you'll have a plain BlockNote instance on your page. However, it's missing 
 
 Because you can't use the built-in React [UI Components](/docs/react/components), you'll need to create and register your own UI elements.
 
-Each UI element is backed by an [extension](/docs/features/extensions). You can retrieve an extension instance from the editor with `editor.getExtension(...)`, and each one exposes a store that holds its current state (visibility, position, and any element-specific data). A store is a small observable container with three members: `state` to read the current value, `setState` to update it, and `subscribe` to be notified of changes. The available UI element extensions are:
+Each UI element is backed by an [extension](/docs/features/extensions). You can retrieve an extension instance from the editor with `editor.getExtension(...)`, and each one exposes a store that holds its current state (visibility, position, and any element-specific data). A store is a small observable container with these primary members: `state` to read the current value, `setState` to update it, and `subscribe` to be notified of changes. The available UI element extensions are:
 
 | UI element         | Extension                     |
 | ------------------ | ----------------------------- |

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -97,7 +97,6 @@
     "@emoji-mart/data": "^1.2.1",
     "@handlewithcare/prosemirror-inputrules": "^0.1.4",
     "@shikijs/types": "^4",
-    "@tanstack/store": "^0.7.7",
     "@tiptap/core": "^3.29.2",
     "@tiptap/extension-bold": "^3.29.2",
     "@tiptap/extension-code": "^3.29.2",

--- a/packages/core/src/comments/extension.ts
+++ b/packages/core/src/comments/extension.ts
@@ -117,11 +117,9 @@ export const CommentsExtension = createExtension(
         threadPositions: new Map<string, { from: number; to: number }>(),
       },
       {
-        onUpdate() {
+        onUpdate(state, prevState) {
           // If the selected thread id changed, we need to update the decorations
-          if (
-            store.state.selectedThreadId !== store.prevState.selectedThreadId
-          ) {
+          if (state.selectedThreadId !== prevState.selectedThreadId) {
             // So, we issue a transaction to update the decorations
             editor.transact((tr) => tr.setMeta(PLUGIN_KEY, true));
           }

--- a/packages/core/src/editor/BlockNoteExtension.ts
+++ b/packages/core/src/editor/BlockNoteExtension.ts
@@ -1,7 +1,7 @@
-import { Store, StoreOptions } from "@tanstack/store";
 import { type AnyExtension } from "@tiptap/core";
 import type { Plugin as ProsemirrorPlugin } from "prosemirror-state";
 import type { PartialBlockNoDefaults } from "../schema/index.js";
+import { Store, StoreOptions } from "../util/Store.js";
 import type { BlockNoteEditor } from "./BlockNoteEditor.js";
 import { originalFactorySymbol } from "./managers/ExtensionManager/symbol.js";
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -23,6 +23,7 @@ export * from "./user/index.js";
 export * from "./util/browser.js";
 export * from "./util/combineByGroup.js";
 export * from "./util/expandToWords.js";
+export * from "./util/Store.js";
 export * from "./util/string.js";
 export * from "./util/table.js";
 export * from "./util/typescript.js";

--- a/packages/core/src/user/UserStore.ts
+++ b/packages/core/src/user/UserStore.ts
@@ -1,5 +1,5 @@
-import { Store } from "@tanstack/store";
 import { createStore } from "../editor/BlockNoteExtension.js";
+import { Store } from "../util/Store.js";
 
 /**
  * A collaborator of the document.

--- a/packages/core/src/util/Store.test.ts
+++ b/packages/core/src/util/Store.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it, vi } from "vite-plus/test";
+import { Store } from "./Store.js";
+
+describe("Store", () => {
+  it("updates state from a value", () => {
+    const store = new Store({ count: 0 });
+
+    store.setState({ count: 1 });
+
+    expect(store.state).toEqual({ count: 1 });
+  });
+
+  it("updates state from an updater function", () => {
+    const store = new Store({ count: 0 });
+
+    store.setState((prev) => ({ count: prev.count + 1 }));
+
+    expect(store.state).toEqual({ count: 1 });
+  });
+
+  it("exposes the previous state after an update", () => {
+    const store = new Store({ count: 0 });
+
+    store.setState({ count: 1 });
+    expect(store.prevState).toEqual({ count: 0 });
+
+    store.setState({ count: 2 });
+    expect(store.prevState).toEqual({ count: 1 });
+  });
+
+  it("notifies listeners with the previous and current state", () => {
+    const store = new Store({ count: 0 });
+    const listener = vi.fn();
+    store.subscribe(listener);
+
+    store.setState({ count: 1 });
+
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(listener).toHaveBeenCalledWith({
+      prevVal: { count: 0 },
+      currentVal: { count: 1 },
+    });
+  });
+
+  it("stops notifying after unsubscribing", () => {
+    const store = new Store({ count: 0 });
+    const listener = vi.fn();
+    const unsubscribe = store.subscribe(listener);
+
+    store.setState({ count: 1 });
+    unsubscribe();
+    store.setState({ count: 2 });
+
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(store.state).toEqual({ count: 2 });
+  });
+
+  it("calls `onUpdate` after the write but before listeners", () => {
+    const calls: string[] = [];
+    const store: Store<{ count: number }> = new Store(
+      { count: 0 },
+      {
+        onUpdate() {
+          // The new state is already committed by the time `onUpdate` runs, which is
+          // what the comments & ShowSelection extensions rely on to dispatch a
+          // transaction reflecting it.
+          calls.push(`onUpdate:${store.state.count}`);
+        },
+      },
+    );
+    store.subscribe(() => calls.push("listener"));
+
+    store.setState({ count: 1 });
+
+    expect(calls).toEqual(["onUpdate:1", "listener"]);
+  });
+
+  it("passes the new and previous state to `onUpdate`", () => {
+    const onUpdate = vi.fn();
+    const store = new Store({ count: 0 }, { onUpdate });
+
+    store.setState({ count: 1 });
+
+    expect(onUpdate).toHaveBeenCalledWith({ count: 1 }, { count: 0 });
+  });
+
+  it("flattens re-entrant updates instead of recursing", () => {
+    const store = new Store({ count: 0 });
+    const seen: number[] = [];
+
+    store.subscribe(({ currentVal }) => {
+      seen.push(currentVal.count);
+      // A listener writing back to the store — e.g. one that dispatches a transaction
+      // which in turn updates state. This must terminate rather than recurse.
+      if (currentVal.count < 3) {
+        store.setState({ count: currentVal.count + 1 });
+      }
+    });
+
+    store.setState({ count: 1 });
+
+    expect(seen).toEqual([1, 2, 3]);
+    expect(store.state).toEqual({ count: 3 });
+  });
+});

--- a/packages/core/src/util/Store.test.ts
+++ b/packages/core/src/util/Store.test.ts
@@ -84,6 +84,33 @@ describe("Store", () => {
     expect(onUpdate).toHaveBeenCalledWith({ count: 1 }, { count: 0 });
   });
 
+  it("notifies once with the settled state when `onUpdate` writes back", () => {
+    const seen: Array<{ prev: number; curr: number }> = [];
+    let nested = false;
+    const store: Store<{ count: number }> = new Store(
+      { count: 0 },
+      {
+        onUpdate(state) {
+          // A callback that writes back to its own store — e.g. one dispatching a
+          // transaction that settles the state. The nested write must be coalesced
+          // into the in-progress flush rather than draining on its own.
+          if (!nested && state.count === 1) {
+            nested = true;
+            store.setState({ count: 2 });
+          }
+        },
+      },
+    );
+    store.subscribe(({ prevVal, currentVal }) =>
+      seen.push({ prev: prevVal.count, curr: currentVal.count }),
+    );
+
+    store.setState({ count: 1 });
+
+    expect(seen).toEqual([{ prev: 1, curr: 2 }]);
+    expect(store.state).toEqual({ count: 2 });
+  });
+
   it("flattens re-entrant updates instead of recursing", () => {
     const store = new Store({ count: 0 });
     const seen: number[] = [];

--- a/packages/core/src/util/Store.ts
+++ b/packages/core/src/util/Store.ts
@@ -71,8 +71,6 @@ export class Store<TState> {
     this.prevState = this.state;
     this.state = isUpdaterFunction(updater) ? updater(this.prevState) : updater;
 
-    this.options?.onUpdate?.(this.state, this.prevState);
-
     flush(this);
   }
 
@@ -94,22 +92,31 @@ function isUpdaterFunction<T>(updater: Updater<T>): updater is (prev: T) => T {
   return typeof updater === "function";
 }
 
-// Notifying listeners can synchronously trigger further `setState` calls — a listener that
-// dispatches a ProseMirror transaction, for example. Rather than recursing, re-entrant
-// writes are queued and drained by the outermost flush, so a write during notification
-// still reaches every listener but the stack stays flat.
+// Both `onUpdate` and listener notification can synchronously trigger further `setState`
+// calls — a callback that dispatches a ProseMirror transaction, for example. Rather than
+// recursing, re-entrant writes are queued and drained by the outermost flush, so a write
+// made during a callback still reaches every listener but the stack stays flat and
+// subscribers see the settled state once.
+//
+// `onUpdate` therefore runs *inside* the flush transaction: the store is queued and the
+// flush is marked in progress before the callback fires, so a nested write it makes is
+// coalesced into this drain rather than starting its own.
 let isFlushing = false;
 const pendingUpdates = new Set<Store<any>>();
 
 function flush(store: Store<any>) {
   pendingUpdates.add(store);
 
-  if (isFlushing) {
-    return;
-  }
+  const isOutermost = !isFlushing;
+  isFlushing = true;
 
   try {
-    isFlushing = true;
+    store.options?.onUpdate?.(store.state, store.prevState);
+
+    if (!isOutermost) {
+      return;
+    }
+
     while (pendingUpdates.size > 0) {
       const stores = Array.from(pendingUpdates);
       pendingUpdates.clear();
@@ -118,6 +125,11 @@ function flush(store: Store<any>) {
       }
     }
   } finally {
-    isFlushing = false;
+    if (isOutermost) {
+      isFlushing = false;
+      // A throwing callback would otherwise strand queued stores, letting them notify
+      // during an unrelated store's next flush.
+      pendingUpdates.clear();
+    }
   }
 }

--- a/packages/core/src/util/Store.ts
+++ b/packages/core/src/util/Store.ts
@@ -1,0 +1,123 @@
+// Vendored from https://github.com/TanStack/store/blob/main/packages/store/src/store.ts (MIT)
+//
+// BlockNote only ever used `Store` — never the `Derived`/`Effect` reactive graph that
+// makes up the rest of `@tanstack/store`, and that graph isn't tree-shakeable because
+// `setState` reaches into the scheduler. Since the `Store` type is part of BlockNote's
+// public API (every extension exposes one), owning these ~40 lines lets us keep that
+// surface stable instead of tracking a 0.x dependency's breaking changes.
+//
+// Behaviour matches `@tanstack/store@0.7.7`, minus the dependency graph and the
+// `updateFn`/`onSubscribe` options, which nothing used. `onUpdate` additionally receives
+// the new and previous state rather than requiring callers to close over the store.
+
+/**
+ * The value a {@link Listener} is called with when a {@link Store} updates.
+ */
+export interface ListenerValue<T> {
+  readonly prevVal: T;
+  readonly currentVal: T;
+}
+
+/**
+ * A callback invoked when a {@link Store}'s state changes.
+ */
+export type Listener<T> = (value: ListenerValue<T>) => void;
+
+/**
+ * A new state, or a function deriving it from the previous state.
+ */
+export type Updater<T> = T | ((prev: T) => T);
+
+export interface StoreOptions<TState> {
+  /**
+   * Called after the state has been updated, before listeners are notified.
+   */
+  onUpdate?: (state: TState, prevState: TState) => void;
+}
+
+/**
+ * A minimal observable state container.
+ *
+ * Extensions expose one of these as their `store` so that both React (via
+ * `useExtensionState`) and vanilla consumers can read and subscribe to their state.
+ */
+export class Store<TState> {
+  listeners = new Set<Listener<TState>>();
+  state: TState;
+  prevState: TState;
+  options?: StoreOptions<TState>;
+
+  constructor(initialState: TState, options?: StoreOptions<TState>) {
+    this.prevState = initialState;
+    this.state = initialState;
+    this.options = options;
+  }
+
+  subscribe = (listener: Listener<TState>) => {
+    this.listeners.add(listener);
+
+    return () => {
+      this.listeners.delete(listener);
+    };
+  };
+
+  /**
+   * Update the store state, either with a new state or a function deriving it from the
+   * previous one.
+   */
+  setState(updater: (prevState: TState) => TState): void;
+  setState(updater: TState): void;
+  setState(updater: Updater<TState>): void {
+    this.prevState = this.state;
+    this.state = isUpdaterFunction(updater) ? updater(this.prevState) : updater;
+
+    this.options?.onUpdate?.(this.state, this.prevState);
+
+    flush(this);
+  }
+
+  /**
+   * @internal Only to be called by {@link flush}.
+   */
+  _notify() {
+    const value: ListenerValue<TState> = {
+      prevVal: this.prevState,
+      currentVal: this.state,
+    };
+    for (const listener of this.listeners) {
+      listener(value);
+    }
+  }
+}
+
+function isUpdaterFunction<T>(updater: Updater<T>): updater is (prev: T) => T {
+  return typeof updater === "function";
+}
+
+// Notifying listeners can synchronously trigger further `setState` calls — a listener that
+// dispatches a ProseMirror transaction, for example. Rather than recursing, re-entrant
+// writes are queued and drained by the outermost flush, so a write during notification
+// still reaches every listener but the stack stays flat.
+let isFlushing = false;
+const pendingUpdates = new Set<Store<any>>();
+
+function flush(store: Store<any>) {
+  pendingUpdates.add(store);
+
+  if (isFlushing) {
+    return;
+  }
+
+  try {
+    isFlushing = true;
+    while (pendingUpdates.size > 0) {
+      const stores = Array.from(pendingUpdates);
+      pendingUpdates.clear();
+      for (const pendingStore of stores) {
+        pendingStore._notify();
+      }
+    }
+  } finally {
+    isFlushing = false;
+  }
+}

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -60,7 +60,6 @@
     "@blocknote/core": "workspace:^",
     "@emoji-mart/data": "^1.2.1",
     "@floating-ui/react": "^0.27.18",
-    "@tanstack/react-store": "0.7.7",
     "@tiptap/core": "^3.29.2",
     "@tiptap/pm": "^3.29.2",
     "@tiptap/react": "^3.29.2",

--- a/packages/react/src/components/Comments/useCommentUsers.ts
+++ b/packages/react/src/components/Comments/useCommentUsers.ts
@@ -1,9 +1,9 @@
 import { User } from "@blocknote/core";
 import { CommentsExtension } from "@blocknote/core/comments";
-import { useStore } from "@tanstack/react-store";
 import { useEffect } from "react";
 
 import { useExtension } from "../../hooks/useExtension.js";
+import { useStore } from "../../hooks/useStore.js";
 
 /**
  * Reads users from the comments extension's user store, loading any that aren't

--- a/packages/react/src/components/Versioning/useVersionUsers.ts
+++ b/packages/react/src/components/Versioning/useVersionUsers.ts
@@ -3,10 +3,10 @@ import {
   VersioningExtension,
   VersionSnapshot,
 } from "@blocknote/core/extensions";
-import { useStore } from "@tanstack/react-store";
 import { useEffect } from "react";
 
 import { useExtension } from "../../hooks/useExtension.js";
+import { useStore } from "../../hooks/useStore.js";
 
 /**
  * Reads users from the versioning extension's user store, loading any that

--- a/packages/react/src/hooks/useExtension.ts
+++ b/packages/react/src/hooks/useExtension.ts
@@ -1,13 +1,11 @@
 import {
   BlockNoteEditor,
-  createStore,
   Extension,
   ExtensionFactory,
+  Store,
 } from "@blocknote/core";
-import { useStore } from "@tanstack/react-store";
 import { useBlockNoteEditor } from "./useBlockNoteEditor.js";
-
-type Store<T> = ReturnType<typeof createStore<T>>;
+import { useStore } from "./useStore.js";
 
 /**
  * Use an extension instance

--- a/packages/react/src/hooks/useStore.ts
+++ b/packages/react/src/hooks/useStore.ts
@@ -1,0 +1,92 @@
+// Vendored from https://github.com/TanStack/store/blob/main/packages/react-store/src/index.ts (MIT)
+//
+// See `packages/core/src/util/Store.ts` for why the store itself is vendored. This is the
+// matching React binding, kept behaviourally identical to `@tanstack/react-store@0.7.7` —
+// in particular the `shallow` default comparator, which `useCommentUsers` and
+// `useVersionUsers` rely on to avoid re-rendering when an unrelated user resolves.
+
+import type { Store } from "@blocknote/core";
+import { useSyncExternalStoreWithSelector } from "use-sync-external-store/shim/with-selector";
+
+/**
+ * Subscribe to a {@link Store}, optionally selecting a slice of its state.
+ *
+ * The component re-renders only when the selected value changes under a
+ * {@link shallow} comparison, so selectors are free to build a fresh object,
+ * `Map` or `Set` on each call.
+ */
+export function useStore<TState, TSelected = NoInfer<TState>>(
+  store: Store<TState>,
+  selector: (state: TState) => TSelected = (d) => d as unknown as TSelected,
+): TSelected {
+  return useSyncExternalStoreWithSelector(
+    store.subscribe,
+    () => store.state,
+    () => store.state,
+    selector,
+    shallow,
+  );
+}
+
+/**
+ * Compares two values one level deep, with special handling for `Map`, `Set` and `Date`.
+ */
+export function shallow<T>(objA: T, objB: T): boolean {
+  if (Object.is(objA, objB)) {
+    return true;
+  }
+
+  if (
+    typeof objA !== "object" ||
+    objA === null ||
+    typeof objB !== "object" ||
+    objB === null
+  ) {
+    return false;
+  }
+
+  if (objA instanceof Map && objB instanceof Map) {
+    if (objA.size !== objB.size) {
+      return false;
+    }
+    for (const [k, v] of objA) {
+      if (!objB.has(k) || !Object.is(v, objB.get(k))) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  if (objA instanceof Set && objB instanceof Set) {
+    if (objA.size !== objB.size) {
+      return false;
+    }
+    for (const v of objA) {
+      if (!objB.has(v)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  if (objA instanceof Date && objB instanceof Date) {
+    return objA.getTime() === objB.getTime();
+  }
+
+  const keysA = getOwnKeys(objA);
+  if (keysA.length !== getOwnKeys(objB).length) {
+    return false;
+  }
+
+  return keysA.every(
+    (key) =>
+      Object.prototype.hasOwnProperty.call(objB, key) &&
+      Object.is(objA[key as keyof T], objB[key as keyof T]),
+  );
+}
+
+function getOwnKeys<T extends object>(obj: T): Array<string | symbol> {
+  return (Object.keys(obj) as Array<string | symbol>).concat(
+    Object.getOwnPropertySymbols(obj),
+  );
+}

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -132,6 +132,7 @@ export * from "./hooks/useOnUploadEnd.js";
 export * from "./hooks/useOnUploadStart.js";
 export * from "./hooks/usePrefersColorScheme.js";
 export * from "./hooks/useSelectedBlocks.js";
+export * from "./hooks/useStore.js";
 export * from "./hooks/useUploadLoading.js";
 export * from "./hooks/useExtension.js";
 export * from "./hooks/useEditorState.js";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4995,9 +4995,6 @@ importers:
       '@shikijs/types':
         specifier: ^4
         version: 4.0.2
-      '@tanstack/store':
-        specifier: ^0.7.7
-        version: 0.7.7
       '@tiptap/core':
         specifier: ^3.29.2
         version: 3.29.2(@tiptap/pm@3.29.2)
@@ -5180,9 +5177,6 @@ importers:
       '@floating-ui/react':
         specifier: ^0.27.18
         version: 0.27.19(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      '@tanstack/react-store':
-        specifier: 0.7.7
-        version: 0.7.7(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@tiptap/core':
         specifier: ^3.29.2
         version: 3.29.2(@tiptap/pm@3.29.2)
@@ -10011,21 +10005,12 @@ packages:
     peerDependencies:
       vite: ^5.2.0 || ^6 || ^7 || ^8
 
-  '@tanstack/react-store@0.7.7':
-    resolution: {integrity: sha512-qqT0ufegFRDGSof9D/VqaZgjNgp4tRPHZIJq2+QIHkMUtHjaJ0lYrrXjeIUJvjnTbgPfSD1XgOMEt0lmANn6Zg==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-
   '@tanstack/react-table@8.21.3':
     resolution: {integrity: sha512-5nNMTSETP4ykGegmVkhjcS8tTLW6Vl4axfEGQN3v0zdHYbK4UfoqfPChclTrJ4EoK9QynqAu9oUf8VEmrpZ5Ww==}
     engines: {node: '>=12'}
     peerDependencies:
       react: '>=16.8'
       react-dom: '>=16.8'
-
-  '@tanstack/store@0.7.7':
-    resolution: {integrity: sha512-xa6pTan1bcaqYDS9BDpSiS63qa6EoDkPN9RsRaxHuDdVDNntzq3xNwR5YKTU/V3SkSyC9T4YVOPh2zRQN0nhIQ==}
 
   '@tanstack/table-core@8.21.3':
     resolution: {integrity: sha512-ldZXEhOBb8Is7xLs01fR3YEc3DERiz5silj8tnGkFZytt1abEvl/GhUmCE0PMLaMPTa3Jk4HbKmRlHmu+gCftg==}
@@ -19872,20 +19857,11 @@ snapshots:
       tailwindcss: 4.2.2
       vite: 8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0)
 
-  '@tanstack/react-store@0.7.7(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
-    dependencies:
-      '@tanstack/store': 0.7.7
-      react: 19.2.5
-      react-dom: 19.2.5(react@19.2.5)
-      use-sync-external-store: 1.6.0(react@19.2.5)
-
   '@tanstack/react-table@8.21.3(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
     dependencies:
       '@tanstack/table-core': 8.21.3
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
-
-  '@tanstack/store@0.7.7': {}
 
   '@tanstack/table-core@8.21.3': {}
 


### PR DESCRIPTION
# Summary

Replaces the `@tanstack/store` and `@tanstack/react-store` dependencies with a ~50-line first-party `Store` in `@blocknote/core` and a matching `useStore` hook in `@blocknote/react`.

## Rationale

We only ever used `state`, `prevState`, `setState`, `subscribe` and the `onUpdate` option — never the `Derived`/`Effect` reactive graph that makes up the rest of the library, which also doesn't tree-shake because `setState` reaches into the scheduler that imports `Derived`. Since `Store` is unavoidably part of our published API (every extension exposes one, and the vanilla-JS docs pointed users at tanstack.com/store), every breaking change in a 0.x dependency became a BlockNote breaking change — and upstream shipped four minor bumps in eleven months, including a full rewrite onto alien-signals in 0.9.0 and a React hook replacement in 0.11.0, with no 1.0 on the roadmap.

## Changes

- Add `packages/core/src/util/Store.ts`, exported by name so consumers can import the type directly rather than only reaching it structurally. Includes the re-entrancy guard that lets a listener write back to the store (e.g. one dispatching a ProseMirror transaction) without recursing.
- Add `packages/react/src/hooks/useStore.ts`, wrapping the `use-sync-external-store` shim `@blocknote/react` already depends on, and preserving the `shallow` default comparator that `useCommentUsers`/`useVersionUsers` rely on.
- `onUpdate` now receives the new and previous state, so callers no longer close over the store to read `prevState`.
- Drop the `TUpdater` type parameter, which existed only to serve the unused `updateFn` option.
- Remove both dependencies and update the vanilla-JS docs.

## Impact

No behavioural change and no public API break: `subscribe` still returns an unsubscribe function, `setState` still accepts a value or an updater, and the listener payload is unchanged. Emitted declarations no longer reference `@tanstack/store` at all (previously 19+ references) and simplify from `Store<T, (cb: T) => T>` to `Store<T>`. This also closes a version-skew hazard where core allowed `^0.7.7` to float while react pinned `0.7.7` exactly, so a future 0.7.x publish would have installed two copies with `Store` instances crossing the package boundary. Bundle cost drops from 1128 B to 340 B gzipped.

## Testing

New `packages/core/src/util/Store.test.ts` covers value- and function-form `setState`, `prevState`, `onUpdate` ordering and arguments, unsubscribe, and re-entrant writes. Full unit suite, lint, type-check and build all pass; e2e passes except for three failures that reproduce identically on a clean tree (see notes).

## Screenshots/Video

N/A — no user-visible change.

## Checklist

- [x] Code follows the project's coding standards.
- [x] Unit tests covering the new feature have been added.
- [x] All existing tests pass.
- [x] The documentation has been updated to reflect the new feature

## Additional Notes

`keyboardhandlers.test.tsx` (2 snapshot mismatches) and `multicolumnDrop.test.tsx` (a `RangeError: Position 30 outside of fragment` in `multiColumnHandleDropPlugin.ts`) fail on this branch, but they fail identically with these changes stashed, so they are pre-existing and unrelated to this PR.

If we ever want `Derived`-style primitives, the suggested path is to depend on `alien-signals` directly — it is past 1.0, has zero runtime dependencies, and is the same engine `@tanstack/store` itself rewrote onto — rather than re-adopting a 0.x store wrapper.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a lightweight store API for managing and subscribing to application state.
  * Exposed store utilities and the React `useStore` hook through the public packages.
  * Added state selection with shallow comparison to help prevent unnecessary React updates.

* **Bug Fixes**
  * Improved notification handling for consecutive and nested state updates.
  * Preserved comment thread selection updates when state changes.

* **Documentation**
  * Updated vanilla JavaScript guidance with direct instructions for using the store API.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->