### PR TITLE
docs(examples): use plain vite for StackBlitz compatibility

### DIFF
--- a/examples/01-basic/01-minimal/package.json
+++ b/examples/01-basic/01-minimal/package.json
@@ -5,10 +5,10 @@
   "private": true,
   "version": "0.12.4",
   "scripts": {
-    "start": "vp dev",
-    "dev": "vp dev",
-    "build:prod": "tsc && vp build",
-    "preview": "vp preview"
+    "start": "vite",
+    "dev": "vite",
+    "build:prod": "tsc && vite build",
+    "preview": "vite preview"
   },
   "dependencies": {
     "@blocknote/ariakit": "latest",
@@ -25,6 +25,6 @@
     "@types/react": "^19.2.3",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.1",
-    "vite-plus": "^0.1.24"
+    "vite": "^8.0.0"
   }
 }

--- a/examples/01-basic/01-minimal/vite-env.d.ts
+++ b/examples/01-basic/01-minimal/vite-env.d.ts
@@ -1,1 +1,1 @@
-/// <reference types="vite-plus/client" />
+/// <reference types="vite/client" />

--- a/examples/01-basic/01-minimal/vite.config.ts
+++ b/examples/01-basic/01-minimal/vite.config.ts
@@ -2,7 +2,7 @@
 import react from "@vitejs/plugin-react";
 import * as fs from "fs";
 import * as path from "path";
-import { defineConfig } from "vite-plus";
+import { defineConfig } from "vite";
 // https://vitejs.dev/config/
 export default defineConfig(((conf: { command: string }) => ({
   plugins: [react()],

--- a/examples/01-basic/02-block-objects/package.json
+++ b/examples/01-basic/02-block-objects/package.json
@@ -5,10 +5,10 @@
   "private": true,
   "version": "0.12.4",
   "scripts": {
-    "start": "vp dev",
-    "dev": "vp dev",
-    "build:prod": "tsc && vp build",
-    "preview": "vp preview"
+    "start": "vite",
+    "dev": "vite",
+    "build:prod": "tsc && vite build",
+    "preview": "vite preview"
   },
   "dependencies": {
     "@blocknote/ariakit": "latest",
@@ -25,6 +25,6 @@
     "@types/react": "^19.2.3",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.1",
-    "vite-plus": "^0.1.24"
+    "vite": "^8.0.0"
   }
 }

--- a/examples/01-basic/02-block-objects/vite-env.d.ts
+++ b/examples/01-basic/02-block-objects/vite-env.d.ts
@@ -1,1 +1,1 @@
-/// <reference types="vite-plus/client" />
+/// <reference types="vite/client" />

--- a/examples/01-basic/02-block-objects/vite.config.ts
+++ b/examples/01-basic/02-block-objects/vite.config.ts
@@ -2,7 +2,7 @@
 import react from "@vitejs/plugin-react";
 import * as fs from "fs";
 import * as path from "path";
-import { defineConfig } from "vite-plus";
+import { defineConfig } from "vite";
 // https://vitejs.dev/config/
 export default defineConfig(((conf: { command: string }) => ({
   plugins: [react()],

--- a/examples/01-basic/03-multi-column/package.json
+++ b/examples/01-basic/03-multi-column/package.json
@@ -5,10 +5,10 @@
   "private": true,
   "version": "0.12.4",
   "scripts": {
-    "start": "vp dev",
-    "dev": "vp dev",
-    "build:prod": "tsc && vp build",
-    "preview": "vp preview"
+    "start": "vite",
+    "dev": "vite",
+    "build:prod": "tsc && vite build",
+    "preview": "vite preview"
   },
   "dependencies": {
     "@blocknote/ariakit": "latest",
@@ -26,6 +26,6 @@
     "@types/react": "^19.2.3",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.1",
-    "vite-plus": "^0.1.24"
+    "vite": "^8.0.0"
   }
 }

--- a/examples/01-basic/03-multi-column/vite-env.d.ts
+++ b/examples/01-basic/03-multi-column/vite-env.d.ts
@@ -1,1 +1,1 @@
-/// <reference types="vite-plus/client" />
+/// <reference types="vite/client" />

--- a/examples/01-basic/03-multi-column/vite.config.ts
+++ b/examples/01-basic/03-multi-column/vite.config.ts
@@ -2,7 +2,7 @@
 import react from "@vitejs/plugin-react";
 import * as fs from "fs";
 import * as path from "path";
-import { defineConfig } from "vite-plus";
+import { defineConfig } from "vite";
 // https://vitejs.dev/config/
 export default defineConfig(((conf: { command: string }) => ({
   plugins: [react()],

--- a/examples/01-basic/04-default-blocks/package.json
+++ b/examples/01-basic/04-default-blocks/package.json
@@ -5,10 +5,10 @@
   "private": true,
   "version": "0.12.4",
   "scripts": {
-    "start": "vp dev",
-    "dev": "vp dev",
-    "build:prod": "tsc && vp build",
-    "preview": "vp preview"
+    "start": "vite",
+    "dev": "vite",
+    "build:prod": "tsc && vite build",
+    "preview": "vite preview"
   },
   "dependencies": {
     "@blocknote/ariakit": "latest",
@@ -25,6 +25,6 @@
     "@types/react": "^19.2.3",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.1",
-    "vite-plus": "^0.1.24"
+    "vite": "^8.0.0"
   }
 }

--- a/examples/01-basic/04-default-blocks/vite-env.d.ts
+++ b/examples/01-basic/04-default-blocks/vite-env.d.ts
@@ -1,1 +1,1 @@
-/// <reference types="vite-plus/client" />
+/// <reference types="vite/client" />

--- a/examples/01-basic/04-default-blocks/vite.config.ts
+++ b/examples/01-basic/04-default-blocks/vite.config.ts
@@ -2,7 +2,7 @@
 import react from "@vitejs/plugin-react";
 import * as fs from "fs";
 import * as path from "path";
-import { defineConfig } from "vite-plus";
+import { defineConfig } from "vite";
 // https://vitejs.dev/config/
 export default defineConfig(((conf: { command: string }) => ({
   plugins: [react()],

--- a/examples/01-basic/05-removing-default-blocks/package.json
+++ b/examples/01-basic/05-removing-default-blocks/package.json
@@ -5,10 +5,10 @@
   "private": true,
   "version": "0.12.4",
   "scripts": {
-    "start": "vp dev",
-    "dev": "vp dev",
-    "build:prod": "tsc && vp build",
-    "preview": "vp preview"
+    "start": "vite",
+    "dev": "vite",
+    "build:prod": "tsc && vite build",
+    "preview": "vite preview"
   },
   "dependencies": {
     "@blocknote/ariakit": "latest",
@@ -25,6 +25,6 @@
     "@types/react": "^19.2.3",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.1",
-    "vite-plus": "^0.1.24"
+    "vite": "^8.0.0"
   }
 }

--- a/examples/01-basic/05-removing-default-blocks/vite-env.d.ts
+++ b/examples/01-basic/05-removing-default-blocks/vite-env.d.ts
@@ -1,1 +1,1 @@
-/// <reference types="vite-plus/client" />
+/// <reference types="vite/client" />

--- a/examples/01-basic/05-removing-default-blocks/vite.config.ts
+++ b/examples/01-basic/05-removing-default-blocks/vite.config.ts
@@ -2,7 +2,7 @@
 import react from "@vitejs/plugin-react";
 import * as fs from "fs";
 import * as path from "path";
-import { defineConfig } from "vite-plus";
+import { defineConfig } from "vite";
 // https://vitejs.dev/config/
 export default defineConfig(((conf: { command: string }) => ({
   plugins: [react()],

--- a/examples/01-basic/06-block-manipulation/package.json
+++ b/examples/01-basic/06-block-manipulation/package.json
@@ -5,10 +5,10 @@
   "private": true,
   "version": "0.12.4",
   "scripts": {
-    "start": "vp dev",
-    "dev": "vp dev",
-    "build:prod": "tsc && vp build",
-    "preview": "vp preview"
+    "start": "vite",
+    "dev": "vite",
+    "build:prod": "tsc && vite build",
+    "preview": "vite preview"
   },
   "dependencies": {
     "@blocknote/ariakit": "latest",
@@ -25,6 +25,6 @@
     "@types/react": "^19.2.3",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.1",
-    "vite-plus": "^0.1.24"
+    "vite": "^8.0.0"
   }
 }

--- a/examples/01-basic/06-block-manipulation/vite-env.d.ts
+++ b/examples/01-basic/06-block-manipulation/vite-env.d.ts
@@ -1,1 +1,1 @@
-/// <reference types="vite-plus/client" />
+/// <reference types="vite/client" />

--- a/examples/01-basic/06-block-manipulation/vite.config.ts
+++ b/examples/01-basic/06-block-manipulation/vite.config.ts
@@ -2,7 +2,7 @@
 import react from "@vitejs/plugin-react";
 import * as fs from "fs";
 import * as path from "path";
-import { defineConfig } from "vite-plus";
+import { defineConfig } from "vite";
 // https://vitejs.dev/config/
 export default defineConfig(((conf: { command: string }) => ({
   plugins: [react()],

--- a/examples/01-basic/07-selection-blocks/package.json
+++ b/examples/01-basic/07-selection-blocks/package.json
@@ -5,10 +5,10 @@
   "private": true,
   "version": "0.12.4",
   "scripts": {
-    "start": "vp dev",
-    "dev": "vp dev",
-    "build:prod": "tsc && vp build",
-    "preview": "vp preview"
+    "start": "vite",
+    "dev": "vite",
+    "build:prod": "tsc && vite build",
+    "preview": "vite preview"
   },
   "dependencies": {
     "@blocknote/ariakit": "latest",
@@ -25,6 +25,6 @@
     "@types/react": "^19.2.3",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.1",
-    "vite-plus": "^0.1.24"
+    "vite": "^8.0.0"
   }
 }

--- a/examples/01-basic/07-selection-blocks/vite-env.d.ts
+++ b/examples/01-basic/07-selection-blocks/vite-env.d.ts
@@ -1,1 +1,1 @@
-/// <reference types="vite-plus/client" />
+/// <reference types="vite/client" />

--- a/examples/01-basic/07-selection-blocks/vite.config.ts
+++ b/examples/01-basic/07-selection-blocks/vite.config.ts
@@ -2,7 +2,7 @@
 import react from "@vitejs/plugin-react";
 import * as fs from "fs";
 import * as path from "path";
-import { defineConfig } from "vite-plus";
+import { defineConfig } from "vite";
 // https://vitejs.dev/config/
 export default defineConfig(((conf: { command: string }) => ({
   plugins: [react()],

--- a/examples/01-basic/08-ariakit/package.json
+++ b/examples/01-basic/08-ariakit/package.json
@@ -5,10 +5,10 @@
   "private": true,
   "version": "0.12.4",
   "scripts": {
-    "start": "vp dev",
-    "dev": "vp dev",
-    "build:prod": "tsc && vp build",
-    "preview": "vp preview"
+    "start": "vite",
+    "dev": "vite",
+    "build:prod": "tsc && vite build",
+    "preview": "vite preview"
   },
   "dependencies": {
     "@blocknote/ariakit": "latest",
@@ -25,6 +25,6 @@
     "@types/react": "^19.2.3",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.1",
-    "vite-plus": "^0.1.24"
+    "vite": "^8.0.0"
   }
 }

--- a/examples/01-basic/08-ariakit/vite-env.d.ts
+++ b/examples/01-basic/08-ariakit/vite-env.d.ts
@@ -1,1 +1,1 @@
-/// <reference types="vite-plus/client" />
+/// <reference types="vite/client" />

--- a/examples/01-basic/08-ariakit/vite.config.ts
+++ b/examples/01-basic/08-ariakit/vite.config.ts
@@ -2,7 +2,7 @@
 import react from "@vitejs/plugin-react";
 import * as fs from "fs";
 import * as path from "path";
-import { defineConfig } from "vite-plus";
+import { defineConfig } from "vite";
 // https://vitejs.dev/config/
 export default defineConfig(((conf: { command: string }) => ({
   plugins: [react()],

--- a/examples/01-basic/09-shadcn/package.json
+++ b/examples/01-basic/09-shadcn/package.json
@@ -5,10 +5,10 @@
   "private": true,
   "version": "0.12.4",
   "scripts": {
-    "start": "vp dev",
-    "dev": "vp dev",
-    "build:prod": "tsc && vp build",
-    "preview": "vp preview"
+    "start": "vite",
+    "dev": "vite",
+    "build:prod": "tsc && vite build",
+    "preview": "vite preview"
   },
   "dependencies": {
     "@blocknote/ariakit": "latest",
@@ -28,6 +28,6 @@
     "@types/react": "^19.2.3",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.1",
-    "vite-plus": "^0.1.24"
+    "vite": "^8.0.0"
   }
 }

--- a/examples/01-basic/09-shadcn/vite-env.d.ts
+++ b/examples/01-basic/09-shadcn/vite-env.d.ts
@@ -1,1 +1,1 @@
-/// <reference types="vite-plus/client" />
+/// <reference types="vite/client" />

--- a/examples/01-basic/09-shadcn/vite.config.ts
+++ b/examples/01-basic/09-shadcn/vite.config.ts
@@ -2,7 +2,7 @@
 import react from "@vitejs/plugin-react";
 import * as fs from "fs";
 import * as path from "path";
-import { defineConfig } from "vite-plus";
+import { defineConfig } from "vite";
 import tailwindcss from "@tailwindcss/vite";
 // https://vitejs.dev/config/
 export default defineConfig(((conf: { command: string }) => ({

--- a/examples/01-basic/10-localization/package.json
+++ b/examples/01-basic/10-localization/package.json
@@ -5,10 +5,10 @@
   "private": true,
   "version": "0.12.4",
   "scripts": {
-    "start": "vp dev",
-    "dev": "vp dev",
-    "build:prod": "tsc && vp build",
-    "preview": "vp preview"
+    "start": "vite",
+    "dev": "vite",
+    "build:prod": "tsc && vite build",
+    "preview": "vite preview"
   },
   "dependencies": {
     "@blocknote/ariakit": "latest",
@@ -25,6 +25,6 @@
     "@types/react": "^19.2.3",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.1",
-    "vite-plus": "^0.1.24"
+    "vite": "^8.0.0"
   }
 }

--- a/examples/01-basic/10-localization/vite-env.d.ts
+++ b/examples/01-basic/10-localization/vite-env.d.ts
@@ -1,1 +1,1 @@
-/// <reference types="vite-plus/client" />
+/// <reference types="vite/client" />

--- a/examples/01-basic/10-localization/vite.config.ts
+++ b/examples/01-basic/10-localization/vite.config.ts
@@ -2,7 +2,7 @@
 import react from "@vitejs/plugin-react";
 import * as fs from "fs";
 import * as path from "path";
-import { defineConfig } from "vite-plus";
+import { defineConfig } from "vite";
 // https://vitejs.dev/config/
 export default defineConfig(((conf: { command: string }) => ({
   plugins: [react()],

--- a/examples/01-basic/11-custom-placeholder/package.json
+++ b/examples/01-basic/11-custom-placeholder/package.json
@@ -5,10 +5,10 @@
   "private": true,
   "version": "0.12.4",
   "scripts": {
-    "start": "vp dev",
-    "dev": "vp dev",
-    "build:prod": "tsc && vp build",
-    "preview": "vp preview"
+    "start": "vite",
+    "dev": "vite",
+    "build:prod": "tsc && vite build",
+    "preview": "vite preview"
   },
   "dependencies": {
     "@blocknote/ariakit": "latest",
@@ -25,6 +25,6 @@
     "@types/react": "^19.2.3",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.1",
-    "vite-plus": "^0.1.24"
+    "vite": "^8.0.0"
   }
 }

--- a/examples/01-basic/11-custom-placeholder/vite-env.d.ts
+++ b/examples/01-basic/11-custom-placeholder/vite-env.d.ts
@@ -1,1 +1,1 @@
-/// <reference types="vite-plus/client" />
+/// <reference types="vite/client" />

--- a/examples/01-basic/11-custom-placeholder/vite.config.ts
+++ b/examples/01-basic/11-custom-placeholder/vite.config.ts
@@ -2,7 +2,7 @@
 import react from "@vitejs/plugin-react";
 import * as fs from "fs";
 import * as path from "path";
-import { defineConfig } from "vite-plus";
+import { defineConfig } from "vite";
 // https://vitejs.dev/config/
 export default defineConfig(((conf: { command: string }) => ({
   plugins: [react()],

--- a/examples/01-basic/12-multi-editor/package.json
+++ b/examples/01-basic/12-multi-editor/package.json
@@ -5,10 +5,10 @@
   "private": true,
   "version": "0.12.4",
   "scripts": {
-    "start": "vp dev",
-    "dev": "vp dev",
-    "build:prod": "tsc && vp build",
-    "preview": "vp preview"
+    "start": "vite",
+    "dev": "vite",
+    "build:prod": "tsc && vite build",
+    "preview": "vite preview"
   },
   "dependencies": {
     "@blocknote/ariakit": "latest",
@@ -25,6 +25,6 @@
     "@types/react": "^19.2.3",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.1",
-    "vite-plus": "^0.1.24"
+    "vite": "^8.0.0"
   }
 }

--- a/examples/01-basic/12-multi-editor/vite-env.d.ts
+++ b/examples/01-basic/12-multi-editor/vite-env.d.ts
@@ -1,1 +1,1 @@
-/// <reference types="vite-plus/client" />
+/// <reference types="vite/client" />

--- a/examples/01-basic/12-multi-editor/vite.config.ts
+++ b/examples/01-basic/12-multi-editor/vite.config.ts
@@ -2,7 +2,7 @@
 import react from "@vitejs/plugin-react";
 import * as fs from "fs";
 import * as path from "path";
-import { defineConfig } from "vite-plus";
+import { defineConfig } from "vite";
 // https://vitejs.dev/config/
 export default defineConfig(((conf: { command: string }) => ({
   plugins: [react()],

--- a/examples/01-basic/13-custom-paste-handler/package.json
+++ b/examples/01-basic/13-custom-paste-handler/package.json
@@ -5,10 +5,10 @@
   "private": true,
   "version": "0.12.4",
   "scripts": {
-    "start": "vp dev",
-    "dev": "vp dev",
-    "build:prod": "tsc && vp build",
-    "preview": "vp preview"
+    "start": "vite",
+    "dev": "vite",
+    "build:prod": "tsc && vite build",
+    "preview": "vite preview"
   },
   "dependencies": {
     "@blocknote/ariakit": "latest",
@@ -25,6 +25,6 @@
     "@types/react": "^19.2.3",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.1",
-    "vite-plus": "^0.1.24"
+    "vite": "^8.0.0"
   }
 }

--- a/examples/01-basic/13-custom-paste-handler/vite-env.d.ts
+++ b/examples/01-basic/13-custom-paste-handler/vite-env.d.ts
@@ -1,1 +1,1 @@
-/// <reference types="vite-plus/client" />
+/// <reference types="vite/client" />

--- a/examples/01-basic/13-custom-paste-handler/vite.config.ts
+++ b/examples/01-basic/13-custom-paste-handler/vite.config.ts
@@ -2,7 +2,7 @@
 import react from "@vitejs/plugin-react";
 import * as fs from "fs";
 import * as path from "path";
-import { defineConfig } from "vite-plus";
+import { defineConfig } from "vite";
 // https://vitejs.dev/config/
 export default defineConfig(((conf: { command: string }) => ({
   plugins: [react()],

--- a/examples/01-basic/14-editor-scrollable/package.json
+++ b/examples/01-basic/14-editor-scrollable/package.json
@@ -5,10 +5,10 @@
   "private": true,
   "version": "0.12.4",
   "scripts": {
-    "start": "vp dev",
-    "dev": "vp dev",
-    "build:prod": "tsc && vp build",
-    "preview": "vp preview"
+    "start": "vite",
+    "dev": "vite",
+    "build:prod": "tsc && vite build",
+    "preview": "vite preview"
   },
   "dependencies": {
     "@blocknote/ariakit": "latest",
@@ -25,6 +25,6 @@
     "@types/react": "^19.2.3",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.1",
-    "vite-plus": "^0.1.24"
+    "vite": "^8.0.0"
   }
 }

--- a/examples/01-basic/14-editor-scrollable/vite-env.d.ts
+++ b/examples/01-basic/14-editor-scrollable/vite-env.d.ts
@@ -1,1 +1,1 @@
-/// <reference types="vite-plus/client" />
+/// <reference types="vite/client" />

--- a/examples/01-basic/14-editor-scrollable/vite.config.ts
+++ b/examples/01-basic/14-editor-scrollable/vite.config.ts
@@ -2,7 +2,7 @@
 import react from "@vitejs/plugin-react";
 import * as fs from "fs";
 import * as path from "path";
-import { defineConfig } from "vite-plus";
+import { defineConfig } from "vite";
 // https://vitejs.dev/config/
 export default defineConfig(((conf: { command: string }) => ({
   plugins: [react()],

--- a/examples/01-basic/15-shadowdom/package.json
+++ b/examples/01-basic/15-shadowdom/package.json
@@ -5,10 +5,10 @@
   "private": true,
   "version": "0.12.4",
   "scripts": {
-    "start": "vp dev",
-    "dev": "vp dev",
-    "build:prod": "tsc && vp build",
-    "preview": "vp preview"
+    "start": "vite",
+    "dev": "vite",
+    "build:prod": "tsc && vite build",
+    "preview": "vite preview"
   },
   "dependencies": {
     "@blocknote/ariakit": "latest",
@@ -25,6 +25,6 @@
     "@types/react": "^19.2.3",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.1",
-    "vite-plus": "^0.1.24"
+    "vite": "^8.0.0"
   }
 }

--- a/examples/01-basic/15-shadowdom/vite-env.d.ts
+++ b/examples/01-basic/15-shadowdom/vite-env.d.ts
@@ -1,1 +1,1 @@
-/// <reference types="vite-plus/client" />
+/// <reference types="vite/client" />

--- a/examples/01-basic/15-shadowdom/vite.config.ts
+++ b/examples/01-basic/15-shadowdom/vite.config.ts
@@ -2,7 +2,7 @@
 import react from "@vitejs/plugin-react";
 import * as fs from "fs";
 import * as path from "path";
-import { defineConfig } from "vite-plus";
+import { defineConfig } from "vite";
 // https://vitejs.dev/config/
 export default defineConfig(((conf: { command: string }) => ({
   plugins: [react()],

--- a/examples/01-basic/16-read-only-editor/package.json
+++ b/examples/01-basic/16-read-only-editor/package.json
@@ -5,10 +5,10 @@
   "private": true,
   "version": "0.12.4",
   "scripts": {
-    "start": "vp dev",
-    "dev": "vp dev",
-    "build:prod": "tsc && vp build",
-    "preview": "vp preview"
+    "start": "vite",
+    "dev": "vite",
+    "build:prod": "tsc && vite build",
+    "preview": "vite preview"
   },
   "dependencies": {
     "@blocknote/ariakit": "latest",
@@ -25,6 +25,6 @@
     "@types/react": "^19.2.3",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.1",
-    "vite-plus": "^0.1.24"
+    "vite": "^8.0.0"
   }
 }

--- a/examples/01-basic/16-read-only-editor/vite-env.d.ts
+++ b/examples/01-basic/16-read-only-editor/vite-env.d.ts
@@ -1,1 +1,1 @@
-/// <reference types="vite-plus/client" />
+/// <reference types="vite/client" />

--- a/examples/01-basic/16-read-only-editor/vite.config.ts
+++ b/examples/01-basic/16-read-only-editor/vite.config.ts
@@ -2,7 +2,7 @@
 import react from "@vitejs/plugin-react";
 import * as fs from "fs";
 import * as path from "path";
-import { defineConfig } from "vite-plus";
+import { defineConfig } from "vite";
 // https://vitejs.dev/config/
 export default defineConfig(((conf: { command: string }) => ({
   plugins: [react()],

--- a/examples/01-basic/17-no-trailing-block/package.json
+++ b/examples/01-basic/17-no-trailing-block/package.json
@@ -5,10 +5,10 @@
   "private": true,
   "version": "0.12.4",
   "scripts": {
-    "start": "vp dev",
-    "dev": "vp dev",
-    "build:prod": "tsc && vp build",
-    "preview": "vp preview"
+    "start": "vite",
+    "dev": "vite",
+    "build:prod": "tsc && vite build",
+    "preview": "vite preview"
   },
   "dependencies": {
     "@blocknote/ariakit": "latest",
@@ -25,6 +25,6 @@
     "@types/react": "^19.2.3",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.1",
-    "vite-plus": "^0.1.24"
+    "vite": "^8.0.0"
   }
 }

--- a/examples/01-basic/17-no-trailing-block/vite-env.d.ts
+++ b/examples/01-basic/17-no-trailing-block/vite-env.d.ts
@@ -1,1 +1,1 @@
-/// <reference types="vite-plus/client" />
+/// <reference types="vite/client" />

--- a/examples/01-basic/17-no-trailing-block/vite.config.ts
+++ b/examples/01-basic/17-no-trailing-block/vite.config.ts
@@ -2,7 +2,7 @@
 import react from "@vitejs/plugin-react";
 import * as fs from "fs";
 import * as path from "path";
-import { defineConfig } from "vite-plus";
+import { defineConfig } from "vite";
 // https://vitejs.dev/config/
 export default defineConfig(((conf: { command: string }) => ({
   plugins: [react()],

--- a/examples/01-basic/testing/package.json
+++ b/examples/01-basic/testing/package.json
@@ -5,10 +5,10 @@
   "private": true,
   "version": "0.12.4",
   "scripts": {
-    "start": "vp dev",
-    "dev": "vp dev",
-    "build:prod": "tsc && vp build",
-    "preview": "vp preview"
+    "start": "vite",
+    "dev": "vite",
+    "build:prod": "tsc && vite build",
+    "preview": "vite preview"
   },
   "dependencies": {
     "@blocknote/ariakit": "latest",
@@ -25,6 +25,6 @@
     "@types/react": "^19.2.3",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.1",
-    "vite-plus": "^0.1.24"
+    "vite": "^8.0.0"
   }
 }

--- a/examples/01-basic/testing/vite-env.d.ts
+++ b/examples/01-basic/testing/vite-env.d.ts
@@ -1,1 +1,1 @@
-/// <reference types="vite-plus/client" />
+/// <reference types="vite/client" />

--- a/examples/01-basic/testing/vite.config.ts
+++ b/examples/01-basic/testing/vite.config.ts
@@ -2,7 +2,7 @@
 import react from "@vitejs/plugin-react";
 import * as fs from "fs";
 import * as path from "path";
-import { defineConfig } from "vite-plus";
+import { defineConfig } from "vite";
 // https://vitejs.dev/config/
 export default defineConfig(((conf: { command: string }) => ({
   plugins: [react()],

--- a/examples/02-backend/01-file-uploading/package.json
+++ b/examples/02-backend/01-file-uploading/package.json
@@ -5,10 +5,10 @@
   "private": true,
   "version": "0.12.4",
   "scripts": {
-    "start": "vp dev",
-    "dev": "vp dev",
-    "build:prod": "tsc && vp build",
-    "preview": "vp preview"
+    "start": "vite",
+    "dev": "vite",
+    "build:prod": "tsc && vite build",
+    "preview": "vite preview"
   },
   "dependencies": {
     "@blocknote/ariakit": "latest",
@@ -25,6 +25,6 @@
     "@types/react": "^19.2.3",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.1",
-    "vite-plus": "^0.1.24"
+    "vite": "^8.0.0"
   }
 }

--- a/examples/02-backend/01-file-uploading/vite-env.d.ts
+++ b/examples/02-backend/01-file-uploading/vite-env.d.ts
@@ -1,1 +1,1 @@
-/// <reference types="vite-plus/client" />
+/// <reference types="vite/client" />

--- a/examples/02-backend/01-file-uploading/vite.config.ts
+++ b/examples/02-backend/01-file-uploading/vite.config.ts
@@ -2,7 +2,7 @@
 import react from "@vitejs/plugin-react";
 import * as fs from "fs";
 import * as path from "path";
-import { defineConfig } from "vite-plus";
+import { defineConfig } from "vite";
 // https://vitejs.dev/config/
 export default defineConfig(((conf: { command: string }) => ({
   plugins: [react()],

--- a/examples/02-backend/02-saving-loading/package.json
+++ b/examples/02-backend/02-saving-loading/package.json
@@ -5,10 +5,10 @@
   "private": true,
   "version": "0.12.4",
   "scripts": {
-    "start": "vp dev",
-    "dev": "vp dev",
-    "build:prod": "tsc && vp build",
-    "preview": "vp preview"
+    "start": "vite",
+    "dev": "vite",
+    "build:prod": "tsc && vite build",
+    "preview": "vite preview"
   },
   "dependencies": {
     "@blocknote/ariakit": "latest",
@@ -25,6 +25,6 @@
     "@types/react": "^19.2.3",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.1",
-    "vite-plus": "^0.1.24"
+    "vite": "^8.0.0"
   }
 }

--- a/examples/02-backend/02-saving-loading/vite-env.d.ts
+++ b/examples/02-backend/02-saving-loading/vite-env.d.ts
@@ -1,1 +1,1 @@
-/// <reference types="vite-plus/client" />
+/// <reference types="vite/client" />

--- a/examples/02-backend/02-saving-loading/vite.config.ts
+++ b/examples/02-backend/02-saving-loading/vite.config.ts
@@ -2,7 +2,7 @@
 import react from "@vitejs/plugin-react";
 import * as fs from "fs";
 import * as path from "path";
-import { defineConfig } from "vite-plus";
+import { defineConfig } from "vite";
 // https://vitejs.dev/config/
 export default defineConfig(((conf: { command: string }) => ({
   plugins: [react()],

--- a/examples/02-backend/03-s3/package.json
+++ b/examples/02-backend/03-s3/package.json
@@ -5,10 +5,10 @@
   "private": true,
   "version": "0.12.4",
   "scripts": {
-    "start": "vp dev",
-    "dev": "vp dev",
-    "build:prod": "tsc && vp build",
-    "preview": "vp preview"
+    "start": "vite",
+    "dev": "vite",
+    "build:prod": "tsc && vite build",
+    "preview": "vite preview"
   },
   "dependencies": {
     "@blocknote/ariakit": "latest",
@@ -27,6 +27,6 @@
     "@types/react": "^19.2.3",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.1",
-    "vite-plus": "^0.1.24"
+    "vite": "^8.0.0"
   }
 }

--- a/examples/02-backend/03-s3/vite-env.d.ts
+++ b/examples/02-backend/03-s3/vite-env.d.ts
@@ -1,1 +1,1 @@
-/// <reference types="vite-plus/client" />
+/// <reference types="vite/client" />

--- a/examples/02-backend/03-s3/vite.config.ts
+++ b/examples/02-backend/03-s3/vite.config.ts
@@ -2,7 +2,7 @@
 import react from "@vitejs/plugin-react";
 import * as fs from "fs";
 import * as path from "path";
-import { defineConfig } from "vite-plus";
+import { defineConfig } from "vite";
 // https://vitejs.dev/config/
 export default defineConfig(((conf: { command: string }) => ({
   plugins: [react()],

--- a/examples/02-backend/04-rendering-static-documents/package.json
+++ b/examples/02-backend/04-rendering-static-documents/package.json
@@ -5,10 +5,10 @@
   "private": true,
   "version": "0.12.4",
   "scripts": {
-    "start": "vp dev",
-    "dev": "vp dev",
-    "build:prod": "tsc && vp build",
-    "preview": "vp preview"
+    "start": "vite",
+    "dev": "vite",
+    "build:prod": "tsc && vite build",
+    "preview": "vite preview"
   },
   "dependencies": {
     "@blocknote/ariakit": "latest",
@@ -26,6 +26,6 @@
     "@types/react": "^19.2.3",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.1",
-    "vite-plus": "^0.1.24"
+    "vite": "^8.0.0"
   }
 }

--- a/examples/02-backend/04-rendering-static-documents/vite-env.d.ts
+++ b/examples/02-backend/04-rendering-static-documents/vite-env.d.ts
@@ -1,1 +1,1 @@
-/// <reference types="vite-plus/client" />
+/// <reference types="vite/client" />

--- a/examples/02-backend/04-rendering-static-documents/vite.config.ts
+++ b/examples/02-backend/04-rendering-static-documents/vite.config.ts
@@ -2,7 +2,7 @@
 import react from "@vitejs/plugin-react";
 import * as fs from "fs";
 import * as path from "path";
-import { defineConfig } from "vite-plus";
+import { defineConfig } from "vite";
 // https://vitejs.dev/config/
 export default defineConfig(((conf: { command: string }) => ({
   plugins: [react()],

--- a/examples/03-ui-components/01-ui-elements-remove/package.json
+++ b/examples/03-ui-components/01-ui-elements-remove/package.json
@@ -5,10 +5,10 @@
   "private": true,
   "version": "0.12.4",
   "scripts": {
-    "start": "vp dev",
-    "dev": "vp dev",
-    "build:prod": "tsc && vp build",
-    "preview": "vp preview"
+    "start": "vite",
+    "dev": "vite",
+    "build:prod": "tsc && vite build",
+    "preview": "vite preview"
   },
   "dependencies": {
     "@blocknote/ariakit": "latest",
@@ -25,6 +25,6 @@
     "@types/react": "^19.2.3",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.1",
-    "vite-plus": "^0.1.24"
+    "vite": "^8.0.0"
   }
 }

--- a/examples/03-ui-components/01-ui-elements-remove/vite-env.d.ts
+++ b/examples/03-ui-components/01-ui-elements-remove/vite-env.d.ts
@@ -1,1 +1,1 @@
-/// <reference types="vite-plus/client" />
+/// <reference types="vite/client" />

--- a/examples/03-ui-components/01-ui-elements-remove/vite.config.ts
+++ b/examples/03-ui-components/01-ui-elements-remove/vite.config.ts
@@ -2,7 +2,7 @@
 import react from "@vitejs/plugin-react";
 import * as fs from "fs";
 import * as path from "path";
-import { defineConfig } from "vite-plus";
+import { defineConfig } from "vite";
 // https://vitejs.dev/config/
 export default defineConfig(((conf: { command: string }) => ({
   plugins: [react()],

--- a/examples/03-ui-components/02-formatting-toolbar-buttons/package.json
+++ b/examples/03-ui-components/02-formatting-toolbar-buttons/package.json
@@ -5,10 +5,10 @@
   "private": true,
   "version": "0.12.4",
   "scripts": {
-    "start": "vp dev",
-    "dev": "vp dev",
-    "build:prod": "tsc && vp build",
-    "preview": "vp preview"
+    "start": "vite",
+    "dev": "vite",
+    "build:prod": "tsc && vite build",
+    "preview": "vite preview"
   },
   "dependencies": {
     "@blocknote/ariakit": "latest",
@@ -25,6 +25,6 @@
     "@types/react": "^19.2.3",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.1",
-    "vite-plus": "^0.1.24"
+    "vite": "^8.0.0"
   }
 }

--- a/examples/03-ui-components/02-formatting-toolbar-buttons/vite-env.d.ts
+++ b/examples/03-ui-components/02-formatting-toolbar-buttons/vite-env.d.ts
@@ -1,1 +1,1 @@
-/// <reference types="vite-plus/client" />
+/// <reference types="vite/client" />

--- a/examples/03-ui-components/02-formatting-toolbar-buttons/vite.config.ts
+++ b/examples/03-ui-components/02-formatting-toolbar-buttons/vite.config.ts
@@ -2,7 +2,7 @@
 import react from "@vitejs/plugin-react";
 import * as fs from "fs";
 import * as path from "path";
-import { defineConfig } from "vite-plus";
+import { defineConfig } from "vite";
 // https://vitejs.dev/config/
 export default defineConfig(((conf: { command: string }) => ({
   plugins: [react()],

--- a/examples/03-ui-components/03-formatting-toolbar-block-type-items/package.json
+++ b/examples/03-ui-components/03-formatting-toolbar-block-type-items/package.json
@@ -5,10 +5,10 @@
   "private": true,
   "version": "0.12.4",
   "scripts": {
-    "start": "vp dev",
-    "dev": "vp dev",
-    "build:prod": "tsc && vp build",
-    "preview": "vp preview"
+    "start": "vite",
+    "dev": "vite",
+    "build:prod": "tsc && vite build",
+    "preview": "vite preview"
   },
   "dependencies": {
     "@blocknote/ariakit": "latest",
@@ -26,6 +26,6 @@
     "@types/react": "^19.2.3",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.1",
-    "vite-plus": "^0.1.24"
+    "vite": "^8.0.0"
   }
 }

--- a/examples/03-ui-components/03-formatting-toolbar-block-type-items/vite-env.d.ts
+++ b/examples/03-ui-components/03-formatting-toolbar-block-type-items/vite-env.d.ts
@@ -1,1 +1,1 @@
-/// <reference types="vite-plus/client" />
+/// <reference types="vite/client" />

--- a/examples/03-ui-components/03-formatting-toolbar-block-type-items/vite.config.ts
+++ b/examples/03-ui-components/03-formatting-toolbar-block-type-items/vite.config.ts
@@ -2,7 +2,7 @@
 import react from "@vitejs/plugin-react";
 import * as fs from "fs";
 import * as path from "path";
-import { defineConfig } from "vite-plus";
+import { defineConfig } from "vite";
 // https://vitejs.dev/config/
 export default defineConfig(((conf: { command: string }) => ({
   plugins: [react()],

--- a/examples/03-ui-components/04-side-menu-buttons/package.json
+++ b/examples/03-ui-components/04-side-menu-buttons/package.json
@@ -5,10 +5,10 @@
   "private": true,
   "version": "0.12.4",
   "scripts": {
-    "start": "vp dev",
-    "dev": "vp dev",
-    "build:prod": "tsc && vp build",
-    "preview": "vp preview"
+    "start": "vite",
+    "dev": "vite",
+    "build:prod": "tsc && vite build",
+    "preview": "vite preview"
   },
   "dependencies": {
     "@blocknote/ariakit": "latest",
@@ -26,6 +26,6 @@
     "@types/react": "^19.2.3",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.1",
-    "vite-plus": "^0.1.24"
+    "vite": "^8.0.0"
   }
 }

--- a/examples/03-ui-components/04-side-menu-buttons/vite-env.d.ts
+++ b/examples/03-ui-components/04-side-menu-buttons/vite-env.d.ts
@@ -1,1 +1,1 @@
-/// <reference types="vite-plus/client" />
+/// <reference types="vite/client" />

--- a/examples/03-ui-components/04-side-menu-buttons/vite.config.ts
+++ b/examples/03-ui-components/04-side-menu-buttons/vite.config.ts
@@ -2,7 +2,7 @@
 import react from "@vitejs/plugin-react";
 import * as fs from "fs";
 import * as path from "path";
-import { defineConfig } from "vite-plus";
+import { defineConfig } from "vite";
 // https://vitejs.dev/config/
 export default defineConfig(((conf: { command: string }) => ({
   plugins: [react()],

--- a/examples/03-ui-components/05-side-menu-drag-handle-items/package.json
+++ b/examples/03-ui-components/05-side-menu-drag-handle-items/package.json
@@ -5,10 +5,10 @@
   "private": true,
   "version": "0.12.4",
   "scripts": {
-    "start": "vp dev",
-    "dev": "vp dev",
-    "build:prod": "tsc && vp build",
-    "preview": "vp preview"
+    "start": "vite",
+    "dev": "vite",
+    "build:prod": "tsc && vite build",
+    "preview": "vite preview"
   },
   "dependencies": {
     "@blocknote/ariakit": "latest",
@@ -26,6 +26,6 @@
     "@types/react": "^19.2.3",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.1",
-    "vite-plus": "^0.1.24"
+    "vite": "^8.0.0"
   }
 }

--- a/examples/03-ui-components/05-side-menu-drag-handle-items/vite-env.d.ts
+++ b/examples/03-ui-components/05-side-menu-drag-handle-items/vite-env.d.ts
@@ -1,1 +1,1 @@
-/// <reference types="vite-plus/client" />
+/// <reference types="vite/client" />

--- a/examples/03-ui-components/05-side-menu-drag-handle-items/vite.config.ts
+++ b/examples/03-ui-components/05-side-menu-drag-handle-items/vite.config.ts
@@ -2,7 +2,7 @@
 import react from "@vitejs/plugin-react";
 import * as fs from "fs";
 import * as path from "path";
-import { defineConfig } from "vite-plus";
+import { defineConfig } from "vite";
 // https://vitejs.dev/config/
 export default defineConfig(((conf: { command: string }) => ({
   plugins: [react()],

--- a/examples/03-ui-components/06-suggestion-menus-slash-menu-items/package.json
+++ b/examples/03-ui-components/06-suggestion-menus-slash-menu-items/package.json
@@ -5,10 +5,10 @@
   "private": true,
   "version": "0.12.4",
   "scripts": {
-    "start": "vp dev",
-    "dev": "vp dev",
-    "build:prod": "tsc && vp build",
-    "preview": "vp preview"
+    "start": "vite",
+    "dev": "vite",
+    "build:prod": "tsc && vite build",
+    "preview": "vite preview"
   },
   "dependencies": {
     "@blocknote/ariakit": "latest",
@@ -26,6 +26,6 @@
     "@types/react": "^19.2.3",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.1",
-    "vite-plus": "^0.1.24"
+    "vite": "^8.0.0"
   }
 }

--- a/examples/03-ui-components/06-suggestion-menus-slash-menu-items/vite-env.d.ts
+++ b/examples/03-ui-components/06-suggestion-menus-slash-menu-items/vite-env.d.ts
@@ -1,1 +1,1 @@
-/// <reference types="vite-plus/client" />
+/// <reference types="vite/client" />

--- a/examples/03-ui-components/06-suggestion-menus-slash-menu-items/vite.config.ts
+++ b/examples/03-ui-components/06-suggestion-menus-slash-menu-items/vite.config.ts
@@ -2,7 +2,7 @@
 import react from "@vitejs/plugin-react";
 import * as fs from "fs";
 import * as path from "path";
-import { defineConfig } from "vite-plus";
+import { defineConfig } from "vite";
 // https://vitejs.dev/config/
 export default defineConfig(((conf: { command: string }) => ({
   plugins: [react()],

--- a/examples/03-ui-components/07-suggestion-menus-slash-menu-component/package.json
+++ b/examples/03-ui-components/07-suggestion-menus-slash-menu-component/package.json
@@ -5,10 +5,10 @@
   "private": true,
   "version": "0.12.4",
   "scripts": {
-    "start": "vp dev",
-    "dev": "vp dev",
-    "build:prod": "tsc && vp build",
-    "preview": "vp preview"
+    "start": "vite",
+    "dev": "vite",
+    "build:prod": "tsc && vite build",
+    "preview": "vite preview"
   },
   "dependencies": {
     "@blocknote/ariakit": "latest",
@@ -25,6 +25,6 @@
     "@types/react": "^19.2.3",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.1",
-    "vite-plus": "^0.1.24"
+    "vite": "^8.0.0"
   }
 }

--- a/examples/03-ui-components/07-suggestion-menus-slash-menu-component/vite-env.d.ts
+++ b/examples/03-ui-components/07-suggestion-menus-slash-menu-component/vite-env.d.ts
@@ -1,1 +1,1 @@
-/// <reference types="vite-plus/client" />
+/// <reference types="vite/client" />

--- a/examples/03-ui-components/07-suggestion-menus-slash-menu-component/vite.config.ts
+++ b/examples/03-ui-components/07-suggestion-menus-slash-menu-component/vite.config.ts
@@ -2,7 +2,7 @@
 import react from "@vitejs/plugin-react";
 import * as fs from "fs";
 import * as path from "path";
-import { defineConfig } from "vite-plus";
+import { defineConfig } from "vite";
 // https://vitejs.dev/config/
 export default defineConfig(((conf: { command: string }) => ({
   plugins: [react()],

--- a/examples/03-ui-components/08-suggestion-menus-emoji-picker-columns/package.json
+++ b/examples/03-ui-components/08-suggestion-menus-emoji-picker-columns/package.json
@@ -5,10 +5,10 @@
   "private": true,
   "version": "0.12.4",
   "scripts": {
-    "start": "vp dev",
-    "dev": "vp dev",
-    "build:prod": "tsc && vp build",
-    "preview": "vp preview"
+    "start": "vite",
+    "dev": "vite",
+    "build:prod": "tsc && vite build",
+    "preview": "vite preview"
   },
   "dependencies": {
     "@blocknote/ariakit": "latest",
@@ -25,6 +25,6 @@
     "@types/react": "^19.2.3",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.1",
-    "vite-plus": "^0.1.24"
+    "vite": "^8.0.0"
   }
 }

--- a/examples/03-ui-components/08-suggestion-menus-emoji-picker-columns/vite-env.d.ts
+++ b/examples/03-ui-components/08-suggestion-menus-emoji-picker-columns/vite-env.d.ts
@@ -1,1 +1,1 @@
-/// <reference types="vite-plus/client" />
+/// <reference types="vite/client" />

--- a/examples/03-ui-components/08-suggestion-menus-emoji-picker-columns/vite.config.ts
+++ b/examples/03-ui-components/08-suggestion-menus-emoji-picker-columns/vite.config.ts
@@ -2,7 +2,7 @@
 import react from "@vitejs/plugin-react";
 import * as fs from "fs";
 import * as path from "path";
-import { defineConfig } from "vite-plus";
+import { defineConfig } from "vite";
 // https://vitejs.dev/config/
 export default defineConfig(((conf: { command: string }) => ({
   plugins: [react()],

--- a/examples/03-ui-components/09-suggestion-menus-emoji-picker-component/package.json
+++ b/examples/03-ui-components/09-suggestion-menus-emoji-picker-component/package.json
@@ -5,10 +5,10 @@
   "private": true,
   "version": "0.12.4",
   "scripts": {
-    "start": "vp dev",
-    "dev": "vp dev",
-    "build:prod": "tsc && vp build",
-    "preview": "vp preview"
+    "start": "vite",
+    "dev": "vite",
+    "build:prod": "tsc && vite build",
+    "preview": "vite preview"
   },
   "dependencies": {
     "@blocknote/ariakit": "latest",
@@ -25,6 +25,6 @@
     "@types/react": "^19.2.3",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.1",
-    "vite-plus": "^0.1.24"
+    "vite": "^8.0.0"
   }
 }

--- a/examples/03-ui-components/09-suggestion-menus-emoji-picker-component/vite-env.d.ts
+++ b/examples/03-ui-components/09-suggestion-menus-emoji-picker-component/vite-env.d.ts
@@ -1,1 +1,1 @@
-/// <reference types="vite-plus/client" />
+/// <reference types="vite/client" />

--- a/examples/03-ui-components/09-suggestion-menus-emoji-picker-component/vite.config.ts
+++ b/examples/03-ui-components/09-suggestion-menus-emoji-picker-component/vite.config.ts
@@ -2,7 +2,7 @@
 import react from "@vitejs/plugin-react";
 import * as fs from "fs";
 import * as path from "path";
-import { defineConfig } from "vite-plus";
+import { defineConfig } from "vite";
 // https://vitejs.dev/config/
 export default defineConfig(((conf: { command: string }) => ({
   plugins: [react()],

--- a/examples/03-ui-components/10-suggestion-menus-grid-mentions/package.json
+++ b/examples/03-ui-components/10-suggestion-menus-grid-mentions/package.json
@@ -5,10 +5,10 @@
   "private": true,
   "version": "0.12.4",
   "scripts": {
-    "start": "vp dev",
-    "dev": "vp dev",
-    "build:prod": "tsc && vp build",
-    "preview": "vp preview"
+    "start": "vite",
+    "dev": "vite",
+    "build:prod": "tsc && vite build",
+    "preview": "vite preview"
   },
   "dependencies": {
     "@blocknote/ariakit": "latest",
@@ -25,6 +25,6 @@
     "@types/react": "^19.2.3",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.1",
-    "vite-plus": "^0.1.24"
+    "vite": "^8.0.0"
   }
 }

--- a/examples/03-ui-components/10-suggestion-menus-grid-mentions/vite-env.d.ts
+++ b/examples/03-ui-components/10-suggestion-menus-grid-mentions/vite-env.d.ts
@@ -1,1 +1,1 @@
-/// <reference types="vite-plus/client" />
+/// <reference types="vite/client" />

--- a/examples/03-ui-components/10-suggestion-menus-grid-mentions/vite.config.ts
+++ b/examples/03-ui-components/10-suggestion-menus-grid-mentions/vite.config.ts
@@ -2,7 +2,7 @@
 import react from "@vitejs/plugin-react";
 import * as fs from "fs";
 import * as path from "path";
-import { defineConfig } from "vite-plus";
+import { defineConfig } from "vite";
 // https://vitejs.dev/config/
 export default defineConfig(((conf: { command: string }) => ({
   plugins: [react()],

--- a/examples/03-ui-components/11-uppy-file-panel/package.json
+++ b/examples/03-ui-components/11-uppy-file-panel/package.json
@@ -5,10 +5,10 @@
   "private": true,
   "version": "0.12.4",
   "scripts": {
-    "start": "vp dev",
-    "dev": "vp dev",
-    "build:prod": "tsc && vp build",
-    "preview": "vp preview"
+    "start": "vite",
+    "dev": "vite",
+    "build:prod": "tsc && vite build",
+    "preview": "vite preview"
   },
   "dependencies": {
     "@blocknote/ariakit": "latest",
@@ -37,6 +37,6 @@
     "@types/react": "^19.2.3",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.1",
-    "vite-plus": "^0.1.24"
+    "vite": "^8.0.0"
   }
 }

--- a/examples/03-ui-components/11-uppy-file-panel/vite-env.d.ts
+++ b/examples/03-ui-components/11-uppy-file-panel/vite-env.d.ts
@@ -1,1 +1,1 @@
-/// <reference types="vite-plus/client" />
+/// <reference types="vite/client" />

--- a/examples/03-ui-components/11-uppy-file-panel/vite.config.ts
+++ b/examples/03-ui-components/11-uppy-file-panel/vite.config.ts
@@ -2,7 +2,7 @@
 import react from "@vitejs/plugin-react";
 import * as fs from "fs";
 import * as path from "path";
-import { defineConfig } from "vite-plus";
+import { defineConfig } from "vite";
 // https://vitejs.dev/config/
 export default defineConfig(((conf: { command: string }) => ({
   plugins: [react()],

--- a/examples/03-ui-components/12-static-formatting-toolbar/package.json
+++ b/examples/03-ui-components/12-static-formatting-toolbar/package.json
@@ -5,10 +5,10 @@
   "private": true,
   "version": "0.12.4",
   "scripts": {
-    "start": "vp dev",
-    "dev": "vp dev",
-    "build:prod": "tsc && vp build",
-    "preview": "vp preview"
+    "start": "vite",
+    "dev": "vite",
+    "build:prod": "tsc && vite build",
+    "preview": "vite preview"
   },
   "dependencies": {
     "@blocknote/ariakit": "latest",
@@ -25,6 +25,6 @@
     "@types/react": "^19.2.3",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.1",
-    "vite-plus": "^0.1.24"
+    "vite": "^8.0.0"
   }
 }

--- a/examples/03-ui-components/12-static-formatting-toolbar/vite-env.d.ts
+++ b/examples/03-ui-components/12-static-formatting-toolbar/vite-env.d.ts
@@ -1,1 +1,1 @@
-/// <reference types="vite-plus/client" />
+/// <reference types="vite/client" />

--- a/examples/03-ui-components/12-static-formatting-toolbar/vite.config.ts
+++ b/examples/03-ui-components/12-static-formatting-toolbar/vite.config.ts
@@ -2,7 +2,7 @@
 import react from "@vitejs/plugin-react";
 import * as fs from "fs";
 import * as path from "path";
-import { defineConfig } from "vite-plus";
+import { defineConfig } from "vite";
 // https://vitejs.dev/config/
 export default defineConfig(((conf: { command: string }) => ({
   plugins: [react()],

--- a/examples/03-ui-components/13-custom-ui/package.json
+++ b/examples/03-ui-components/13-custom-ui/package.json
@@ -5,10 +5,10 @@
   "private": true,
   "version": "0.12.4",
   "scripts": {
-    "start": "vp dev",
-    "dev": "vp dev",
-    "build:prod": "tsc && vp build",
-    "preview": "vp preview"
+    "start": "vite",
+    "dev": "vite",
+    "build:prod": "tsc && vite build",
+    "preview": "vite preview"
   },
   "dependencies": {
     "@blocknote/ariakit": "latest",
@@ -27,6 +27,6 @@
     "@types/react": "^19.2.3",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.1",
-    "vite-plus": "^0.1.24"
+    "vite": "^8.0.0"
   }
 }

--- a/examples/03-ui-components/13-custom-ui/vite-env.d.ts
+++ b/examples/03-ui-components/13-custom-ui/vite-env.d.ts
@@ -1,1 +1,1 @@
-/// <reference types="vite-plus/client" />
+/// <reference types="vite/client" />

--- a/examples/03-ui-components/13-custom-ui/vite.config.ts
+++ b/examples/03-ui-components/13-custom-ui/vite.config.ts
@@ -2,7 +2,7 @@
 import react from "@vitejs/plugin-react";
 import * as fs from "fs";
 import * as path from "path";
-import { defineConfig } from "vite-plus";
+import { defineConfig } from "vite";
 // https://vitejs.dev/config/
 export default defineConfig(((conf: { command: string }) => ({
   plugins: [react()],

--- a/examples/03-ui-components/14-experimental-mobile-formatting-toolbar/package.json
+++ b/examples/03-ui-components/14-experimental-mobile-formatting-toolbar/package.json
@@ -5,10 +5,10 @@
   "private": true,
   "version": "0.12.4",
   "scripts": {
-    "start": "vp dev",
-    "dev": "vp dev",
-    "build:prod": "tsc && vp build",
-    "preview": "vp preview"
+    "start": "vite",
+    "dev": "vite",
+    "build:prod": "tsc && vite build",
+    "preview": "vite preview"
   },
   "dependencies": {
     "@blocknote/ariakit": "latest",
@@ -25,6 +25,6 @@
     "@types/react": "^19.2.3",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.1",
-    "vite-plus": "^0.1.24"
+    "vite": "^8.0.0"
   }
 }

--- a/examples/03-ui-components/14-experimental-mobile-formatting-toolbar/vite-env.d.ts
+++ b/examples/03-ui-components/14-experimental-mobile-formatting-toolbar/vite-env.d.ts
@@ -1,1 +1,1 @@
-/// <reference types="vite-plus/client" />
+/// <reference types="vite/client" />

--- a/examples/03-ui-components/14-experimental-mobile-formatting-toolbar/vite.config.ts
+++ b/examples/03-ui-components/14-experimental-mobile-formatting-toolbar/vite.config.ts
@@ -2,7 +2,7 @@
 import react from "@vitejs/plugin-react";
 import * as fs from "fs";
 import * as path from "path";
-import { defineConfig } from "vite-plus";
+import { defineConfig } from "vite";
 // https://vitejs.dev/config/
 export default defineConfig(((conf: { command: string }) => ({
   plugins: [react()],

--- a/examples/03-ui-components/15-advanced-tables/package.json
+++ b/examples/03-ui-components/15-advanced-tables/package.json
@@ -5,10 +5,10 @@
   "private": true,
   "version": "0.12.4",
   "scripts": {
-    "start": "vp dev",
-    "dev": "vp dev",
-    "build:prod": "tsc && vp build",
-    "preview": "vp preview"
+    "start": "vite",
+    "dev": "vite",
+    "build:prod": "tsc && vite build",
+    "preview": "vite preview"
   },
   "dependencies": {
     "@blocknote/ariakit": "latest",
@@ -25,6 +25,6 @@
     "@types/react": "^19.2.3",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.1",
-    "vite-plus": "^0.1.24"
+    "vite": "^8.0.0"
   }
 }

--- a/examples/03-ui-components/15-advanced-tables/vite-env.d.ts
+++ b/examples/03-ui-components/15-advanced-tables/vite-env.d.ts
@@ -1,1 +1,1 @@
-/// <reference types="vite-plus/client" />
+/// <reference types="vite/client" />

--- a/examples/03-ui-components/15-advanced-tables/vite.config.ts
+++ b/examples/03-ui-components/15-advanced-tables/vite.config.ts
@@ -2,7 +2,7 @@
 import react from "@vitejs/plugin-react";
 import * as fs from "fs";
 import * as path from "path";
-import { defineConfig } from "vite-plus";
+import { defineConfig } from "vite";
 // https://vitejs.dev/config/
 export default defineConfig(((conf: { command: string }) => ({
   plugins: [react()],

--- a/examples/03-ui-components/16-link-toolbar-buttons/package.json
+++ b/examples/03-ui-components/16-link-toolbar-buttons/package.json
@@ -5,10 +5,10 @@
   "private": true,
   "version": "0.12.4",
   "scripts": {
-    "start": "vp dev",
-    "dev": "vp dev",
-    "build:prod": "tsc && vp build",
-    "preview": "vp preview"
+    "start": "vite",
+    "dev": "vite",
+    "build:prod": "tsc && vite build",
+    "preview": "vite preview"
   },
   "dependencies": {
     "@blocknote/ariakit": "latest",
@@ -25,6 +25,6 @@
     "@types/react": "^19.2.3",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.1",
-    "vite-plus": "^0.1.24"
+    "vite": "^8.0.0"
   }
 }

--- a/examples/03-ui-components/16-link-toolbar-buttons/vite-env.d.ts
+++ b/examples/03-ui-components/16-link-toolbar-buttons/vite-env.d.ts
@@ -1,1 +1,1 @@
-/// <reference types="vite-plus/client" />
+/// <reference types="vite/client" />

--- a/examples/03-ui-components/16-link-toolbar-buttons/vite.config.ts
+++ b/examples/03-ui-components/16-link-toolbar-buttons/vite.config.ts
@@ -2,7 +2,7 @@
 import react from "@vitejs/plugin-react";
 import * as fs from "fs";
 import * as path from "path";
-import { defineConfig } from "vite-plus";
+import { defineConfig } from "vite";
 // https://vitejs.dev/config/
 export default defineConfig(((conf: { command: string }) => ({
   plugins: [react()],

--- a/examples/03-ui-components/17-advanced-tables-2/package.json
+++ b/examples/03-ui-components/17-advanced-tables-2/package.json
@@ -5,10 +5,10 @@
   "private": true,
   "version": "0.12.4",
   "scripts": {
-    "start": "vp dev",
-    "dev": "vp dev",
-    "build:prod": "tsc && vp build",
-    "preview": "vp preview"
+    "start": "vite",
+    "dev": "vite",
+    "build:prod": "tsc && vite build",
+    "preview": "vite preview"
   },
   "dependencies": {
     "@blocknote/ariakit": "latest",
@@ -25,6 +25,6 @@
     "@types/react": "^19.2.3",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.1",
-    "vite-plus": "^0.1.24"
+    "vite": "^8.0.0"
   }
 }

--- a/examples/03-ui-components/17-advanced-tables-2/vite-env.d.ts
+++ b/examples/03-ui-components/17-advanced-tables-2/vite-env.d.ts
@@ -1,1 +1,1 @@
-/// <reference types="vite-plus/client" />
+/// <reference types="vite/client" />

--- a/examples/03-ui-components/17-advanced-tables-2/vite.config.ts
+++ b/examples/03-ui-components/17-advanced-tables-2/vite.config.ts
@@ -2,7 +2,7 @@
 import react from "@vitejs/plugin-react";
 import * as fs from "fs";
 import * as path from "path";
-import { defineConfig } from "vite-plus";
+import { defineConfig } from "vite";
 // https://vitejs.dev/config/
 export default defineConfig(((conf: { command: string }) => ({
   plugins: [react()],

--- a/examples/03-ui-components/18-drag-n-drop/package.json
+++ b/examples/03-ui-components/18-drag-n-drop/package.json
@@ -5,10 +5,10 @@
   "private": true,
   "version": "0.12.4",
   "scripts": {
-    "start": "vp dev",
-    "dev": "vp dev",
-    "build:prod": "tsc && vp build",
-    "preview": "vp preview"
+    "start": "vite",
+    "dev": "vite",
+    "build:prod": "tsc && vite build",
+    "preview": "vite preview"
   },
   "dependencies": {
     "@blocknote/ariakit": "latest",
@@ -25,6 +25,6 @@
     "@types/react": "^19.2.3",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.1",
-    "vite-plus": "^0.1.24"
+    "vite": "^8.0.0"
   }
 }

--- a/examples/03-ui-components/18-drag-n-drop/vite-env.d.ts
+++ b/examples/03-ui-components/18-drag-n-drop/vite-env.d.ts
@@ -1,1 +1,1 @@
-/// <reference types="vite-plus/client" />
+/// <reference types="vite/client" />

--- a/examples/03-ui-components/18-drag-n-drop/vite.config.ts
+++ b/examples/03-ui-components/18-drag-n-drop/vite.config.ts
@@ -2,7 +2,7 @@
 import react from "@vitejs/plugin-react";
 import * as fs from "fs";
 import * as path from "path";
-import { defineConfig } from "vite-plus";
+import { defineConfig } from "vite";
 // https://vitejs.dev/config/
 export default defineConfig(((conf: { command: string }) => ({
   plugins: [react()],

--- a/examples/03-ui-components/19-suggestion-menus-grouping-ordering/package.json
+++ b/examples/03-ui-components/19-suggestion-menus-grouping-ordering/package.json
@@ -5,10 +5,10 @@
   "private": true,
   "version": "0.12.4",
   "scripts": {
-    "start": "vp dev",
-    "dev": "vp dev",
-    "build:prod": "tsc && vp build",
-    "preview": "vp preview"
+    "start": "vite",
+    "dev": "vite",
+    "build:prod": "tsc && vite build",
+    "preview": "vite preview"
   },
   "dependencies": {
     "@blocknote/ariakit": "latest",
@@ -25,6 +25,6 @@
     "@types/react": "^19.2.3",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.1",
-    "vite-plus": "^0.1.24"
+    "vite": "^8.0.0"
   }
 }

--- a/examples/03-ui-components/19-suggestion-menus-grouping-ordering/vite-env.d.ts
+++ b/examples/03-ui-components/19-suggestion-menus-grouping-ordering/vite-env.d.ts
@@ -1,1 +1,1 @@
-/// <reference types="vite-plus/client" />
+/// <reference types="vite/client" />

--- a/examples/03-ui-components/19-suggestion-menus-grouping-ordering/vite.config.ts
+++ b/examples/03-ui-components/19-suggestion-menus-grouping-ordering/vite.config.ts
@@ -2,7 +2,7 @@
 import react from "@vitejs/plugin-react";
 import * as fs from "fs";
 import * as path from "path";
-import { defineConfig } from "vite-plus";
+import { defineConfig } from "vite";
 // https://vitejs.dev/config/
 export default defineConfig(((conf: { command: string }) => ({
   plugins: [react()],

--- a/examples/03-ui-components/20-portal-elements/package.json
+++ b/examples/03-ui-components/20-portal-elements/package.json
@@ -5,10 +5,10 @@
   "private": true,
   "version": "0.12.4",
   "scripts": {
-    "start": "vp dev",
-    "dev": "vp dev",
-    "build:prod": "tsc && vp build",
-    "preview": "vp preview"
+    "start": "vite",
+    "dev": "vite",
+    "build:prod": "tsc && vite build",
+    "preview": "vite preview"
   },
   "dependencies": {
     "@blocknote/ariakit": "latest",
@@ -25,6 +25,6 @@
     "@types/react": "^19.2.3",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.1",
-    "vite-plus": "^0.1.24"
+    "vite": "^8.0.0"
   }
 }

--- a/examples/03-ui-components/20-portal-elements/vite-env.d.ts
+++ b/examples/03-ui-components/20-portal-elements/vite-env.d.ts
@@ -1,1 +1,1 @@
-/// <reference types="vite-plus/client" />
+/// <reference types="vite/client" />

--- a/examples/03-ui-components/20-portal-elements/vite.config.ts
+++ b/examples/03-ui-components/20-portal-elements/vite.config.ts
@@ -2,7 +2,7 @@
 import react from "@vitejs/plugin-react";
 import * as fs from "fs";
 import * as path from "path";
-import { defineConfig } from "vite-plus";
+import { defineConfig } from "vite";
 // https://vitejs.dev/config/
 export default defineConfig(((conf: { command: string }) => ({
   plugins: [react()],

--- a/examples/04-theming/01-theming-dom-attributes/package.json
+++ b/examples/04-theming/01-theming-dom-attributes/package.json
@@ -5,10 +5,10 @@
   "private": true,
   "version": "0.12.4",
   "scripts": {
-    "start": "vp dev",
-    "dev": "vp dev",
-    "build:prod": "tsc && vp build",
-    "preview": "vp preview"
+    "start": "vite",
+    "dev": "vite",
+    "build:prod": "tsc && vite build",
+    "preview": "vite preview"
   },
   "dependencies": {
     "@blocknote/ariakit": "latest",
@@ -25,6 +25,6 @@
     "@types/react": "^19.2.3",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.1",
-    "vite-plus": "^0.1.24"
+    "vite": "^8.0.0"
   }
 }

--- a/examples/04-theming/01-theming-dom-attributes/vite-env.d.ts
+++ b/examples/04-theming/01-theming-dom-attributes/vite-env.d.ts
@@ -1,1 +1,1 @@
-/// <reference types="vite-plus/client" />
+/// <reference types="vite/client" />

--- a/examples/04-theming/01-theming-dom-attributes/vite.config.ts
+++ b/examples/04-theming/01-theming-dom-attributes/vite.config.ts
@@ -2,7 +2,7 @@
 import react from "@vitejs/plugin-react";
 import * as fs from "fs";
 import * as path from "path";
-import { defineConfig } from "vite-plus";
+import { defineConfig } from "vite";
 // https://vitejs.dev/config/
 export default defineConfig(((conf: { command: string }) => ({
   plugins: [react()],

--- a/examples/04-theming/02-changing-font/package.json
+++ b/examples/04-theming/02-changing-font/package.json
@@ -5,10 +5,10 @@
   "private": true,
   "version": "0.12.4",
   "scripts": {
-    "start": "vp dev",
-    "dev": "vp dev",
-    "build:prod": "tsc && vp build",
-    "preview": "vp preview"
+    "start": "vite",
+    "dev": "vite",
+    "build:prod": "tsc && vite build",
+    "preview": "vite preview"
   },
   "dependencies": {
     "@blocknote/ariakit": "latest",
@@ -25,6 +25,6 @@
     "@types/react": "^19.2.3",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.1",
-    "vite-plus": "^0.1.24"
+    "vite": "^8.0.0"
   }
 }

--- a/examples/04-theming/02-changing-font/vite-env.d.ts
+++ b/examples/04-theming/02-changing-font/vite-env.d.ts
@@ -1,1 +1,1 @@
-/// <reference types="vite-plus/client" />
+/// <reference types="vite/client" />

--- a/examples/04-theming/02-changing-font/vite.config.ts
+++ b/examples/04-theming/02-changing-font/vite.config.ts
@@ -2,7 +2,7 @@
 import react from "@vitejs/plugin-react";
 import * as fs from "fs";
 import * as path from "path";
-import { defineConfig } from "vite-plus";
+import { defineConfig } from "vite";
 // https://vitejs.dev/config/
 export default defineConfig(((conf: { command: string }) => ({
   plugins: [react()],

--- a/examples/04-theming/03-theming-css/package.json
+++ b/examples/04-theming/03-theming-css/package.json
@@ -5,10 +5,10 @@
   "private": true,
   "version": "0.12.4",
   "scripts": {
-    "start": "vp dev",
-    "dev": "vp dev",
-    "build:prod": "tsc && vp build",
-    "preview": "vp preview"
+    "start": "vite",
+    "dev": "vite",
+    "build:prod": "tsc && vite build",
+    "preview": "vite preview"
   },
   "dependencies": {
     "@blocknote/ariakit": "latest",
@@ -25,6 +25,6 @@
     "@types/react": "^19.2.3",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.1",
-    "vite-plus": "^0.1.24"
+    "vite": "^8.0.0"
   }
 }

--- a/examples/04-theming/03-theming-css/vite-env.d.ts
+++ b/examples/04-theming/03-theming-css/vite-env.d.ts
@@ -1,1 +1,1 @@
-/// <reference types="vite-plus/client" />
+/// <reference types="vite/client" />

--- a/examples/04-theming/03-theming-css/vite.config.ts
+++ b/examples/04-theming/03-theming-css/vite.config.ts
@@ -2,7 +2,7 @@
 import react from "@vitejs/plugin-react";
 import * as fs from "fs";
 import * as path from "path";
-import { defineConfig } from "vite-plus";
+import { defineConfig } from "vite";
 // https://vitejs.dev/config/
 export default defineConfig(((conf: { command: string }) => ({
   plugins: [react()],

--- a/examples/04-theming/04-theming-css-variables/package.json
+++ b/examples/04-theming/04-theming-css-variables/package.json
@@ -5,10 +5,10 @@
   "private": true,
   "version": "0.12.4",
   "scripts": {
-    "start": "vp dev",
-    "dev": "vp dev",
-    "build:prod": "tsc && vp build",
-    "preview": "vp preview"
+    "start": "vite",
+    "dev": "vite",
+    "build:prod": "tsc && vite build",
+    "preview": "vite preview"
   },
   "dependencies": {
     "@blocknote/ariakit": "latest",
@@ -25,6 +25,6 @@
     "@types/react": "^19.2.3",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.1",
-    "vite-plus": "^0.1.24"
+    "vite": "^8.0.0"
   }
 }

--- a/examples/04-theming/04-theming-css-variables/vite-env.d.ts
+++ b/examples/04-theming/04-theming-css-variables/vite-env.d.ts
@@ -1,1 +1,1 @@
-/// <reference types="vite-plus/client" />
+/// <reference types="vite/client" />

--- a/examples/04-theming/04-theming-css-variables/vite.config.ts
+++ b/examples/04-theming/04-theming-css-variables/vite.config.ts
@@ -2,7 +2,7 @@
 import react from "@vitejs/plugin-react";
 import * as fs from "fs";
 import * as path from "path";
-import { defineConfig } from "vite-plus";
+import { defineConfig } from "vite";
 // https://vitejs.dev/config/
 export default defineConfig(((conf: { command: string }) => ({
   plugins: [react()],

--- a/examples/04-theming/05-theming-css-variables-code/package.json
+++ b/examples/04-theming/05-theming-css-variables-code/package.json
@@ -5,10 +5,10 @@
   "private": true,
   "version": "0.12.4",
   "scripts": {
-    "start": "vp dev",
-    "dev": "vp dev",
-    "build:prod": "tsc && vp build",
-    "preview": "vp preview"
+    "start": "vite",
+    "dev": "vite",
+    "build:prod": "tsc && vite build",
+    "preview": "vite preview"
   },
   "dependencies": {
     "@blocknote/ariakit": "latest",
@@ -25,6 +25,6 @@
     "@types/react": "^19.2.3",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.1",
-    "vite-plus": "^0.1.24"
+    "vite": "^8.0.0"
   }
 }

--- a/examples/04-theming/05-theming-css-variables-code/vite-env.d.ts
+++ b/examples/04-theming/05-theming-css-variables-code/vite-env.d.ts
@@ -1,1 +1,1 @@
-/// <reference types="vite-plus/client" />
+/// <reference types="vite/client" />

--- a/examples/04-theming/05-theming-css-variables-code/vite.config.ts
+++ b/examples/04-theming/05-theming-css-variables-code/vite.config.ts
@@ -2,7 +2,7 @@
 import react from "@vitejs/plugin-react";
 import * as fs from "fs";
 import * as path from "path";
-import { defineConfig } from "vite-plus";
+import { defineConfig } from "vite";
 // https://vitejs.dev/config/
 export default defineConfig(((conf: { command: string }) => ({
   plugins: [react()],

--- a/examples/04-theming/06-code-block/package.json
+++ b/examples/04-theming/06-code-block/package.json
@@ -5,10 +5,10 @@
   "private": true,
   "version": "0.12.4",
   "scripts": {
-    "start": "vp dev",
-    "dev": "vp dev",
-    "build:prod": "tsc && vp build",
-    "preview": "vp preview"
+    "start": "vite",
+    "dev": "vite",
+    "build:prod": "tsc && vite build",
+    "preview": "vite preview"
   },
   "dependencies": {
     "@blocknote/ariakit": "latest",
@@ -26,6 +26,6 @@
     "@types/react": "^19.2.3",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.1",
-    "vite-plus": "^0.1.24"
+    "vite": "^8.0.0"
   }
 }

--- a/examples/04-theming/06-code-block/vite-env.d.ts
+++ b/examples/04-theming/06-code-block/vite-env.d.ts
@@ -1,1 +1,1 @@
-/// <reference types="vite-plus/client" />
+/// <reference types="vite/client" />

--- a/examples/04-theming/06-code-block/vite.config.ts
+++ b/examples/04-theming/06-code-block/vite.config.ts
@@ -2,7 +2,7 @@
 import react from "@vitejs/plugin-react";
 import * as fs from "fs";
 import * as path from "path";
-import { defineConfig } from "vite-plus";
+import { defineConfig } from "vite";
 // https://vitejs.dev/config/
 export default defineConfig(((conf: { command: string }) => ({
   plugins: [react()],

--- a/examples/04-theming/07-custom-code-block/package.json
+++ b/examples/04-theming/07-custom-code-block/package.json
@@ -5,10 +5,10 @@
   "private": true,
   "version": "0.12.4",
   "scripts": {
-    "start": "vp dev",
-    "dev": "vp dev",
-    "build:prod": "tsc && vp build",
-    "preview": "vp preview"
+    "start": "vite",
+    "dev": "vite",
+    "build:prod": "tsc && vite build",
+    "preview": "vite preview"
   },
   "dependencies": {
     "@blocknote/ariakit": "latest",
@@ -31,6 +31,6 @@
     "@types/react": "^19.2.3",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.1",
-    "vite-plus": "^0.1.24"
+    "vite": "^8.0.0"
   }
 }

--- a/examples/04-theming/07-custom-code-block/vite-env.d.ts
+++ b/examples/04-theming/07-custom-code-block/vite-env.d.ts
@@ -1,1 +1,1 @@
-/// <reference types="vite-plus/client" />
+/// <reference types="vite/client" />

--- a/examples/04-theming/07-custom-code-block/vite.config.ts
+++ b/examples/04-theming/07-custom-code-block/vite.config.ts
@@ -2,7 +2,7 @@
 import react from "@vitejs/plugin-react";
 import * as fs from "fs";
 import * as path from "path";
-import { defineConfig } from "vite-plus";
+import { defineConfig } from "vite";
 // https://vitejs.dev/config/
 export default defineConfig(((conf: { command: string }) => ({
   plugins: [react()],

--- a/examples/05-interoperability/01-converting-blocks-to-html/package.json
+++ b/examples/05-interoperability/01-converting-blocks-to-html/package.json
@@ -5,10 +5,10 @@
   "private": true,
   "version": "0.12.4",
   "scripts": {
-    "start": "vp dev",
-    "dev": "vp dev",
-    "build:prod": "tsc && vp build",
-    "preview": "vp preview"
+    "start": "vite",
+    "dev": "vite",
+    "build:prod": "tsc && vite build",
+    "preview": "vite preview"
   },
   "dependencies": {
     "@blocknote/ariakit": "latest",
@@ -25,6 +25,6 @@
     "@types/react": "^19.2.3",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.1",
-    "vite-plus": "^0.1.24"
+    "vite": "^8.0.0"
   }
 }

--- a/examples/05-interoperability/01-converting-blocks-to-html/vite-env.d.ts
+++ b/examples/05-interoperability/01-converting-blocks-to-html/vite-env.d.ts
@@ -1,1 +1,1 @@
-/// <reference types="vite-plus/client" />
+/// <reference types="vite/client" />

--- a/examples/05-interoperability/01-converting-blocks-to-html/vite.config.ts
+++ b/examples/05-interoperability/01-converting-blocks-to-html/vite.config.ts
@@ -2,7 +2,7 @@
 import react from "@vitejs/plugin-react";
 import * as fs from "fs";
 import * as path from "path";
-import { defineConfig } from "vite-plus";
+import { defineConfig } from "vite";
 // https://vitejs.dev/config/
 export default defineConfig(((conf: { command: string }) => ({
   plugins: [react()],

--- a/examples/05-interoperability/02-converting-blocks-from-html/package.json
+++ b/examples/05-interoperability/02-converting-blocks-from-html/package.json
@@ -5,10 +5,10 @@
   "private": true,
   "version": "0.12.4",
   "scripts": {
-    "start": "vp dev",
-    "dev": "vp dev",
-    "build:prod": "tsc && vp build",
-    "preview": "vp preview"
+    "start": "vite",
+    "dev": "vite",
+    "build:prod": "tsc && vite build",
+    "preview": "vite preview"
   },
   "dependencies": {
     "@blocknote/ariakit": "latest",
@@ -25,6 +25,6 @@
     "@types/react": "^19.2.3",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.1",
-    "vite-plus": "^0.1.24"
+    "vite": "^8.0.0"
   }
 }

--- a/examples/05-interoperability/02-converting-blocks-from-html/vite-env.d.ts
+++ b/examples/05-interoperability/02-converting-blocks-from-html/vite-env.d.ts
@@ -1,1 +1,1 @@
-/// <reference types="vite-plus/client" />
+/// <reference types="vite/client" />

--- a/examples/05-interoperability/02-converting-blocks-from-html/vite.config.ts
+++ b/examples/05-interoperability/02-converting-blocks-from-html/vite.config.ts
@@ -2,7 +2,7 @@
 import react from "@vitejs/plugin-react";
 import * as fs from "fs";
 import * as path from "path";
-import { defineConfig } from "vite-plus";
+import { defineConfig } from "vite";
 // https://vitejs.dev/config/
 export default defineConfig(((conf: { command: string }) => ({
   plugins: [react()],

--- a/examples/05-interoperability/03-converting-blocks-to-md/package.json
+++ b/examples/05-interoperability/03-converting-blocks-to-md/package.json
@@ -5,10 +5,10 @@
   "private": true,
   "version": "0.12.4",
   "scripts": {
-    "start": "vp dev",
-    "dev": "vp dev",
-    "build:prod": "tsc && vp build",
-    "preview": "vp preview"
+    "start": "vite",
+    "dev": "vite",
+    "build:prod": "tsc && vite build",
+    "preview": "vite preview"
   },
   "dependencies": {
     "@blocknote/ariakit": "latest",
@@ -25,6 +25,6 @@
     "@types/react": "^19.2.3",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.1",
-    "vite-plus": "^0.1.24"
+    "vite": "^8.0.0"
   }
 }

--- a/examples/05-interoperability/03-converting-blocks-to-md/vite-env.d.ts
+++ b/examples/05-interoperability/03-converting-blocks-to-md/vite-env.d.ts
@@ -1,1 +1,1 @@
-/// <reference types="vite-plus/client" />
+/// <reference types="vite/client" />

--- a/examples/05-interoperability/03-converting-blocks-to-md/vite.config.ts
+++ b/examples/05-interoperability/03-converting-blocks-to-md/vite.config.ts
@@ -2,7 +2,7 @@
 import react from "@vitejs/plugin-react";
 import * as fs from "fs";
 import * as path from "path";
-import { defineConfig } from "vite-plus";
+import { defineConfig } from "vite";
 // https://vitejs.dev/config/
 export default defineConfig(((conf: { command: string }) => ({
   plugins: [react()],

--- a/examples/05-interoperability/04-converting-blocks-from-md/package.json
+++ b/examples/05-interoperability/04-converting-blocks-from-md/package.json
@@ -5,10 +5,10 @@
   "private": true,
   "version": "0.12.4",
   "scripts": {
-    "start": "vp dev",
-    "dev": "vp dev",
-    "build:prod": "tsc && vp build",
-    "preview": "vp preview"
+    "start": "vite",
+    "dev": "vite",
+    "build:prod": "tsc && vite build",
+    "preview": "vite preview"
   },
   "dependencies": {
     "@blocknote/ariakit": "latest",
@@ -25,6 +25,6 @@
     "@types/react": "^19.2.3",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.1",
-    "vite-plus": "^0.1.24"
+    "vite": "^8.0.0"
   }
 }

--- a/examples/05-interoperability/04-converting-blocks-from-md/vite-env.d.ts
+++ b/examples/05-interoperability/04-converting-blocks-from-md/vite-env.d.ts
@@ -1,1 +1,1 @@
-/// <reference types="vite-plus/client" />
+/// <reference types="vite/client" />

--- a/examples/05-interoperability/04-converting-blocks-from-md/vite.config.ts
+++ b/examples/05-interoperability/04-converting-blocks-from-md/vite.config.ts
@@ -2,7 +2,7 @@
 import react from "@vitejs/plugin-react";
 import * as fs from "fs";
 import * as path from "path";
-import { defineConfig } from "vite-plus";
+import { defineConfig } from "vite";
 // https://vitejs.dev/config/
 export default defineConfig(((conf: { command: string }) => ({
   plugins: [react()],

--- a/examples/05-interoperability/05-converting-blocks-to-pdf/package.json
+++ b/examples/05-interoperability/05-converting-blocks-to-pdf/package.json
@@ -5,10 +5,10 @@
   "private": true,
   "version": "0.12.4",
   "scripts": {
-    "start": "vp dev",
-    "dev": "vp dev",
-    "build:prod": "tsc && vp build",
-    "preview": "vp preview"
+    "start": "vite",
+    "dev": "vite",
+    "build:prod": "tsc && vite build",
+    "preview": "vite preview"
   },
   "dependencies": {
     "@blocknote/ariakit": "latest",
@@ -28,6 +28,6 @@
     "@types/react": "^19.2.3",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.1",
-    "vite-plus": "^0.1.24"
+    "vite": "^8.0.0"
   }
 }

--- a/examples/05-interoperability/05-converting-blocks-to-pdf/vite-env.d.ts
+++ b/examples/05-interoperability/05-converting-blocks-to-pdf/vite-env.d.ts
@@ -1,1 +1,1 @@
-/// <reference types="vite-plus/client" />
+/// <reference types="vite/client" />

--- a/examples/05-interoperability/05-converting-blocks-to-pdf/vite.config.ts
+++ b/examples/05-interoperability/05-converting-blocks-to-pdf/vite.config.ts
@@ -2,7 +2,7 @@
 import react from "@vitejs/plugin-react";
 import * as fs from "fs";
 import * as path from "path";
-import { defineConfig } from "vite-plus";
+import { defineConfig } from "vite";
 // https://vitejs.dev/config/
 export default defineConfig(((conf: { command: string }) => ({
   plugins: [react()],

--- a/examples/05-interoperability/06-converting-blocks-to-docx/package.json
+++ b/examples/05-interoperability/06-converting-blocks-to-docx/package.json
@@ -5,10 +5,10 @@
   "private": true,
   "version": "0.12.4",
   "scripts": {
-    "start": "vp dev",
-    "dev": "vp dev",
-    "build:prod": "tsc && vp build",
-    "preview": "vp preview"
+    "start": "vite",
+    "dev": "vite",
+    "build:prod": "tsc && vite build",
+    "preview": "vite preview"
   },
   "dependencies": {
     "@blocknote/ariakit": "latest",
@@ -27,6 +27,6 @@
     "@types/react": "^19.2.3",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.1",
-    "vite-plus": "^0.1.24"
+    "vite": "^8.0.0"
   }
 }

--- a/examples/05-interoperability/06-converting-blocks-to-docx/vite-env.d.ts
+++ b/examples/05-interoperability/06-converting-blocks-to-docx/vite-env.d.ts
@@ -1,1 +1,1 @@
-/// <reference types="vite-plus/client" />
+/// <reference types="vite/client" />

--- a/examples/05-interoperability/06-converting-blocks-to-docx/vite.config.ts
+++ b/examples/05-interoperability/06-converting-blocks-to-docx/vite.config.ts
@@ -2,7 +2,7 @@
 import react from "@vitejs/plugin-react";
 import * as fs from "fs";
 import * as path from "path";
-import { defineConfig } from "vite-plus";
+import { defineConfig } from "vite";
 // https://vitejs.dev/config/
 export default defineConfig(((conf: { command: string }) => ({
   plugins: [react()],

--- a/examples/05-interoperability/07-converting-blocks-to-odt/package.json
+++ b/examples/05-interoperability/07-converting-blocks-to-odt/package.json
@@ -5,10 +5,10 @@
   "private": true,
   "version": "0.12.4",
   "scripts": {
-    "start": "vp dev",
-    "dev": "vp dev",
-    "build:prod": "tsc && vp build",
-    "preview": "vp preview"
+    "start": "vite",
+    "dev": "vite",
+    "build:prod": "tsc && vite build",
+    "preview": "vite preview"
   },
   "dependencies": {
     "@blocknote/ariakit": "latest",
@@ -27,6 +27,6 @@
     "@types/react": "^19.2.3",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.1",
-    "vite-plus": "^0.1.24"
+    "vite": "^8.0.0"
   }
 }

--- a/examples/05-interoperability/07-converting-blocks-to-odt/vite-env.d.ts
+++ b/examples/05-interoperability/07-converting-blocks-to-odt/vite-env.d.ts
@@ -1,1 +1,1 @@
-/// <reference types="vite-plus/client" />
+/// <reference types="vite/client" />

--- a/examples/05-interoperability/07-converting-blocks-to-odt/vite.config.ts
+++ b/examples/05-interoperability/07-converting-blocks-to-odt/vite.config.ts
@@ -2,7 +2,7 @@
 import react from "@vitejs/plugin-react";
 import * as fs from "fs";
 import * as path from "path";
-import { defineConfig } from "vite-plus";
+import { defineConfig } from "vite";
 // https://vitejs.dev/config/
 export default defineConfig(((conf: { command: string }) => ({
   plugins: [react()],

--- a/examples/05-interoperability/08-converting-blocks-to-react-email/package.json
+++ b/examples/05-interoperability/08-converting-blocks-to-react-email/package.json
@@ -5,10 +5,10 @@
   "private": true,
   "version": "0.12.4",
   "scripts": {
-    "start": "vp dev",
-    "dev": "vp dev",
-    "build:prod": "tsc && vp build",
-    "preview": "vp preview"
+    "start": "vite",
+    "dev": "vite",
+    "build:prod": "tsc && vite build",
+    "preview": "vite preview"
   },
   "dependencies": {
     "@blocknote/ariakit": "latest",
@@ -27,6 +27,6 @@
     "@types/react": "^19.2.3",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.1",
-    "vite-plus": "^0.1.24"
+    "vite": "^8.0.0"
   }
 }

--- a/examples/05-interoperability/08-converting-blocks-to-react-email/vite-env.d.ts
+++ b/examples/05-interoperability/08-converting-blocks-to-react-email/vite-env.d.ts
@@ -1,1 +1,1 @@
-/// <reference types="vite-plus/client" />
+/// <reference types="vite/client" />

--- a/examples/05-interoperability/08-converting-blocks-to-react-email/vite.config.ts
+++ b/examples/05-interoperability/08-converting-blocks-to-react-email/vite.config.ts
@@ -2,7 +2,7 @@
 import react from "@vitejs/plugin-react";
 import * as fs from "fs";
 import * as path from "path";
-import { defineConfig } from "vite-plus";
+import { defineConfig } from "vite";
 // https://vitejs.dev/config/
 export default defineConfig(((conf: { command: string }) => ({
   plugins: [react()],

--- a/examples/05-interoperability/09-blocks-to-html-static-render/package.json
+++ b/examples/05-interoperability/09-blocks-to-html-static-render/package.json
@@ -5,10 +5,10 @@
   "private": true,
   "version": "0.12.4",
   "scripts": {
-    "start": "vp dev",
-    "dev": "vp dev",
-    "build:prod": "tsc && vp build",
-    "preview": "vp preview"
+    "start": "vite",
+    "dev": "vite",
+    "build:prod": "tsc && vite build",
+    "preview": "vite preview"
   },
   "dependencies": {
     "@blocknote/ariakit": "latest",
@@ -25,6 +25,6 @@
     "@types/react": "^19.2.3",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.1",
-    "vite-plus": "^0.1.24"
+    "vite": "^8.0.0"
   }
 }

--- a/examples/05-interoperability/09-blocks-to-html-static-render/vite-env.d.ts
+++ b/examples/05-interoperability/09-blocks-to-html-static-render/vite-env.d.ts
@@ -1,1 +1,1 @@
-/// <reference types="vite-plus/client" />
+/// <reference types="vite/client" />

--- a/examples/05-interoperability/09-blocks-to-html-static-render/vite.config.ts
+++ b/examples/05-interoperability/09-blocks-to-html-static-render/vite.config.ts
@@ -2,7 +2,7 @@
 import react from "@vitejs/plugin-react";
 import * as fs from "fs";
 import * as path from "path";
-import { defineConfig } from "vite-plus";
+import { defineConfig } from "vite";
 // https://vitejs.dev/config/
 export default defineConfig(((conf: { command: string }) => ({
   plugins: [react()],

--- a/examples/05-interoperability/10-static-html-render/package.json
+++ b/examples/05-interoperability/10-static-html-render/package.json
@@ -5,10 +5,10 @@
   "private": true,
   "version": "0.12.4",
   "scripts": {
-    "start": "vp dev",
-    "dev": "vp dev",
-    "build:prod": "tsc && vp build",
-    "preview": "vp preview"
+    "start": "vite",
+    "dev": "vite",
+    "build:prod": "tsc && vite build",
+    "preview": "vite preview"
   },
   "dependencies": {
     "@blocknote/ariakit": "latest",
@@ -25,6 +25,6 @@
     "@types/react": "^19.2.3",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.1",
-    "vite-plus": "^0.1.24"
+    "vite": "^8.0.0"
   }
 }

--- a/examples/05-interoperability/10-static-html-render/vite-env.d.ts
+++ b/examples/05-interoperability/10-static-html-render/vite-env.d.ts
@@ -1,1 +1,1 @@
-/// <reference types="vite-plus/client" />
+/// <reference types="vite/client" />

--- a/examples/05-interoperability/10-static-html-render/vite.config.ts
+++ b/examples/05-interoperability/10-static-html-render/vite.config.ts
@@ -2,7 +2,7 @@
 import react from "@vitejs/plugin-react";
 import * as fs from "fs";
 import * as path from "path";
-import { defineConfig } from "vite-plus";
+import { defineConfig } from "vite";
 // https://vitejs.dev/config/
 export default defineConfig(((conf: { command: string }) => ({
   plugins: [react()],

--- a/examples/06-custom-schema/01-alert-block/package.json
+++ b/examples/06-custom-schema/01-alert-block/package.json
@@ -5,10 +5,10 @@
   "private": true,
   "version": "0.12.4",
   "scripts": {
-    "start": "vp dev",
-    "dev": "vp dev",
-    "build:prod": "tsc && vp build",
-    "preview": "vp preview"
+    "start": "vite",
+    "dev": "vite",
+    "build:prod": "tsc && vite build",
+    "preview": "vite preview"
   },
   "dependencies": {
     "@blocknote/ariakit": "latest",
@@ -26,6 +26,6 @@
     "@types/react": "^19.2.3",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.1",
-    "vite-plus": "^0.1.24"
+    "vite": "^8.0.0"
   }
 }

--- a/examples/06-custom-schema/01-alert-block/vite-env.d.ts
+++ b/examples/06-custom-schema/01-alert-block/vite-env.d.ts
@@ -1,1 +1,1 @@
-/// <reference types="vite-plus/client" />
+/// <reference types="vite/client" />

--- a/examples/06-custom-schema/01-alert-block/vite.config.ts
+++ b/examples/06-custom-schema/01-alert-block/vite.config.ts
@@ -2,7 +2,7 @@
 import react from "@vitejs/plugin-react";
 import * as fs from "fs";
 import * as path from "path";
-import { defineConfig } from "vite-plus";
+import { defineConfig } from "vite";
 // https://vitejs.dev/config/
 export default defineConfig(((conf: { command: string }) => ({
   plugins: [react()],

--- a/examples/06-custom-schema/02-suggestion-menus-mentions/package.json
+++ b/examples/06-custom-schema/02-suggestion-menus-mentions/package.json
@@ -5,10 +5,10 @@
   "private": true,
   "version": "0.12.4",
   "scripts": {
-    "start": "vp dev",
-    "dev": "vp dev",
-    "build:prod": "tsc && vp build",
-    "preview": "vp preview"
+    "start": "vite",
+    "dev": "vite",
+    "build:prod": "tsc && vite build",
+    "preview": "vite preview"
   },
   "dependencies": {
     "@blocknote/ariakit": "latest",
@@ -25,6 +25,6 @@
     "@types/react": "^19.2.3",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.1",
-    "vite-plus": "^0.1.24"
+    "vite": "^8.0.0"
   }
 }

--- a/examples/06-custom-schema/02-suggestion-menus-mentions/vite-env.d.ts
+++ b/examples/06-custom-schema/02-suggestion-menus-mentions/vite-env.d.ts
@@ -1,1 +1,1 @@
-/// <reference types="vite-plus/client" />
+/// <reference types="vite/client" />

--- a/examples/06-custom-schema/02-suggestion-menus-mentions/vite.config.ts
+++ b/examples/06-custom-schema/02-suggestion-menus-mentions/vite.config.ts
@@ -2,7 +2,7 @@
 import react from "@vitejs/plugin-react";
 import * as fs from "fs";
 import * as path from "path";
-import { defineConfig } from "vite-plus";
+import { defineConfig } from "vite";
 // https://vitejs.dev/config/
 export default defineConfig(((conf: { command: string }) => ({
   plugins: [react()],

--- a/examples/06-custom-schema/03-font-style/package.json
+++ b/examples/06-custom-schema/03-font-style/package.json
@@ -5,10 +5,10 @@
   "private": true,
   "version": "0.12.4",
   "scripts": {
-    "start": "vp dev",
-    "dev": "vp dev",
-    "build:prod": "tsc && vp build",
-    "preview": "vp preview"
+    "start": "vite",
+    "dev": "vite",
+    "build:prod": "tsc && vite build",
+    "preview": "vite preview"
   },
   "dependencies": {
     "@blocknote/ariakit": "latest",
@@ -26,6 +26,6 @@
     "@types/react": "^19.2.3",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.1",
-    "vite-plus": "^0.1.24"
+    "vite": "^8.0.0"
   }
 }

--- a/examples/06-custom-schema/03-font-style/vite-env.d.ts
+++ b/examples/06-custom-schema/03-font-style/vite-env.d.ts
@@ -1,1 +1,1 @@
-/// <reference types="vite-plus/client" />
+/// <reference types="vite/client" />

--- a/examples/06-custom-schema/03-font-style/vite.config.ts
+++ b/examples/06-custom-schema/03-font-style/vite.config.ts
@@ -2,7 +2,7 @@
 import react from "@vitejs/plugin-react";
 import * as fs from "fs";
 import * as path from "path";
-import { defineConfig } from "vite-plus";
+import { defineConfig } from "vite";
 // https://vitejs.dev/config/
 export default defineConfig(((conf: { command: string }) => ({
   plugins: [react()],

--- a/examples/06-custom-schema/04-pdf-file-block/package.json
+++ b/examples/06-custom-schema/04-pdf-file-block/package.json
@@ -5,10 +5,10 @@
   "private": true,
   "version": "0.12.4",
   "scripts": {
-    "start": "vp dev",
-    "dev": "vp dev",
-    "build:prod": "tsc && vp build",
-    "preview": "vp preview"
+    "start": "vite",
+    "dev": "vite",
+    "build:prod": "tsc && vite build",
+    "preview": "vite preview"
   },
   "dependencies": {
     "@blocknote/ariakit": "latest",
@@ -26,6 +26,6 @@
     "@types/react": "^19.2.3",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.1",
-    "vite-plus": "^0.1.24"
+    "vite": "^8.0.0"
   }
 }

--- a/examples/06-custom-schema/04-pdf-file-block/vite-env.d.ts
+++ b/examples/06-custom-schema/04-pdf-file-block/vite-env.d.ts
@@ -1,1 +1,1 @@
-/// <reference types="vite-plus/client" />
+/// <reference types="vite/client" />

--- a/examples/06-custom-schema/04-pdf-file-block/vite.config.ts
+++ b/examples/06-custom-schema/04-pdf-file-block/vite.config.ts
@@ -2,7 +2,7 @@
 import react from "@vitejs/plugin-react";
 import * as fs from "fs";
 import * as path from "path";
-import { defineConfig } from "vite-plus";
+import { defineConfig } from "vite";
 // https://vitejs.dev/config/
 export default defineConfig(((conf: { command: string }) => ({
   plugins: [react()],

--- a/examples/06-custom-schema/05-alert-block-full-ux/package.json
+++ b/examples/06-custom-schema/05-alert-block-full-ux/package.json
@@ -5,10 +5,10 @@
   "private": true,
   "version": "0.12.4",
   "scripts": {
-    "start": "vp dev",
-    "dev": "vp dev",
-    "build:prod": "tsc && vp build",
-    "preview": "vp preview"
+    "start": "vite",
+    "dev": "vite",
+    "build:prod": "tsc && vite build",
+    "preview": "vite preview"
   },
   "dependencies": {
     "@blocknote/ariakit": "latest",
@@ -26,6 +26,6 @@
     "@types/react": "^19.2.3",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.1",
-    "vite-plus": "^0.1.24"
+    "vite": "^8.0.0"
   }
 }

--- a/examples/06-custom-schema/05-alert-block-full-ux/vite-env.d.ts
+++ b/examples/06-custom-schema/05-alert-block-full-ux/vite-env.d.ts
@@ -1,1 +1,1 @@
-/// <reference types="vite-plus/client" />
+/// <reference types="vite/client" />

--- a/examples/06-custom-schema/05-alert-block-full-ux/vite.config.ts
+++ b/examples/06-custom-schema/05-alert-block-full-ux/vite.config.ts
@@ -2,7 +2,7 @@
 import react from "@vitejs/plugin-react";
 import * as fs from "fs";
 import * as path from "path";
-import { defineConfig } from "vite-plus";
+import { defineConfig } from "vite";
 // https://vitejs.dev/config/
 export default defineConfig(((conf: { command: string }) => ({
   plugins: [react()],

--- a/examples/06-custom-schema/06-toggleable-blocks/package.json
+++ b/examples/06-custom-schema/06-toggleable-blocks/package.json
@@ -5,10 +5,10 @@
   "private": true,
   "version": "0.12.4",
   "scripts": {
-    "start": "vp dev",
-    "dev": "vp dev",
-    "build:prod": "tsc && vp build",
-    "preview": "vp preview"
+    "start": "vite",
+    "dev": "vite",
+    "build:prod": "tsc && vite build",
+    "preview": "vite preview"
   },
   "dependencies": {
     "@blocknote/ariakit": "latest",
@@ -25,6 +25,6 @@
     "@types/react": "^19.2.3",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.1",
-    "vite-plus": "^0.1.24"
+    "vite": "^8.0.0"
   }
 }

--- a/examples/06-custom-schema/06-toggleable-blocks/vite-env.d.ts
+++ b/examples/06-custom-schema/06-toggleable-blocks/vite-env.d.ts
@@ -1,1 +1,1 @@
-/// <reference types="vite-plus/client" />
+/// <reference types="vite/client" />

--- a/examples/06-custom-schema/06-toggleable-blocks/vite.config.ts
+++ b/examples/06-custom-schema/06-toggleable-blocks/vite.config.ts
@@ -2,7 +2,7 @@
 import react from "@vitejs/plugin-react";
 import * as fs from "fs";
 import * as path from "path";
-import { defineConfig } from "vite-plus";
+import { defineConfig } from "vite";
 // https://vitejs.dev/config/
 export default defineConfig(((conf: { command: string }) => ({
   plugins: [react()],

--- a/examples/06-custom-schema/07-configuring-blocks/package.json
+++ b/examples/06-custom-schema/07-configuring-blocks/package.json
@@ -5,10 +5,10 @@
   "private": true,
   "version": "0.12.4",
   "scripts": {
-    "start": "vp dev",
-    "dev": "vp dev",
-    "build:prod": "tsc && vp build",
-    "preview": "vp preview"
+    "start": "vite",
+    "dev": "vite",
+    "build:prod": "tsc && vite build",
+    "preview": "vite preview"
   },
   "dependencies": {
     "@blocknote/ariakit": "latest",
@@ -25,6 +25,6 @@
     "@types/react": "^19.2.3",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.1",
-    "vite-plus": "^0.1.24"
+    "vite": "^8.0.0"
   }
 }

--- a/examples/06-custom-schema/07-configuring-blocks/vite-env.d.ts
+++ b/examples/06-custom-schema/07-configuring-blocks/vite-env.d.ts
@@ -1,1 +1,1 @@
-/// <reference types="vite-plus/client" />
+/// <reference types="vite/client" />

--- a/examples/06-custom-schema/07-configuring-blocks/vite.config.ts
+++ b/examples/06-custom-schema/07-configuring-blocks/vite.config.ts
@@ -2,7 +2,7 @@
 import react from "@vitejs/plugin-react";
 import * as fs from "fs";
 import * as path from "path";
-import { defineConfig } from "vite-plus";
+import { defineConfig } from "vite";
 // https://vitejs.dev/config/
 export default defineConfig(((conf: { command: string }) => ({
   plugins: [react()],

--- a/examples/06-custom-schema/08-non-editable-block/package.json
+++ b/examples/06-custom-schema/08-non-editable-block/package.json
@@ -5,10 +5,10 @@
   "private": true,
   "version": "0.12.4",
   "scripts": {
-    "start": "vp dev",
-    "dev": "vp dev",
-    "build:prod": "tsc && vp build",
-    "preview": "vp preview"
+    "start": "vite",
+    "dev": "vite",
+    "build:prod": "tsc && vite build",
+    "preview": "vite preview"
   },
   "dependencies": {
     "@blocknote/ariakit": "latest",
@@ -25,6 +25,6 @@
     "@types/react": "^19.2.3",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.1",
-    "vite-plus": "^0.1.24"
+    "vite": "^8.0.0"
   }
 }

--- a/examples/06-custom-schema/08-non-editable-block/vite-env.d.ts
+++ b/examples/06-custom-schema/08-non-editable-block/vite-env.d.ts
@@ -1,1 +1,1 @@
-/// <reference types="vite-plus/client" />
+/// <reference types="vite/client" />

--- a/examples/06-custom-schema/08-non-editable-block/vite.config.ts
+++ b/examples/06-custom-schema/08-non-editable-block/vite.config.ts
@@ -2,7 +2,7 @@
 import react from "@vitejs/plugin-react";
 import * as fs from "fs";
 import * as path from "path";
-import { defineConfig } from "vite-plus";
+import { defineConfig } from "vite";
 // https://vitejs.dev/config/
 export default defineConfig(((conf: { command: string }) => ({
   plugins: [react()],

--- a/examples/06-custom-schema/draggable-inline-content/package.json
+++ b/examples/06-custom-schema/draggable-inline-content/package.json
@@ -5,10 +5,10 @@
   "private": true,
   "version": "0.12.4",
   "scripts": {
-    "start": "vp dev",
-    "dev": "vp dev",
-    "build:prod": "tsc && vp build",
-    "preview": "vp preview"
+    "start": "vite",
+    "dev": "vite",
+    "build:prod": "tsc && vite build",
+    "preview": "vite preview"
   },
   "dependencies": {
     "@blocknote/ariakit": "latest",
@@ -25,6 +25,6 @@
     "@types/react": "^19.2.3",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.1",
-    "vite-plus": "^0.1.24"
+    "vite": "^8.0.0"
   }
 }

--- a/examples/06-custom-schema/draggable-inline-content/vite-env.d.ts
+++ b/examples/06-custom-schema/draggable-inline-content/vite-env.d.ts
@@ -1,1 +1,1 @@
-/// <reference types="vite-plus/client" />
+/// <reference types="vite/client" />

--- a/examples/06-custom-schema/draggable-inline-content/vite.config.ts
+++ b/examples/06-custom-schema/draggable-inline-content/vite.config.ts
@@ -2,7 +2,7 @@
 import react from "@vitejs/plugin-react";
 import * as fs from "fs";
 import * as path from "path";
-import { defineConfig } from "vite-plus";
+import { defineConfig } from "vite";
 // https://vitejs.dev/config/
 export default defineConfig(((conf: { command: string }) => ({
   plugins: [react()],

--- a/examples/06-custom-schema/react-custom-blocks/package.json
+++ b/examples/06-custom-schema/react-custom-blocks/package.json
@@ -5,10 +5,10 @@
   "private": true,
   "version": "0.12.4",
   "scripts": {
-    "start": "vp dev",
-    "dev": "vp dev",
-    "build:prod": "tsc && vp build",
-    "preview": "vp preview"
+    "start": "vite",
+    "dev": "vite",
+    "build:prod": "tsc && vite build",
+    "preview": "vite preview"
   },
   "dependencies": {
     "@blocknote/ariakit": "latest",
@@ -25,6 +25,6 @@
     "@types/react": "^19.2.3",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.1",
-    "vite-plus": "^0.1.24"
+    "vite": "^8.0.0"
   }
 }

--- a/examples/06-custom-schema/react-custom-blocks/vite-env.d.ts
+++ b/examples/06-custom-schema/react-custom-blocks/vite-env.d.ts
@@ -1,1 +1,1 @@
-/// <reference types="vite-plus/client" />
+/// <reference types="vite/client" />

--- a/examples/06-custom-schema/react-custom-blocks/vite.config.ts
+++ b/examples/06-custom-schema/react-custom-blocks/vite.config.ts
@@ -2,7 +2,7 @@
 import react from "@vitejs/plugin-react";
 import * as fs from "fs";
 import * as path from "path";
-import { defineConfig } from "vite-plus";
+import { defineConfig } from "vite";
 // https://vitejs.dev/config/
 export default defineConfig(((conf: { command: string }) => ({
   plugins: [react()],

--- a/examples/06-custom-schema/react-custom-inline-content/package.json
+++ b/examples/06-custom-schema/react-custom-inline-content/package.json
@@ -5,10 +5,10 @@
   "private": true,
   "version": "0.12.4",
   "scripts": {
-    "start": "vp dev",
-    "dev": "vp dev",
-    "build:prod": "tsc && vp build",
-    "preview": "vp preview"
+    "start": "vite",
+    "dev": "vite",
+    "build:prod": "tsc && vite build",
+    "preview": "vite preview"
   },
   "dependencies": {
     "@blocknote/ariakit": "latest",
@@ -25,6 +25,6 @@
     "@types/react": "^19.2.3",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.1",
-    "vite-plus": "^0.1.24"
+    "vite": "^8.0.0"
   }
 }

--- a/examples/06-custom-schema/react-custom-inline-content/vite-env.d.ts
+++ b/examples/06-custom-schema/react-custom-inline-content/vite-env.d.ts
@@ -1,1 +1,1 @@
-/// <reference types="vite-plus/client" />
+/// <reference types="vite/client" />

--- a/examples/06-custom-schema/react-custom-inline-content/vite.config.ts
+++ b/examples/06-custom-schema/react-custom-inline-content/vite.config.ts
@@ -2,7 +2,7 @@
 import react from "@vitejs/plugin-react";
 import * as fs from "fs";
 import * as path from "path";
-import { defineConfig } from "vite-plus";
+import { defineConfig } from "vite";
 // https://vitejs.dev/config/
 export default defineConfig(((conf: { command: string }) => ({
   plugins: [react()],

--- a/examples/06-custom-schema/react-custom-styles/package.json
+++ b/examples/06-custom-schema/react-custom-styles/package.json
@@ -5,10 +5,10 @@
   "private": true,
   "version": "0.12.4",
   "scripts": {
-    "start": "vp dev",
-    "dev": "vp dev",
-    "build:prod": "tsc && vp build",
-    "preview": "vp preview"
+    "start": "vite",
+    "dev": "vite",
+    "build:prod": "tsc && vite build",
+    "preview": "vite preview"
   },
   "dependencies": {
     "@blocknote/ariakit": "latest",
@@ -25,6 +25,6 @@
     "@types/react": "^19.2.3",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.1",
-    "vite-plus": "^0.1.24"
+    "vite": "^8.0.0"
   }
 }

--- a/examples/06-custom-schema/react-custom-styles/vite-env.d.ts
+++ b/examples/06-custom-schema/react-custom-styles/vite-env.d.ts
@@ -1,1 +1,1 @@
-/// <reference types="vite-plus/client" />
+/// <reference types="vite/client" />

--- a/examples/06-custom-schema/react-custom-styles/vite.config.ts
+++ b/examples/06-custom-schema/react-custom-styles/vite.config.ts
@@ -2,7 +2,7 @@
 import react from "@vitejs/plugin-react";
 import * as fs from "fs";
 import * as path from "path";
-import { defineConfig } from "vite-plus";
+import { defineConfig } from "vite";
 // https://vitejs.dev/config/
 export default defineConfig(((conf: { command: string }) => ({
   plugins: [react()],

--- a/examples/07-collaboration/01-partykit/package.json
+++ b/examples/07-collaboration/01-partykit/package.json
@@ -5,10 +5,10 @@
   "private": true,
   "version": "0.12.4",
   "scripts": {
-    "start": "vp dev",
-    "dev": "vp dev",
-    "build:prod": "tsc && vp build",
-    "preview": "vp preview"
+    "start": "vite",
+    "dev": "vite",
+    "build:prod": "tsc && vite build",
+    "preview": "vite preview"
   },
   "dependencies": {
     "@blocknote/ariakit": "latest",
@@ -27,6 +27,6 @@
     "@types/react": "^19.2.3",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.1",
-    "vite-plus": "^0.1.24"
+    "vite": "^8.0.0"
   }
 }

--- a/examples/07-collaboration/01-partykit/vite-env.d.ts
+++ b/examples/07-collaboration/01-partykit/vite-env.d.ts
@@ -1,1 +1,1 @@
-/// <reference types="vite-plus/client" />
+/// <reference types="vite/client" />

--- a/examples/07-collaboration/01-partykit/vite.config.ts
+++ b/examples/07-collaboration/01-partykit/vite.config.ts
@@ -2,7 +2,7 @@
 import react from "@vitejs/plugin-react";
 import * as fs from "fs";
 import * as path from "path";
-import { defineConfig } from "vite-plus";
+import { defineConfig } from "vite";
 // https://vitejs.dev/config/
 export default defineConfig(((conf: { command: string }) => ({
   plugins: [react()],

--- a/examples/07-collaboration/02-liveblocks/package.json
+++ b/examples/07-collaboration/02-liveblocks/package.json
@@ -5,10 +5,10 @@
   "private": true,
   "version": "0.12.4",
   "scripts": {
-    "start": "vp dev",
-    "dev": "vp dev",
-    "build:prod": "tsc && vp build",
-    "preview": "vp preview"
+    "start": "vite",
+    "dev": "vite",
+    "build:prod": "tsc && vite build",
+    "preview": "vite preview"
   },
   "dependencies": {
     "@blocknote/ariakit": "latest",
@@ -31,6 +31,6 @@
     "@types/react": "^19.2.3",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.1",
-    "vite-plus": "^0.1.24"
+    "vite": "^8.0.0"
   }
 }

--- a/examples/07-collaboration/02-liveblocks/vite-env.d.ts
+++ b/examples/07-collaboration/02-liveblocks/vite-env.d.ts
@@ -1,1 +1,1 @@
-/// <reference types="vite-plus/client" />
+/// <reference types="vite/client" />

--- a/examples/07-collaboration/02-liveblocks/vite.config.ts
+++ b/examples/07-collaboration/02-liveblocks/vite.config.ts
@@ -2,7 +2,7 @@
 import react from "@vitejs/plugin-react";
 import * as fs from "fs";
 import * as path from "path";
-import { defineConfig } from "vite-plus";
+import { defineConfig } from "vite";
 // https://vitejs.dev/config/
 export default defineConfig(((conf: { command: string }) => ({
   plugins: [react()],

--- a/examples/07-collaboration/03-y-sweet/package.json
+++ b/examples/07-collaboration/03-y-sweet/package.json
@@ -5,10 +5,10 @@
   "private": true,
   "version": "0.12.4",
   "scripts": {
-    "start": "vp dev",
-    "dev": "vp dev",
-    "build:prod": "tsc && vp build",
-    "preview": "vp preview"
+    "start": "vite",
+    "dev": "vite",
+    "build:prod": "tsc && vite build",
+    "preview": "vite preview"
   },
   "dependencies": {
     "@blocknote/ariakit": "latest",
@@ -26,6 +26,6 @@
     "@types/react": "^19.2.3",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.1",
-    "vite-plus": "^0.1.24"
+    "vite": "^8.0.0"
   }
 }

--- a/examples/07-collaboration/03-y-sweet/vite-env.d.ts
+++ b/examples/07-collaboration/03-y-sweet/vite-env.d.ts
@@ -1,1 +1,1 @@
-/// <reference types="vite-plus/client" />
+/// <reference types="vite/client" />

--- a/examples/07-collaboration/03-y-sweet/vite.config.ts
+++ b/examples/07-collaboration/03-y-sweet/vite.config.ts
@@ -2,7 +2,7 @@
 import react from "@vitejs/plugin-react";
 import * as fs from "fs";
 import * as path from "path";
-import { defineConfig } from "vite-plus";
+import { defineConfig } from "vite";
 // https://vitejs.dev/config/
 export default defineConfig(((conf: { command: string }) => ({
   plugins: [react()],

--- a/examples/07-collaboration/04-electric-sql/package.json
+++ b/examples/07-collaboration/04-electric-sql/package.json
@@ -5,10 +5,10 @@
   "private": true,
   "version": "0.12.4",
   "scripts": {
-    "start": "vp dev",
-    "dev": "vp dev",
-    "build:prod": "tsc && vp build",
-    "preview": "vp preview"
+    "start": "vite",
+    "dev": "vite",
+    "build:prod": "tsc && vite build",
+    "preview": "vite preview"
   },
   "dependencies": {
     "@blocknote/ariakit": "latest",
@@ -25,6 +25,6 @@
     "@types/react": "^19.2.3",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.1",
-    "vite-plus": "^0.1.24"
+    "vite": "^8.0.0"
   }
 }

--- a/examples/07-collaboration/04-electric-sql/vite-env.d.ts
+++ b/examples/07-collaboration/04-electric-sql/vite-env.d.ts
@@ -1,1 +1,1 @@
-/// <reference types="vite-plus/client" />
+/// <reference types="vite/client" />

--- a/examples/07-collaboration/04-electric-sql/vite.config.ts
+++ b/examples/07-collaboration/04-electric-sql/vite.config.ts
@@ -2,7 +2,7 @@
 import react from "@vitejs/plugin-react";
 import * as fs from "fs";
 import * as path from "path";
-import { defineConfig } from "vite-plus";
+import { defineConfig } from "vite";
 // https://vitejs.dev/config/
 export default defineConfig(((conf: { command: string }) => ({
   plugins: [react()],

--- a/examples/07-collaboration/05-comments/package.json
+++ b/examples/07-collaboration/05-comments/package.json
@@ -5,10 +5,10 @@
   "private": true,
   "version": "0.12.4",
   "scripts": {
-    "start": "vp dev",
-    "dev": "vp dev",
-    "build:prod": "tsc && vp build",
-    "preview": "vp preview"
+    "start": "vite",
+    "dev": "vite",
+    "build:prod": "tsc && vite build",
+    "preview": "vite preview"
   },
   "dependencies": {
     "@blocknote/ariakit": "latest",
@@ -26,6 +26,6 @@
     "@types/react": "^19.2.3",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.1",
-    "vite-plus": "^0.1.24"
+    "vite": "^8.0.0"
   }
 }

--- a/examples/07-collaboration/05-comments/vite-env.d.ts
+++ b/examples/07-collaboration/05-comments/vite-env.d.ts
@@ -1,1 +1,1 @@
-/// <reference types="vite-plus/client" />
+/// <reference types="vite/client" />

--- a/examples/07-collaboration/05-comments/vite.config.ts
+++ b/examples/07-collaboration/05-comments/vite.config.ts
@@ -2,7 +2,7 @@
 import react from "@vitejs/plugin-react";
 import * as fs from "fs";
 import * as path from "path";
-import { defineConfig } from "vite-plus";
+import { defineConfig } from "vite";
 // https://vitejs.dev/config/
 export default defineConfig(((conf: { command: string }) => ({
   plugins: [react()],

--- a/examples/07-collaboration/06-comments-with-sidebar/package.json
+++ b/examples/07-collaboration/06-comments-with-sidebar/package.json
@@ -5,10 +5,10 @@
   "private": true,
   "version": "0.12.4",
   "scripts": {
-    "start": "vp dev",
-    "dev": "vp dev",
-    "build:prod": "tsc && vp build",
-    "preview": "vp preview"
+    "start": "vite",
+    "dev": "vite",
+    "build:prod": "tsc && vite build",
+    "preview": "vite preview"
   },
   "dependencies": {
     "@blocknote/ariakit": "latest",
@@ -27,6 +27,6 @@
     "@types/react": "^19.2.3",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.1",
-    "vite-plus": "^0.1.24"
+    "vite": "^8.0.0"
   }
 }

--- a/examples/07-collaboration/06-comments-with-sidebar/vite-env.d.ts
+++ b/examples/07-collaboration/06-comments-with-sidebar/vite-env.d.ts
@@ -1,1 +1,1 @@
-/// <reference types="vite-plus/client" />
+/// <reference types="vite/client" />

--- a/examples/07-collaboration/06-comments-with-sidebar/vite.config.ts
+++ b/examples/07-collaboration/06-comments-with-sidebar/vite.config.ts
@@ -2,7 +2,7 @@
 import react from "@vitejs/plugin-react";
 import * as fs from "fs";
 import * as path from "path";
-import { defineConfig } from "vite-plus";
+import { defineConfig } from "vite";
 // https://vitejs.dev/config/
 export default defineConfig(((conf: { command: string }) => ({
   plugins: [react()],

--- a/examples/07-collaboration/07-ghost-writer/package.json
+++ b/examples/07-collaboration/07-ghost-writer/package.json
@@ -5,10 +5,10 @@
   "private": true,
   "version": "0.12.4",
   "scripts": {
-    "start": "vp dev",
-    "dev": "vp dev",
-    "build:prod": "tsc && vp build",
-    "preview": "vp preview"
+    "start": "vite",
+    "dev": "vite",
+    "build:prod": "tsc && vite build",
+    "preview": "vite preview"
   },
   "dependencies": {
     "@blocknote/ariakit": "latest",
@@ -27,6 +27,6 @@
     "@types/react": "^19.2.3",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.1",
-    "vite-plus": "^0.1.24"
+    "vite": "^8.0.0"
   }
 }

--- a/examples/07-collaboration/07-ghost-writer/vite-env.d.ts
+++ b/examples/07-collaboration/07-ghost-writer/vite-env.d.ts
@@ -1,1 +1,1 @@
-/// <reference types="vite-plus/client" />
+/// <reference types="vite/client" />

--- a/examples/07-collaboration/07-ghost-writer/vite.config.ts
+++ b/examples/07-collaboration/07-ghost-writer/vite.config.ts
@@ -2,7 +2,7 @@
 import react from "@vitejs/plugin-react";
 import * as fs from "fs";
 import * as path from "path";
-import { defineConfig } from "vite-plus";
+import { defineConfig } from "vite";
 // https://vitejs.dev/config/
 export default defineConfig(((conf: { command: string }) => ({
   plugins: [react()],

--- a/examples/07-collaboration/08-forking/package.json
+++ b/examples/07-collaboration/08-forking/package.json
@@ -5,10 +5,10 @@
   "private": true,
   "version": "0.12.4",
   "scripts": {
-    "start": "vp dev",
-    "dev": "vp dev",
-    "build:prod": "tsc && vp build",
-    "preview": "vp preview"
+    "start": "vite",
+    "dev": "vite",
+    "build:prod": "tsc && vite build",
+    "preview": "vite preview"
   },
   "dependencies": {
     "@blocknote/ariakit": "latest",
@@ -27,6 +27,6 @@
     "@types/react": "^19.2.3",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.1",
-    "vite-plus": "^0.1.24"
+    "vite": "^8.0.0"
   }
 }

--- a/examples/07-collaboration/08-forking/vite-env.d.ts
+++ b/examples/07-collaboration/08-forking/vite-env.d.ts
@@ -1,1 +1,1 @@
-/// <reference types="vite-plus/client" />
+/// <reference types="vite/client" />

--- a/examples/07-collaboration/08-forking/vite.config.ts
+++ b/examples/07-collaboration/08-forking/vite.config.ts
@@ -2,7 +2,7 @@
 import react from "@vitejs/plugin-react";
 import * as fs from "fs";
 import * as path from "path";
-import { defineConfig } from "vite-plus";
+import { defineConfig } from "vite";
 // https://vitejs.dev/config/
 export default defineConfig(((conf: { command: string }) => ({
   plugins: [react()],

--- a/examples/07-collaboration/09-comments-testing/package.json
+++ b/examples/07-collaboration/09-comments-testing/package.json
@@ -5,10 +5,10 @@
   "private": true,
   "version": "0.12.4",
   "scripts": {
-    "start": "vp dev",
-    "dev": "vp dev",
-    "build:prod": "tsc && vp build",
-    "preview": "vp preview"
+    "start": "vite",
+    "dev": "vite",
+    "build:prod": "tsc && vite build",
+    "preview": "vite preview"
   },
   "dependencies": {
     "@blocknote/ariakit": "latest",
@@ -26,6 +26,6 @@
     "@types/react": "^19.2.3",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.1",
-    "vite-plus": "^0.1.24"
+    "vite": "^8.0.0"
   }
 }

--- a/examples/07-collaboration/09-comments-testing/vite-env.d.ts
+++ b/examples/07-collaboration/09-comments-testing/vite-env.d.ts
@@ -1,1 +1,1 @@
-/// <reference types="vite-plus/client" />
+/// <reference types="vite/client" />

--- a/examples/07-collaboration/09-comments-testing/vite.config.ts
+++ b/examples/07-collaboration/09-comments-testing/vite.config.ts
@@ -2,7 +2,7 @@
 import react from "@vitejs/plugin-react";
 import * as fs from "fs";
 import * as path from "path";
-import { defineConfig } from "vite-plus";
+import { defineConfig } from "vite";
 // https://vitejs.dev/config/
 export default defineConfig(((conf: { command: string }) => ({
   plugins: [react()],

--- a/examples/07-collaboration/10-suggestion-multi-editor/package.json
+++ b/examples/07-collaboration/10-suggestion-multi-editor/package.json
@@ -5,10 +5,10 @@
   "private": true,
   "version": "0.12.4",
   "scripts": {
-    "start": "vp dev",
-    "dev": "vp dev",
-    "build:prod": "tsc && vp build",
-    "preview": "vp preview"
+    "start": "vite",
+    "dev": "vite",
+    "build:prod": "tsc && vite build",
+    "preview": "vite preview"
   },
   "dependencies": {
     "@blocknote/ariakit": "latest",
@@ -29,6 +29,6 @@
     "@types/react": "^19.2.3",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.1",
-    "vite-plus": "^0.1.24"
+    "vite": "^8.0.0"
   }
 }

--- a/examples/07-collaboration/10-suggestion-multi-editor/vite-env.d.ts
+++ b/examples/07-collaboration/10-suggestion-multi-editor/vite-env.d.ts
@@ -1,1 +1,1 @@
-/// <reference types="vite-plus/client" />
+/// <reference types="vite/client" />

--- a/examples/07-collaboration/10-suggestion-multi-editor/vite.config.ts
+++ b/examples/07-collaboration/10-suggestion-multi-editor/vite.config.ts
@@ -2,7 +2,7 @@
 import react from "@vitejs/plugin-react";
 import * as fs from "fs";
 import * as path from "path";
-import { defineConfig } from "vite-plus";
+import { defineConfig } from "vite";
 // https://vitejs.dev/config/
 export default defineConfig(((conf: { command: string }) => ({
   plugins: [react()],

--- a/examples/07-collaboration/11-versioning-yjs13/package.json
+++ b/examples/07-collaboration/11-versioning-yjs13/package.json
@@ -5,10 +5,10 @@
   "private": true,
   "version": "0.12.4",
   "scripts": {
-    "start": "vp dev",
-    "dev": "vp dev",
-    "build:prod": "tsc && vp build",
-    "preview": "vp preview"
+    "start": "vite",
+    "dev": "vite",
+    "build:prod": "tsc && vite build",
+    "preview": "vite preview"
   },
   "dependencies": {
     "@blocknote/ariakit": "latest",
@@ -28,6 +28,6 @@
     "@types/react": "^19.2.3",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.1",
-    "vite-plus": "^0.1.24"
+    "vite": "^8.0.0"
   }
 }

--- a/examples/07-collaboration/11-versioning-yjs13/vite-env.d.ts
+++ b/examples/07-collaboration/11-versioning-yjs13/vite-env.d.ts
@@ -1,1 +1,1 @@
-/// <reference types="vite-plus/client" />
+/// <reference types="vite/client" />

--- a/examples/07-collaboration/11-versioning-yjs13/vite.config.ts
+++ b/examples/07-collaboration/11-versioning-yjs13/vite.config.ts
@@ -2,7 +2,7 @@
 import react from "@vitejs/plugin-react";
 import * as fs from "fs";
 import * as path from "path";
-import { defineConfig } from "vite-plus";
+import { defineConfig } from "vite";
 // https://vitejs.dev/config/
 export default defineConfig(((conf: { command: string }) => ({
   plugins: [react()],

--- a/examples/07-collaboration/12-multi-doc-versioning/package.json
+++ b/examples/07-collaboration/12-multi-doc-versioning/package.json
@@ -5,10 +5,10 @@
   "private": true,
   "version": "0.12.4",
   "scripts": {
-    "start": "vp dev",
-    "dev": "vp dev",
-    "build:prod": "tsc && vp build",
-    "preview": "vp preview"
+    "start": "vite",
+    "dev": "vite",
+    "build:prod": "tsc && vite build",
+    "preview": "vite preview"
   },
   "dependencies": {
     "@blocknote/ariakit": "latest",
@@ -29,6 +29,6 @@
     "@types/react": "^19.2.3",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.1",
-    "vite-plus": "^0.1.24"
+    "vite": "^8.0.0"
   }
 }

--- a/examples/07-collaboration/12-multi-doc-versioning/vite-env.d.ts
+++ b/examples/07-collaboration/12-multi-doc-versioning/vite-env.d.ts
@@ -1,1 +1,1 @@
-/// <reference types="vite-plus/client" />
+/// <reference types="vite/client" />

--- a/examples/07-collaboration/12-multi-doc-versioning/vite.config.ts
+++ b/examples/07-collaboration/12-multi-doc-versioning/vite.config.ts
@@ -2,7 +2,7 @@
 import react from "@vitejs/plugin-react";
 import * as fs from "fs";
 import * as path from "path";
-import { defineConfig } from "vite-plus";
+import { defineConfig } from "vite";
 // https://vitejs.dev/config/
 export default defineConfig(((conf: { command: string }) => ({
   plugins: [react()],

--- a/examples/07-collaboration/13-versioning-yjs14/package.json
+++ b/examples/07-collaboration/13-versioning-yjs14/package.json
@@ -5,10 +5,10 @@
   "private": true,
   "version": "0.12.4",
   "scripts": {
-    "start": "vp dev",
-    "dev": "vp dev",
-    "build:prod": "tsc && vp build",
-    "preview": "vp preview"
+    "start": "vite",
+    "dev": "vite",
+    "build:prod": "tsc && vite build",
+    "preview": "vite preview"
   },
   "dependencies": {
     "@blocknote/ariakit": "latest",
@@ -30,6 +30,6 @@
     "@types/react": "^19.2.3",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.1",
-    "vite-plus": "^0.1.24"
+    "vite": "^8.0.0"
   }
 }

--- a/examples/07-collaboration/13-versioning-yjs14/vite-env.d.ts
+++ b/examples/07-collaboration/13-versioning-yjs14/vite-env.d.ts
@@ -1,1 +1,1 @@
-/// <reference types="vite-plus/client" />
+/// <reference types="vite/client" />

--- a/examples/07-collaboration/13-versioning-yjs14/vite.config.ts
+++ b/examples/07-collaboration/13-versioning-yjs14/vite.config.ts
@@ -2,7 +2,7 @@
 import react from "@vitejs/plugin-react";
 import * as fs from "fs";
 import * as path from "path";
-import { defineConfig } from "vite-plus";
+import { defineConfig } from "vite";
 // https://vitejs.dev/config/
 export default defineConfig(((conf: { command: string }) => ({
   plugins: [react()],

--- a/examples/07-collaboration/14-suggestion-gallery/package.json
+++ b/examples/07-collaboration/14-suggestion-gallery/package.json
@@ -5,10 +5,10 @@
   "private": true,
   "version": "0.12.4",
   "scripts": {
-    "start": "vp dev",
-    "dev": "vp dev",
-    "build:prod": "tsc && vp build",
-    "preview": "vp preview"
+    "start": "vite",
+    "dev": "vite",
+    "build:prod": "tsc && vite build",
+    "preview": "vite preview"
   },
   "dependencies": {
     "@blocknote/ariakit": "latest",
@@ -29,6 +29,6 @@
     "@types/react": "^19.2.3",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.1",
-    "vite-plus": "^0.1.24"
+    "vite": "^8.0.0"
   }
 }

--- a/examples/07-collaboration/14-suggestion-gallery/vite-env.d.ts
+++ b/examples/07-collaboration/14-suggestion-gallery/vite-env.d.ts
@@ -1,1 +1,1 @@
-/// <reference types="vite-plus/client" />
+/// <reference types="vite/client" />

--- a/examples/07-collaboration/14-suggestion-gallery/vite.config.ts
+++ b/examples/07-collaboration/14-suggestion-gallery/vite.config.ts
@@ -2,7 +2,7 @@
 import react from "@vitejs/plugin-react";
 import * as fs from "fs";
 import * as path from "path";
-import { defineConfig } from "vite-plus";
+import { defineConfig } from "vite";
 // https://vitejs.dev/config/
 export default defineConfig(((conf: { command: string }) => ({
   plugins: [react()],

--- a/examples/08-extensions/01-tiptap-arrow-conversion/package.json
+++ b/examples/08-extensions/01-tiptap-arrow-conversion/package.json
@@ -5,10 +5,10 @@
   "private": true,
   "version": "0.12.4",
   "scripts": {
-    "start": "vp dev",
-    "dev": "vp dev",
-    "build:prod": "tsc && vp build",
-    "preview": "vp preview"
+    "start": "vite",
+    "dev": "vite",
+    "build:prod": "tsc && vite build",
+    "preview": "vite preview"
   },
   "dependencies": {
     "@blocknote/ariakit": "latest",
@@ -26,6 +26,6 @@
     "@types/react": "^19.2.3",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.1",
-    "vite-plus": "^0.1.24"
+    "vite": "^8.0.0"
   }
 }

--- a/examples/08-extensions/01-tiptap-arrow-conversion/vite-env.d.ts
+++ b/examples/08-extensions/01-tiptap-arrow-conversion/vite-env.d.ts
@@ -1,1 +1,1 @@
-/// <reference types="vite-plus/client" />
+/// <reference types="vite/client" />

--- a/examples/08-extensions/01-tiptap-arrow-conversion/vite.config.ts
+++ b/examples/08-extensions/01-tiptap-arrow-conversion/vite.config.ts
@@ -2,7 +2,7 @@
 import react from "@vitejs/plugin-react";
 import * as fs from "fs";
 import * as path from "path";
-import { defineConfig } from "vite-plus";
+import { defineConfig } from "vite";
 // https://vitejs.dev/config/
 export default defineConfig(((conf: { command: string }) => ({
   plugins: [react()],

--- a/examples/08-extensions/02-versioning/package.json
+++ b/examples/08-extensions/02-versioning/package.json
@@ -5,10 +5,10 @@
   "private": true,
   "version": "0.12.4",
   "scripts": {
-    "start": "vp dev",
-    "dev": "vp dev",
-    "build:prod": "tsc && vp build",
-    "preview": "vp preview"
+    "start": "vite",
+    "dev": "vite",
+    "build:prod": "tsc && vite build",
+    "preview": "vite preview"
   },
   "dependencies": {
     "@blocknote/ariakit": "latest",
@@ -27,6 +27,6 @@
     "@types/react": "^19.2.3",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.1",
-    "vite-plus": "^0.1.24"
+    "vite": "^8.0.0"
   }
 }

--- a/examples/08-extensions/02-versioning/vite-env.d.ts
+++ b/examples/08-extensions/02-versioning/vite-env.d.ts
@@ -1,1 +1,1 @@
-/// <reference types="vite-plus/client" />
+/// <reference types="vite/client" />

--- a/examples/08-extensions/02-versioning/vite.config.ts
+++ b/examples/08-extensions/02-versioning/vite.config.ts
@@ -2,7 +2,7 @@
 import react from "@vitejs/plugin-react";
 import * as fs from "fs";
 import * as path from "path";
-import { defineConfig } from "vite-plus";
+import { defineConfig } from "vite";
 // https://vitejs.dev/config/
 export default defineConfig(((conf: { command: string }) => ({
   plugins: [react()],

--- a/examples/09-ai/01-minimal/package.json
+++ b/examples/09-ai/01-minimal/package.json
@@ -5,10 +5,10 @@
   "private": true,
   "version": "0.12.4",
   "scripts": {
-    "start": "vp dev",
-    "dev": "vp dev",
-    "build:prod": "tsc && vp build",
-    "preview": "vp preview"
+    "start": "vite",
+    "dev": "vite",
+    "build:prod": "tsc && vite build",
+    "preview": "vite preview"
   },
   "dependencies": {
     "@blocknote/ariakit": "latest",
@@ -27,6 +27,6 @@
     "@types/react": "^19.2.3",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.1",
-    "vite-plus": "^0.1.24"
+    "vite": "^8.0.0"
   }
 }

--- a/examples/09-ai/01-minimal/vite-env.d.ts
+++ b/examples/09-ai/01-minimal/vite-env.d.ts
@@ -1,1 +1,1 @@
-/// <reference types="vite-plus/client" />
+/// <reference types="vite/client" />

--- a/examples/09-ai/01-minimal/vite.config.ts
+++ b/examples/09-ai/01-minimal/vite.config.ts
@@ -2,7 +2,7 @@
 import react from "@vitejs/plugin-react";
 import * as fs from "fs";
 import * as path from "path";
-import { defineConfig } from "vite-plus";
+import { defineConfig } from "vite";
 // https://vitejs.dev/config/
 export default defineConfig(((conf: { command: string }) => ({
   plugins: [react()],

--- a/examples/09-ai/02-playground/package.json
+++ b/examples/09-ai/02-playground/package.json
@@ -5,10 +5,10 @@
   "private": true,
   "version": "0.12.4",
   "scripts": {
-    "start": "vp dev",
-    "dev": "vp dev",
-    "build:prod": "tsc && vp build",
-    "preview": "vp preview"
+    "start": "vite",
+    "dev": "vite",
+    "build:prod": "tsc && vite build",
+    "preview": "vite preview"
   },
   "dependencies": {
     "@blocknote/ariakit": "latest",
@@ -27,6 +27,6 @@
     "@types/react": "^19.2.3",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.1",
-    "vite-plus": "^0.1.24"
+    "vite": "^8.0.0"
   }
 }

--- a/examples/09-ai/02-playground/vite-env.d.ts
+++ b/examples/09-ai/02-playground/vite-env.d.ts
@@ -1,1 +1,1 @@
-/// <reference types="vite-plus/client" />
+/// <reference types="vite/client" />

--- a/examples/09-ai/02-playground/vite.config.ts
+++ b/examples/09-ai/02-playground/vite.config.ts
@@ -2,7 +2,7 @@
 import react from "@vitejs/plugin-react";
 import * as fs from "fs";
 import * as path from "path";
-import { defineConfig } from "vite-plus";
+import { defineConfig } from "vite";
 // https://vitejs.dev/config/
 export default defineConfig(((conf: { command: string }) => ({
   plugins: [react()],

--- a/examples/09-ai/03-custom-ai-menu-items/package.json
+++ b/examples/09-ai/03-custom-ai-menu-items/package.json
@@ -5,10 +5,10 @@
   "private": true,
   "version": "0.12.4",
   "scripts": {
-    "start": "vp dev",
-    "dev": "vp dev",
-    "build:prod": "tsc && vp build",
-    "preview": "vp preview"
+    "start": "vite",
+    "dev": "vite",
+    "build:prod": "tsc && vite build",
+    "preview": "vite preview"
   },
   "dependencies": {
     "@blocknote/ariakit": "latest",
@@ -28,6 +28,6 @@
     "@types/react": "^19.2.3",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.1",
-    "vite-plus": "^0.1.24"
+    "vite": "^8.0.0"
   }
 }

--- a/examples/09-ai/03-custom-ai-menu-items/vite-env.d.ts
+++ b/examples/09-ai/03-custom-ai-menu-items/vite-env.d.ts
@@ -1,1 +1,1 @@
-/// <reference types="vite-plus/client" />
+/// <reference types="vite/client" />

--- a/examples/09-ai/03-custom-ai-menu-items/vite.config.ts
+++ b/examples/09-ai/03-custom-ai-menu-items/vite.config.ts
@@ -2,7 +2,7 @@
 import react from "@vitejs/plugin-react";
 import * as fs from "fs";
 import * as path from "path";
-import { defineConfig } from "vite-plus";
+import { defineConfig } from "vite";
 // https://vitejs.dev/config/
 export default defineConfig(((conf: { command: string }) => ({
   plugins: [react()],

--- a/examples/09-ai/04-with-collaboration/package.json
+++ b/examples/09-ai/04-with-collaboration/package.json
@@ -5,10 +5,10 @@
   "private": true,
   "version": "0.12.4",
   "scripts": {
-    "start": "vp dev",
-    "dev": "vp dev",
-    "build:prod": "tsc && vp build",
-    "preview": "vp preview"
+    "start": "vite",
+    "dev": "vite",
+    "build:prod": "tsc && vite build",
+    "preview": "vite preview"
   },
   "dependencies": {
     "@blocknote/ariakit": "latest",
@@ -29,6 +29,6 @@
     "@types/react": "^19.2.3",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.1",
-    "vite-plus": "^0.1.24"
+    "vite": "^8.0.0"
   }
 }

--- a/examples/09-ai/04-with-collaboration/vite-env.d.ts
+++ b/examples/09-ai/04-with-collaboration/vite-env.d.ts
@@ -1,1 +1,1 @@
-/// <reference types="vite-plus/client" />
+/// <reference types="vite/client" />

--- a/examples/09-ai/04-with-collaboration/vite.config.ts
+++ b/examples/09-ai/04-with-collaboration/vite.config.ts
@@ -2,7 +2,7 @@
 import react from "@vitejs/plugin-react";
 import * as fs from "fs";
 import * as path from "path";
-import { defineConfig } from "vite-plus";
+import { defineConfig } from "vite";
 // https://vitejs.dev/config/
 export default defineConfig(((conf: { command: string }) => ({
   plugins: [react()],

--- a/examples/09-ai/05-manual-execution/package.json
+++ b/examples/09-ai/05-manual-execution/package.json
@@ -5,10 +5,10 @@
   "private": true,
   "version": "0.12.4",
   "scripts": {
-    "start": "vp dev",
-    "dev": "vp dev",
-    "build:prod": "tsc && vp build",
-    "preview": "vp preview"
+    "start": "vite",
+    "dev": "vite",
+    "build:prod": "tsc && vite build",
+    "preview": "vite preview"
   },
   "dependencies": {
     "@blocknote/ariakit": "latest",
@@ -29,6 +29,6 @@
     "@types/react": "^19.2.3",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.1",
-    "vite-plus": "^0.1.24"
+    "vite": "^8.0.0"
   }
 }

--- a/examples/09-ai/05-manual-execution/vite-env.d.ts
+++ b/examples/09-ai/05-manual-execution/vite-env.d.ts
@@ -1,1 +1,1 @@
-/// <reference types="vite-plus/client" />
+/// <reference types="vite/client" />

--- a/examples/09-ai/05-manual-execution/vite.config.ts
+++ b/examples/09-ai/05-manual-execution/vite.config.ts
@@ -2,7 +2,7 @@
 import react from "@vitejs/plugin-react";
 import * as fs from "fs";
 import * as path from "path";
-import { defineConfig } from "vite-plus";
+import { defineConfig } from "vite";
 // https://vitejs.dev/config/
 export default defineConfig(((conf: { command: string }) => ({
   plugins: [react()],

--- a/examples/09-ai/06-client-side-transport/package.json
+++ b/examples/09-ai/06-client-side-transport/package.json
@@ -5,10 +5,10 @@
   "private": true,
   "version": "0.12.4",
   "scripts": {
-    "start": "vp dev",
-    "dev": "vp dev",
-    "build:prod": "tsc && vp build",
-    "preview": "vp preview"
+    "start": "vite",
+    "dev": "vite",
+    "build:prod": "tsc && vite build",
+    "preview": "vite preview"
   },
   "dependencies": {
     "@blocknote/ariakit": "latest",
@@ -28,6 +28,6 @@
     "@types/react": "^19.2.3",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.1",
-    "vite-plus": "^0.1.24"
+    "vite": "^8.0.0"
   }
 }

--- a/examples/09-ai/06-client-side-transport/vite-env.d.ts
+++ b/examples/09-ai/06-client-side-transport/vite-env.d.ts
@@ -1,1 +1,1 @@
-/// <reference types="vite-plus/client" />
+/// <reference types="vite/client" />

--- a/examples/09-ai/06-client-side-transport/vite.config.ts
+++ b/examples/09-ai/06-client-side-transport/vite.config.ts
@@ -2,7 +2,7 @@
 import react from "@vitejs/plugin-react";
 import * as fs from "fs";
 import * as path from "path";
-import { defineConfig } from "vite-plus";
+import { defineConfig } from "vite";
 // https://vitejs.dev/config/
 export default defineConfig(((conf: { command: string }) => ({
   plugins: [react()],

--- a/examples/09-ai/07-server-persistence/package.json
+++ b/examples/09-ai/07-server-persistence/package.json
@@ -5,10 +5,10 @@
   "private": true,
   "version": "0.12.4",
   "scripts": {
-    "start": "vp dev",
-    "dev": "vp dev",
-    "build:prod": "tsc && vp build",
-    "preview": "vp preview"
+    "start": "vite",
+    "dev": "vite",
+    "build:prod": "tsc && vite build",
+    "preview": "vite preview"
   },
   "dependencies": {
     "@blocknote/ariakit": "latest",
@@ -27,6 +27,6 @@
     "@types/react": "^19.2.3",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.1",
-    "vite-plus": "^0.1.24"
+    "vite": "^8.0.0"
   }
 }

--- a/examples/09-ai/07-server-persistence/vite-env.d.ts
+++ b/examples/09-ai/07-server-persistence/vite-env.d.ts
@@ -1,1 +1,1 @@
-/// <reference types="vite-plus/client" />
+/// <reference types="vite/client" />

--- a/examples/09-ai/07-server-persistence/vite.config.ts
+++ b/examples/09-ai/07-server-persistence/vite.config.ts
@@ -2,7 +2,7 @@
 import react from "@vitejs/plugin-react";
 import * as fs from "fs";
 import * as path from "path";
-import { defineConfig } from "vite-plus";
+import { defineConfig } from "vite";
 // https://vitejs.dev/config/
 export default defineConfig(((conf: { command: string }) => ({
   plugins: [react()],

--- a/examples/vanilla-js/react-vanilla-custom-blocks/package.json
+++ b/examples/vanilla-js/react-vanilla-custom-blocks/package.json
@@ -5,10 +5,10 @@
   "private": true,
   "version": "0.12.4",
   "scripts": {
-    "start": "vp dev",
-    "dev": "vp dev",
-    "build:prod": "tsc && vp build",
-    "preview": "vp preview"
+    "start": "vite",
+    "dev": "vite",
+    "build:prod": "tsc && vite build",
+    "preview": "vite preview"
   },
   "dependencies": {
     "@blocknote/ariakit": "latest",
@@ -25,6 +25,6 @@
     "@types/react": "^19.2.3",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.1",
-    "vite-plus": "^0.1.24"
+    "vite": "^8.0.0"
   }
 }

--- a/examples/vanilla-js/react-vanilla-custom-blocks/vite-env.d.ts
+++ b/examples/vanilla-js/react-vanilla-custom-blocks/vite-env.d.ts
@@ -1,1 +1,1 @@
-/// <reference types="vite-plus/client" />
+/// <reference types="vite/client" />

--- a/examples/vanilla-js/react-vanilla-custom-blocks/vite.config.ts
+++ b/examples/vanilla-js/react-vanilla-custom-blocks/vite.config.ts
@@ -2,7 +2,7 @@
 import react from "@vitejs/plugin-react";
 import * as fs from "fs";
 import * as path from "path";
-import { defineConfig } from "vite-plus";
+import { defineConfig } from "vite";
 // https://vitejs.dev/config/
 export default defineConfig(((conf: { command: string }) => ({
   plugins: [react()],

--- a/examples/vanilla-js/react-vanilla-custom-inline-content/package.json
+++ b/examples/vanilla-js/react-vanilla-custom-inline-content/package.json
@@ -5,10 +5,10 @@
   "private": true,
   "version": "0.12.4",
   "scripts": {
-    "start": "vp dev",
-    "dev": "vp dev",
-    "build:prod": "tsc && vp build",
-    "preview": "vp preview"
+    "start": "vite",
+    "dev": "vite",
+    "build:prod": "tsc && vite build",
+    "preview": "vite preview"
   },
   "dependencies": {
     "@blocknote/ariakit": "latest",
@@ -25,6 +25,6 @@
     "@types/react": "^19.2.3",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.1",
-    "vite-plus": "^0.1.24"
+    "vite": "^8.0.0"
   }
 }

--- a/examples/vanilla-js/react-vanilla-custom-inline-content/vite-env.d.ts
+++ b/examples/vanilla-js/react-vanilla-custom-inline-content/vite-env.d.ts
@@ -1,1 +1,1 @@
-/// <reference types="vite-plus/client" />
+/// <reference types="vite/client" />

--- a/examples/vanilla-js/react-vanilla-custom-inline-content/vite.config.ts
+++ b/examples/vanilla-js/react-vanilla-custom-inline-content/vite.config.ts
@@ -2,7 +2,7 @@
 import react from "@vitejs/plugin-react";
 import * as fs from "fs";
 import * as path from "path";
-import { defineConfig } from "vite-plus";
+import { defineConfig } from "vite";
 // https://vitejs.dev/config/
 export default defineConfig(((conf: { command: string }) => ({
   plugins: [react()],

--- a/examples/vanilla-js/react-vanilla-custom-styles/package.json
+++ b/examples/vanilla-js/react-vanilla-custom-styles/package.json
@@ -5,10 +5,10 @@
   "private": true,
   "version": "0.12.4",
   "scripts": {
-    "start": "vp dev",
-    "dev": "vp dev",
-    "build:prod": "tsc && vp build",
-    "preview": "vp preview"
+    "start": "vite",
+    "dev": "vite",
+    "build:prod": "tsc && vite build",
+    "preview": "vite preview"
   },
   "dependencies": {
     "@blocknote/ariakit": "latest",
@@ -25,6 +25,6 @@
     "@types/react": "^19.2.3",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.1",
-    "vite-plus": "^0.1.24"
+    "vite": "^8.0.0"
   }
 }

--- a/examples/vanilla-js/react-vanilla-custom-styles/vite-env.d.ts
+++ b/examples/vanilla-js/react-vanilla-custom-styles/vite-env.d.ts
@@ -1,1 +1,1 @@
-/// <reference types="vite-plus/client" />
+/// <reference types="vite/client" />

--- a/examples/vanilla-js/react-vanilla-custom-styles/vite.config.ts
+++ b/examples/vanilla-js/react-vanilla-custom-styles/vite.config.ts
@@ -2,7 +2,7 @@
 import react from "@vitejs/plugin-react";
 import * as fs from "fs";
 import * as path from "path";
-import { defineConfig } from "vite-plus";
+import { defineConfig } from "vite";
 // https://vitejs.dev/config/
 export default defineConfig(((conf: { command: string }) => ({
   plugins: [react()],

--- a/examples/vanilla-js/vanilla-custom-side-menu/package.json
+++ b/examples/vanilla-js/vanilla-custom-side-menu/package.json
@@ -5,10 +5,10 @@
   "private": true,
   "version": "0.12.4",
   "scripts": {
-    "start": "vp dev",
-    "dev": "vp dev",
-    "build:prod": "tsc && vp build",
-    "preview": "vp preview"
+    "start": "vite",
+    "dev": "vite",
+    "build:prod": "tsc && vite build",
+    "preview": "vite preview"
   },
   "dependencies": {
     "@blocknote/ariakit": "latest",
@@ -25,6 +25,6 @@
     "@types/react": "^19.2.3",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.1",
-    "vite-plus": "^0.1.24"
+    "vite": "^8.0.0"
   }
 }

--- a/examples/vanilla-js/vanilla-custom-side-menu/vite-env.d.ts
+++ b/examples/vanilla-js/vanilla-custom-side-menu/vite-env.d.ts
@@ -1,1 +1,1 @@
-/// <reference types="vite-plus/client" />
+/// <reference types="vite/client" />

--- a/examples/vanilla-js/vanilla-custom-side-menu/vite.config.ts
+++ b/examples/vanilla-js/vanilla-custom-side-menu/vite.config.ts
@@ -2,7 +2,7 @@
 import react from "@vitejs/plugin-react";
 import * as fs from "fs";
 import * as path from "path";
-import { defineConfig } from "vite-plus";
+import { defineConfig } from "vite";
 // https://vitejs.dev/config/
 export default defineConfig(((conf: { command: string }) => ({
   plugins: [react()],

--- a/packages/dev-scripts/examples/template-react/package.json.template.tsx
+++ b/packages/dev-scripts/examples/template-react/package.json.template.tsx
@@ -7,10 +7,10 @@ const template = (project: Project) => ({
   private: true,
   version: "0.12.4",
   scripts: {
-    start: "vp dev",
-    dev: "vp dev",
-    "build:prod": "tsc && vp build",
-    preview: "vp preview",
+    start: "vite",
+    dev: "vite",
+    "build:prod": "tsc && vite build",
+    preview: "vite preview",
   },
   dependencies: {
     "@blocknote/ariakit": "latest",
@@ -39,7 +39,7 @@ const template = (project: Project) => ({
     "@types/react": "^19.2.3",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.1",
-    "vite-plus": getCatalogVersion("vite-plus"),
+    vite: getCatalogVersion("vite"),
     ...(project.config?.devDependencies || {}),
   },
 });

--- a/packages/dev-scripts/examples/template-react/vite-env.d.ts.template.tsx
+++ b/packages/dev-scripts/examples/template-react/vite-env.d.ts.template.tsx
@@ -1,3 +1,3 @@
-const template = () => `/// <reference types="vite-plus/client" />\n`;
+const template = () => `/// <reference types="vite/client" />\n`;
 
 export default template;

--- a/packages/dev-scripts/examples/template-react/vite.config.ts.template.tsx
+++ b/packages/dev-scripts/examples/template-react/vite.config.ts.template.tsx
@@ -7,7 +7,7 @@ const template = (
 import react from "@vitejs/plugin-react";
 import * as fs from "fs";
 import * as path from "path";
-import { defineConfig } from "vite-plus";${
+import { defineConfig } from "vite";${
   project.config.tailwind
     ? `
 import tailwindcss from "@tailwindcss/vite";`

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -416,9 +416,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^6.0.1
         version: 6.0.1(babel-plugin-react-compiler@1.0.0)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))
-      vite-plus:
-        specifier: ^0.1.24
-        version: 0.1.24(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.0.1)(canvas@3.1.0))(terser@5.46.2)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0)
+      vite:
+        specifier: ^8.0.0
+        version: 8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0)
 
   examples/01-basic/02-block-objects:
     dependencies:
@@ -459,9 +459,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^6.0.1
         version: 6.0.1(babel-plugin-react-compiler@1.0.0)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))
-      vite-plus:
-        specifier: ^0.1.24
-        version: 0.1.24(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.0.1)(canvas@3.1.0))(terser@5.46.2)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0)
+      vite:
+        specifier: ^8.0.0
+        version: 8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0)
 
   examples/01-basic/03-multi-column:
     dependencies:
@@ -505,9 +505,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^6.0.1
         version: 6.0.1(babel-plugin-react-compiler@1.0.0)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))
-      vite-plus:
-        specifier: ^0.1.24
-        version: 0.1.24(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.0.1)(canvas@3.1.0))(terser@5.46.2)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0)
+      vite:
+        specifier: ^8.0.0
+        version: 8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0)
 
   examples/01-basic/04-default-blocks:
     dependencies:
@@ -548,9 +548,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^6.0.1
         version: 6.0.1(babel-plugin-react-compiler@1.0.0)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))
-      vite-plus:
-        specifier: ^0.1.24
-        version: 0.1.24(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.0.1)(canvas@3.1.0))(terser@5.46.2)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0)
+      vite:
+        specifier: ^8.0.0
+        version: 8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0)
 
   examples/01-basic/05-removing-default-blocks:
     dependencies:
@@ -591,9 +591,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^6.0.1
         version: 6.0.1(babel-plugin-react-compiler@1.0.0)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))
-      vite-plus:
-        specifier: ^0.1.24
-        version: 0.1.24(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.0.1)(canvas@3.1.0))(terser@5.46.2)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0)
+      vite:
+        specifier: ^8.0.0
+        version: 8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0)
 
   examples/01-basic/06-block-manipulation:
     dependencies:
@@ -634,9 +634,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^6.0.1
         version: 6.0.1(babel-plugin-react-compiler@1.0.0)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))
-      vite-plus:
-        specifier: ^0.1.24
-        version: 0.1.24(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.0.1)(canvas@3.1.0))(terser@5.46.2)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0)
+      vite:
+        specifier: ^8.0.0
+        version: 8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0)
 
   examples/01-basic/07-selection-blocks:
     dependencies:
@@ -677,9 +677,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^6.0.1
         version: 6.0.1(babel-plugin-react-compiler@1.0.0)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))
-      vite-plus:
-        specifier: ^0.1.24
-        version: 0.1.24(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.0.1)(canvas@3.1.0))(terser@5.46.2)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0)
+      vite:
+        specifier: ^8.0.0
+        version: 8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0)
 
   examples/01-basic/08-ariakit:
     dependencies:
@@ -720,9 +720,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^6.0.1
         version: 6.0.1(babel-plugin-react-compiler@1.0.0)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))
-      vite-plus:
-        specifier: ^0.1.24
-        version: 0.1.24(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.0.1)(canvas@3.1.0))(terser@5.46.2)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0)
+      vite:
+        specifier: ^8.0.0
+        version: 8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0)
 
   examples/01-basic/09-shadcn:
     dependencies:
@@ -772,9 +772,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^6.0.1
         version: 6.0.1(babel-plugin-react-compiler@1.0.0)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))
-      vite-plus:
-        specifier: ^0.1.24
-        version: 0.1.24(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.0.1)(canvas@3.1.0))(terser@5.46.2)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0)
+      vite:
+        specifier: ^8.0.0
+        version: 8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0)
 
   examples/01-basic/10-localization:
     dependencies:
@@ -815,9 +815,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^6.0.1
         version: 6.0.1(babel-plugin-react-compiler@1.0.0)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))
-      vite-plus:
-        specifier: ^0.1.24
-        version: 0.1.24(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.0.1)(canvas@3.1.0))(terser@5.46.2)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0)
+      vite:
+        specifier: ^8.0.0
+        version: 8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0)
 
   examples/01-basic/11-custom-placeholder:
     dependencies:
@@ -858,9 +858,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^6.0.1
         version: 6.0.1(babel-plugin-react-compiler@1.0.0)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))
-      vite-plus:
-        specifier: ^0.1.24
-        version: 0.1.24(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.0.1)(canvas@3.1.0))(terser@5.46.2)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0)
+      vite:
+        specifier: ^8.0.0
+        version: 8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0)
 
   examples/01-basic/12-multi-editor:
     dependencies:
@@ -901,9 +901,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^6.0.1
         version: 6.0.1(babel-plugin-react-compiler@1.0.0)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))
-      vite-plus:
-        specifier: ^0.1.24
-        version: 0.1.24(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.0.1)(canvas@3.1.0))(terser@5.46.2)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0)
+      vite:
+        specifier: ^8.0.0
+        version: 8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0)
 
   examples/01-basic/13-custom-paste-handler:
     dependencies:
@@ -944,9 +944,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^6.0.1
         version: 6.0.1(babel-plugin-react-compiler@1.0.0)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))
-      vite-plus:
-        specifier: ^0.1.24
-        version: 0.1.24(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.0.1)(canvas@3.1.0))(terser@5.46.2)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0)
+      vite:
+        specifier: ^8.0.0
+        version: 8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0)
 
   examples/01-basic/14-editor-scrollable:
     dependencies:
@@ -987,9 +987,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^6.0.1
         version: 6.0.1(babel-plugin-react-compiler@1.0.0)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))
-      vite-plus:
-        specifier: ^0.1.24
-        version: 0.1.24(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.0.1)(canvas@3.1.0))(terser@5.46.2)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0)
+      vite:
+        specifier: ^8.0.0
+        version: 8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0)
 
   examples/01-basic/15-shadowdom:
     dependencies:
@@ -1030,9 +1030,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^6.0.1
         version: 6.0.1(babel-plugin-react-compiler@1.0.0)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))
-      vite-plus:
-        specifier: ^0.1.24
-        version: 0.1.24(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.0.1)(canvas@3.1.0))(terser@5.46.2)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0)
+      vite:
+        specifier: ^8.0.0
+        version: 8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0)
 
   examples/01-basic/16-read-only-editor:
     dependencies:
@@ -1073,9 +1073,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^6.0.1
         version: 6.0.1(babel-plugin-react-compiler@1.0.0)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))
-      vite-plus:
-        specifier: ^0.1.24
-        version: 0.1.24(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.0.1)(canvas@3.1.0))(terser@5.46.2)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0)
+      vite:
+        specifier: ^8.0.0
+        version: 8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0)
 
   examples/01-basic/17-no-trailing-block:
     dependencies:
@@ -1116,9 +1116,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^6.0.1
         version: 6.0.1(babel-plugin-react-compiler@1.0.0)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))
-      vite-plus:
-        specifier: ^0.1.24
-        version: 0.1.24(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.0.1)(canvas@3.1.0))(terser@5.46.2)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0)
+      vite:
+        specifier: ^8.0.0
+        version: 8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0)
 
   examples/01-basic/testing:
     dependencies:
@@ -1159,9 +1159,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^6.0.1
         version: 6.0.1(babel-plugin-react-compiler@1.0.0)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))
-      vite-plus:
-        specifier: ^0.1.24
-        version: 0.1.24(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.0.1)(canvas@3.1.0))(terser@5.46.2)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0)
+      vite:
+        specifier: ^8.0.0
+        version: 8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0)
 
   examples/02-backend/01-file-uploading:
     dependencies:
@@ -1202,9 +1202,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^6.0.1
         version: 6.0.1(babel-plugin-react-compiler@1.0.0)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))
-      vite-plus:
-        specifier: ^0.1.24
-        version: 0.1.24(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.0.1)(canvas@3.1.0))(terser@5.46.2)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0)
+      vite:
+        specifier: ^8.0.0
+        version: 8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0)
 
   examples/02-backend/02-saving-loading:
     dependencies:
@@ -1245,9 +1245,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^6.0.1
         version: 6.0.1(babel-plugin-react-compiler@1.0.0)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))
-      vite-plus:
-        specifier: ^0.1.24
-        version: 0.1.24(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.0.1)(canvas@3.1.0))(terser@5.46.2)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0)
+      vite:
+        specifier: ^8.0.0
+        version: 8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0)
 
   examples/02-backend/03-s3:
     dependencies:
@@ -1294,9 +1294,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^6.0.1
         version: 6.0.1(babel-plugin-react-compiler@1.0.0)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))
-      vite-plus:
-        specifier: ^0.1.24
-        version: 0.1.24(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.0.1)(canvas@3.1.0))(terser@5.46.2)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0)
+      vite:
+        specifier: ^8.0.0
+        version: 8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0)
 
   examples/02-backend/04-rendering-static-documents:
     dependencies:
@@ -1340,9 +1340,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^6.0.1
         version: 6.0.1(babel-plugin-react-compiler@1.0.0)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))
-      vite-plus:
-        specifier: ^0.1.24
-        version: 0.1.24(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.0.1)(canvas@3.1.0))(terser@5.46.2)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0)
+      vite:
+        specifier: ^8.0.0
+        version: 8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0)
 
   examples/03-ui-components/01-ui-elements-remove:
     dependencies:
@@ -1383,9 +1383,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^6.0.1
         version: 6.0.1(babel-plugin-react-compiler@1.0.0)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))
-      vite-plus:
-        specifier: ^0.1.24
-        version: 0.1.24(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.0.1)(canvas@3.1.0))(terser@5.46.2)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0)
+      vite:
+        specifier: ^8.0.0
+        version: 8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0)
 
   examples/03-ui-components/02-formatting-toolbar-buttons:
     dependencies:
@@ -1426,9 +1426,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^6.0.1
         version: 6.0.1(babel-plugin-react-compiler@1.0.0)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))
-      vite-plus:
-        specifier: ^0.1.24
-        version: 0.1.24(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.0.1)(canvas@3.1.0))(terser@5.46.2)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0)
+      vite:
+        specifier: ^8.0.0
+        version: 8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0)
 
   examples/03-ui-components/03-formatting-toolbar-block-type-items:
     dependencies:
@@ -1472,9 +1472,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^6.0.1
         version: 6.0.1(babel-plugin-react-compiler@1.0.0)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))
-      vite-plus:
-        specifier: ^0.1.24
-        version: 0.1.24(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.0.1)(canvas@3.1.0))(terser@5.46.2)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0)
+      vite:
+        specifier: ^8.0.0
+        version: 8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0)
 
   examples/03-ui-components/04-side-menu-buttons:
     dependencies:
@@ -1518,9 +1518,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^6.0.1
         version: 6.0.1(babel-plugin-react-compiler@1.0.0)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))
-      vite-plus:
-        specifier: ^0.1.24
-        version: 0.1.24(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.0.1)(canvas@3.1.0))(terser@5.46.2)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0)
+      vite:
+        specifier: ^8.0.0
+        version: 8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0)
 
   examples/03-ui-components/05-side-menu-drag-handle-items:
     dependencies:
@@ -1564,9 +1564,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^6.0.1
         version: 6.0.1(babel-plugin-react-compiler@1.0.0)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))
-      vite-plus:
-        specifier: ^0.1.24
-        version: 0.1.24(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.0.1)(canvas@3.1.0))(terser@5.46.2)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0)
+      vite:
+        specifier: ^8.0.0
+        version: 8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0)
 
   examples/03-ui-components/06-suggestion-menus-slash-menu-items:
     dependencies:
@@ -1610,9 +1610,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^6.0.1
         version: 6.0.1(babel-plugin-react-compiler@1.0.0)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))
-      vite-plus:
-        specifier: ^0.1.24
-        version: 0.1.24(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.0.1)(canvas@3.1.0))(terser@5.46.2)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0)
+      vite:
+        specifier: ^8.0.0
+        version: 8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0)
 
   examples/03-ui-components/07-suggestion-menus-slash-menu-component:
     dependencies:
@@ -1653,9 +1653,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^6.0.1
         version: 6.0.1(babel-plugin-react-compiler@1.0.0)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))
-      vite-plus:
-        specifier: ^0.1.24
-        version: 0.1.24(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.0.1)(canvas@3.1.0))(terser@5.46.2)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0)
+      vite:
+        specifier: ^8.0.0
+        version: 8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0)
 
   examples/03-ui-components/08-suggestion-menus-emoji-picker-columns:
     dependencies:
@@ -1696,9 +1696,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^6.0.1
         version: 6.0.1(babel-plugin-react-compiler@1.0.0)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))
-      vite-plus:
-        specifier: ^0.1.24
-        version: 0.1.24(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.0.1)(canvas@3.1.0))(terser@5.46.2)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0)
+      vite:
+        specifier: ^8.0.0
+        version: 8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0)
 
   examples/03-ui-components/09-suggestion-menus-emoji-picker-component:
     dependencies:
@@ -1739,9 +1739,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^6.0.1
         version: 6.0.1(babel-plugin-react-compiler@1.0.0)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))
-      vite-plus:
-        specifier: ^0.1.24
-        version: 0.1.24(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.0.1)(canvas@3.1.0))(terser@5.46.2)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0)
+      vite:
+        specifier: ^8.0.0
+        version: 8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0)
 
   examples/03-ui-components/10-suggestion-menus-grid-mentions:
     dependencies:
@@ -1782,9 +1782,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^6.0.1
         version: 6.0.1(babel-plugin-react-compiler@1.0.0)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))
-      vite-plus:
-        specifier: ^0.1.24
-        version: 0.1.24(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.0.1)(canvas@3.1.0))(terser@5.46.2)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0)
+      vite:
+        specifier: ^8.0.0
+        version: 8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0)
 
   examples/03-ui-components/11-uppy-file-panel:
     dependencies:
@@ -1861,9 +1861,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^6.0.1
         version: 6.0.1(babel-plugin-react-compiler@1.0.0)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))
-      vite-plus:
-        specifier: ^0.1.24
-        version: 0.1.24(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.0.1)(canvas@3.1.0))(terser@5.46.2)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0)
+      vite:
+        specifier: ^8.0.0
+        version: 8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0)
 
   examples/03-ui-components/12-static-formatting-toolbar:
     dependencies:
@@ -1904,9 +1904,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^6.0.1
         version: 6.0.1(babel-plugin-react-compiler@1.0.0)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))
-      vite-plus:
-        specifier: ^0.1.24
-        version: 0.1.24(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.0.1)(canvas@3.1.0))(terser@5.46.2)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0)
+      vite:
+        specifier: ^8.0.0
+        version: 8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0)
 
   examples/03-ui-components/13-custom-ui:
     dependencies:
@@ -1953,9 +1953,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^6.0.1
         version: 6.0.1(babel-plugin-react-compiler@1.0.0)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))
-      vite-plus:
-        specifier: ^0.1.24
-        version: 0.1.24(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.0.1)(canvas@3.1.0))(terser@5.46.2)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0)
+      vite:
+        specifier: ^8.0.0
+        version: 8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0)
 
   examples/03-ui-components/14-experimental-mobile-formatting-toolbar:
     dependencies:
@@ -1996,9 +1996,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^6.0.1
         version: 6.0.1(babel-plugin-react-compiler@1.0.0)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))
-      vite-plus:
-        specifier: ^0.1.24
-        version: 0.1.24(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.0.1)(canvas@3.1.0))(terser@5.46.2)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0)
+      vite:
+        specifier: ^8.0.0
+        version: 8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0)
 
   examples/03-ui-components/15-advanced-tables:
     dependencies:
@@ -2039,9 +2039,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^6.0.1
         version: 6.0.1(babel-plugin-react-compiler@1.0.0)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))
-      vite-plus:
-        specifier: ^0.1.24
-        version: 0.1.24(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.0.1)(canvas@3.1.0))(terser@5.46.2)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0)
+      vite:
+        specifier: ^8.0.0
+        version: 8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0)
 
   examples/03-ui-components/16-link-toolbar-buttons:
     dependencies:
@@ -2082,9 +2082,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^6.0.1
         version: 6.0.1(babel-plugin-react-compiler@1.0.0)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))
-      vite-plus:
-        specifier: ^0.1.24
-        version: 0.1.24(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.0.1)(canvas@3.1.0))(terser@5.46.2)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0)
+      vite:
+        specifier: ^8.0.0
+        version: 8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0)
 
   examples/03-ui-components/17-advanced-tables-2:
     dependencies:
@@ -2125,9 +2125,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^6.0.1
         version: 6.0.1(babel-plugin-react-compiler@1.0.0)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))
-      vite-plus:
-        specifier: ^0.1.24
-        version: 0.1.24(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.0.1)(canvas@3.1.0))(terser@5.46.2)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0)
+      vite:
+        specifier: ^8.0.0
+        version: 8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0)
 
   examples/03-ui-components/18-drag-n-drop:
     dependencies:
@@ -2168,9 +2168,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^6.0.1
         version: 6.0.1(babel-plugin-react-compiler@1.0.0)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))
-      vite-plus:
-        specifier: ^0.1.24
-        version: 0.1.24(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.0.1)(canvas@3.1.0))(terser@5.46.2)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0)
+      vite:
+        specifier: ^8.0.0
+        version: 8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0)
 
   examples/03-ui-components/19-suggestion-menus-grouping-ordering:
     dependencies:
@@ -2211,9 +2211,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^6.0.1
         version: 6.0.1(babel-plugin-react-compiler@1.0.0)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))
-      vite-plus:
-        specifier: ^0.1.24
-        version: 0.1.24(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.0.1)(canvas@3.1.0))(terser@5.46.2)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0)
+      vite:
+        specifier: ^8.0.0
+        version: 8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0)
 
   examples/03-ui-components/20-portal-elements:
     dependencies:
@@ -2254,9 +2254,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^6.0.1
         version: 6.0.1(babel-plugin-react-compiler@1.0.0)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))
-      vite-plus:
-        specifier: ^0.1.24
-        version: 0.1.24(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.0.1)(canvas@3.1.0))(terser@5.46.2)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0)
+      vite:
+        specifier: ^8.0.0
+        version: 8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0)
 
   examples/04-theming/01-theming-dom-attributes:
     dependencies:
@@ -2297,9 +2297,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^6.0.1
         version: 6.0.1(babel-plugin-react-compiler@1.0.0)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))
-      vite-plus:
-        specifier: ^0.1.24
-        version: 0.1.24(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.0.1)(canvas@3.1.0))(terser@5.46.2)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0)
+      vite:
+        specifier: ^8.0.0
+        version: 8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0)
 
   examples/04-theming/02-changing-font:
     dependencies:
@@ -2340,9 +2340,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^6.0.1
         version: 6.0.1(babel-plugin-react-compiler@1.0.0)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))
-      vite-plus:
-        specifier: ^0.1.24
-        version: 0.1.24(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.0.1)(canvas@3.1.0))(terser@5.46.2)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0)
+      vite:
+        specifier: ^8.0.0
+        version: 8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0)
 
   examples/04-theming/03-theming-css:
     dependencies:
@@ -2383,9 +2383,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^6.0.1
         version: 6.0.1(babel-plugin-react-compiler@1.0.0)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))
-      vite-plus:
-        specifier: ^0.1.24
-        version: 0.1.24(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.0.1)(canvas@3.1.0))(terser@5.46.2)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0)
+      vite:
+        specifier: ^8.0.0
+        version: 8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0)
 
   examples/04-theming/04-theming-css-variables:
     dependencies:
@@ -2426,9 +2426,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^6.0.1
         version: 6.0.1(babel-plugin-react-compiler@1.0.0)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))
-      vite-plus:
-        specifier: ^0.1.24
-        version: 0.1.24(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.0.1)(canvas@3.1.0))(terser@5.46.2)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0)
+      vite:
+        specifier: ^8.0.0
+        version: 8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0)
 
   examples/04-theming/05-theming-css-variables-code:
     dependencies:
@@ -2469,9 +2469,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^6.0.1
         version: 6.0.1(babel-plugin-react-compiler@1.0.0)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))
-      vite-plus:
-        specifier: ^0.1.24
-        version: 0.1.24(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.0.1)(canvas@3.1.0))(terser@5.46.2)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0)
+      vite:
+        specifier: ^8.0.0
+        version: 8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0)
 
   examples/04-theming/06-code-block:
     dependencies:
@@ -2515,9 +2515,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^6.0.1
         version: 6.0.1(babel-plugin-react-compiler@1.0.0)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))
-      vite-plus:
-        specifier: ^0.1.24
-        version: 0.1.24(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.0.1)(canvas@3.1.0))(terser@5.46.2)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0)
+      vite:
+        specifier: ^8.0.0
+        version: 8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0)
 
   examples/04-theming/07-custom-code-block:
     dependencies:
@@ -2576,9 +2576,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^6.0.1
         version: 6.0.1(babel-plugin-react-compiler@1.0.0)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))
-      vite-plus:
-        specifier: ^0.1.24
-        version: 0.1.24(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.0.1)(canvas@3.1.0))(terser@5.46.2)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0)
+      vite:
+        specifier: ^8.0.0
+        version: 8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0)
 
   examples/05-interoperability/01-converting-blocks-to-html:
     dependencies:
@@ -2619,9 +2619,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^6.0.1
         version: 6.0.1(babel-plugin-react-compiler@1.0.0)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))
-      vite-plus:
-        specifier: ^0.1.24
-        version: 0.1.24(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.0.1)(canvas@3.1.0))(terser@5.46.2)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0)
+      vite:
+        specifier: ^8.0.0
+        version: 8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0)
 
   examples/05-interoperability/02-converting-blocks-from-html:
     dependencies:
@@ -2662,9 +2662,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^6.0.1
         version: 6.0.1(babel-plugin-react-compiler@1.0.0)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))
-      vite-plus:
-        specifier: ^0.1.24
-        version: 0.1.24(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.0.1)(canvas@3.1.0))(terser@5.46.2)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0)
+      vite:
+        specifier: ^8.0.0
+        version: 8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0)
 
   examples/05-interoperability/03-converting-blocks-to-md:
     dependencies:
@@ -2705,9 +2705,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^6.0.1
         version: 6.0.1(babel-plugin-react-compiler@1.0.0)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))
-      vite-plus:
-        specifier: ^0.1.24
-        version: 0.1.24(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.0.1)(canvas@3.1.0))(terser@5.46.2)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0)
+      vite:
+        specifier: ^8.0.0
+        version: 8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0)
 
   examples/05-interoperability/04-converting-blocks-from-md:
     dependencies:
@@ -2748,9 +2748,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^6.0.1
         version: 6.0.1(babel-plugin-react-compiler@1.0.0)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))
-      vite-plus:
-        specifier: ^0.1.24
-        version: 0.1.24(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.0.1)(canvas@3.1.0))(terser@5.46.2)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0)
+      vite:
+        specifier: ^8.0.0
+        version: 8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0)
 
   examples/05-interoperability/05-converting-blocks-to-pdf:
     dependencies:
@@ -2800,9 +2800,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^6.0.1
         version: 6.0.1(babel-plugin-react-compiler@1.0.0)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))
-      vite-plus:
-        specifier: ^0.1.24
-        version: 0.1.24(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.0.1)(canvas@3.1.0))(terser@5.46.2)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0)
+      vite:
+        specifier: ^8.0.0
+        version: 8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0)
 
   examples/05-interoperability/06-converting-blocks-to-docx:
     dependencies:
@@ -2849,9 +2849,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^6.0.1
         version: 6.0.1(babel-plugin-react-compiler@1.0.0)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))
-      vite-plus:
-        specifier: ^0.1.24
-        version: 0.1.24(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.0.1)(canvas@3.1.0))(terser@5.46.2)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0)
+      vite:
+        specifier: ^8.0.0
+        version: 8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0)
 
   examples/05-interoperability/07-converting-blocks-to-odt:
     dependencies:
@@ -2898,9 +2898,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^6.0.1
         version: 6.0.1(babel-plugin-react-compiler@1.0.0)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))
-      vite-plus:
-        specifier: ^0.1.24
-        version: 0.1.24(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.0.1)(canvas@3.1.0))(terser@5.46.2)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0)
+      vite:
+        specifier: ^8.0.0
+        version: 8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0)
 
   examples/05-interoperability/08-converting-blocks-to-react-email:
     dependencies:
@@ -2947,9 +2947,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^6.0.1
         version: 6.0.1(babel-plugin-react-compiler@1.0.0)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))
-      vite-plus:
-        specifier: ^0.1.24
-        version: 0.1.24(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.0.1)(canvas@3.1.0))(terser@5.46.2)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0)
+      vite:
+        specifier: ^8.0.0
+        version: 8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0)
 
   examples/05-interoperability/09-blocks-to-html-static-render:
     dependencies:
@@ -2990,9 +2990,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^6.0.1
         version: 6.0.1(babel-plugin-react-compiler@1.0.0)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))
-      vite-plus:
-        specifier: ^0.1.24
-        version: 0.1.24(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.0.1)(canvas@3.1.0))(terser@5.46.2)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0)
+      vite:
+        specifier: ^8.0.0
+        version: 8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0)
 
   examples/05-interoperability/10-static-html-render:
     dependencies:
@@ -3033,9 +3033,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^6.0.1
         version: 6.0.1(babel-plugin-react-compiler@1.0.0)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))
-      vite-plus:
-        specifier: ^0.1.24
-        version: 0.1.24(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.0.1)(canvas@3.1.0))(terser@5.46.2)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0)
+      vite:
+        specifier: ^8.0.0
+        version: 8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0)
 
   examples/06-custom-schema/01-alert-block:
     dependencies:
@@ -3079,9 +3079,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^6.0.1
         version: 6.0.1(babel-plugin-react-compiler@1.0.0)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))
-      vite-plus:
-        specifier: ^0.1.24
-        version: 0.1.24(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.0.1)(canvas@3.1.0))(terser@5.46.2)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0)
+      vite:
+        specifier: ^8.0.0
+        version: 8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0)
 
   examples/06-custom-schema/02-suggestion-menus-mentions:
     dependencies:
@@ -3122,9 +3122,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^6.0.1
         version: 6.0.1(babel-plugin-react-compiler@1.0.0)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))
-      vite-plus:
-        specifier: ^0.1.24
-        version: 0.1.24(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.0.1)(canvas@3.1.0))(terser@5.46.2)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0)
+      vite:
+        specifier: ^8.0.0
+        version: 8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0)
 
   examples/06-custom-schema/03-font-style:
     dependencies:
@@ -3168,9 +3168,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^6.0.1
         version: 6.0.1(babel-plugin-react-compiler@1.0.0)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))
-      vite-plus:
-        specifier: ^0.1.24
-        version: 0.1.24(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.0.1)(canvas@3.1.0))(terser@5.46.2)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0)
+      vite:
+        specifier: ^8.0.0
+        version: 8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0)
 
   examples/06-custom-schema/04-pdf-file-block:
     dependencies:
@@ -3214,9 +3214,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^6.0.1
         version: 6.0.1(babel-plugin-react-compiler@1.0.0)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))
-      vite-plus:
-        specifier: ^0.1.24
-        version: 0.1.24(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.0.1)(canvas@3.1.0))(terser@5.46.2)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0)
+      vite:
+        specifier: ^8.0.0
+        version: 8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0)
 
   examples/06-custom-schema/05-alert-block-full-ux:
     dependencies:
@@ -3260,9 +3260,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^6.0.1
         version: 6.0.1(babel-plugin-react-compiler@1.0.0)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))
-      vite-plus:
-        specifier: ^0.1.24
-        version: 0.1.24(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.0.1)(canvas@3.1.0))(terser@5.46.2)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0)
+      vite:
+        specifier: ^8.0.0
+        version: 8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0)
 
   examples/06-custom-schema/06-toggleable-blocks:
     dependencies:
@@ -3303,9 +3303,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^6.0.1
         version: 6.0.1(babel-plugin-react-compiler@1.0.0)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))
-      vite-plus:
-        specifier: ^0.1.24
-        version: 0.1.24(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.0.1)(canvas@3.1.0))(terser@5.46.2)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0)
+      vite:
+        specifier: ^8.0.0
+        version: 8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0)
 
   examples/06-custom-schema/07-configuring-blocks:
     dependencies:
@@ -3346,9 +3346,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^6.0.1
         version: 6.0.1(babel-plugin-react-compiler@1.0.0)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))
-      vite-plus:
-        specifier: ^0.1.24
-        version: 0.1.24(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.0.1)(canvas@3.1.0))(terser@5.46.2)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0)
+      vite:
+        specifier: ^8.0.0
+        version: 8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0)
 
   examples/06-custom-schema/08-non-editable-block:
     dependencies:
@@ -3389,9 +3389,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^6.0.1
         version: 6.0.1(babel-plugin-react-compiler@1.0.0)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))
-      vite-plus:
-        specifier: ^0.1.24
-        version: 0.1.24(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.0.1)(canvas@3.1.0))(terser@5.46.2)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0)
+      vite:
+        specifier: ^8.0.0
+        version: 8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0)
 
   examples/06-custom-schema/draggable-inline-content:
     dependencies:
@@ -3432,9 +3432,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^6.0.1
         version: 6.0.1(babel-plugin-react-compiler@1.0.0)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))
-      vite-plus:
-        specifier: ^0.1.24
-        version: 0.1.24(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.0.1)(canvas@3.1.0))(terser@5.46.2)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0)
+      vite:
+        specifier: ^8.0.0
+        version: 8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0)
 
   examples/06-custom-schema/react-custom-blocks:
     dependencies:
@@ -3475,9 +3475,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^6.0.1
         version: 6.0.1(babel-plugin-react-compiler@1.0.0)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))
-      vite-plus:
-        specifier: ^0.1.24
-        version: 0.1.24(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.0.1)(canvas@3.1.0))(terser@5.46.2)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0)
+      vite:
+        specifier: ^8.0.0
+        version: 8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0)
 
   examples/06-custom-schema/react-custom-inline-content:
     dependencies:
@@ -3518,9 +3518,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^6.0.1
         version: 6.0.1(babel-plugin-react-compiler@1.0.0)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))
-      vite-plus:
-        specifier: ^0.1.24
-        version: 0.1.24(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.0.1)(canvas@3.1.0))(terser@5.46.2)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0)
+      vite:
+        specifier: ^8.0.0
+        version: 8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0)
 
   examples/06-custom-schema/react-custom-styles:
     dependencies:
@@ -3561,9 +3561,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^6.0.1
         version: 6.0.1(babel-plugin-react-compiler@1.0.0)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))
-      vite-plus:
-        specifier: ^0.1.24
-        version: 0.1.24(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.0.1)(canvas@3.1.0))(terser@5.46.2)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0)
+      vite:
+        specifier: ^8.0.0
+        version: 8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0)
 
   examples/07-collaboration/01-partykit:
     dependencies:
@@ -3610,9 +3610,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^6.0.1
         version: 6.0.1(babel-plugin-react-compiler@1.0.0)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))
-      vite-plus:
-        specifier: ^0.1.24
-        version: 0.1.24(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.0.1)(canvas@3.1.0))(terser@5.46.2)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0)
+      vite:
+        specifier: ^8.0.0
+        version: 8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0)
 
   examples/07-collaboration/02-liveblocks:
     dependencies:
@@ -3671,9 +3671,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^6.0.1
         version: 6.0.1(babel-plugin-react-compiler@1.0.0)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))
-      vite-plus:
-        specifier: ^0.1.24
-        version: 0.1.24(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.0.1)(canvas@3.1.0))(terser@5.46.2)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0)
+      vite:
+        specifier: ^8.0.0
+        version: 8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0)
 
   examples/07-collaboration/03-y-sweet:
     dependencies:
@@ -3717,9 +3717,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^6.0.1
         version: 6.0.1(babel-plugin-react-compiler@1.0.0)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))
-      vite-plus:
-        specifier: ^0.1.24
-        version: 0.1.24(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.0.1)(canvas@3.1.0))(terser@5.46.2)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0)
+      vite:
+        specifier: ^8.0.0
+        version: 8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0)
 
   examples/07-collaboration/04-electric-sql:
     dependencies:
@@ -3760,9 +3760,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^6.0.1
         version: 6.0.1(babel-plugin-react-compiler@1.0.0)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))
-      vite-plus:
-        specifier: ^0.1.24
-        version: 0.1.24(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.0.1)(canvas@3.1.0))(terser@5.46.2)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0)
+      vite:
+        specifier: ^8.0.0
+        version: 8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0)
 
   examples/07-collaboration/05-comments:
     dependencies:
@@ -3806,9 +3806,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^6.0.1
         version: 6.0.1(babel-plugin-react-compiler@1.0.0)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))
-      vite-plus:
-        specifier: ^0.1.24
-        version: 0.1.24(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.0.1)(canvas@3.1.0))(terser@5.46.2)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0)
+      vite:
+        specifier: ^8.0.0
+        version: 8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0)
 
   examples/07-collaboration/06-comments-with-sidebar:
     dependencies:
@@ -3855,9 +3855,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^6.0.1
         version: 6.0.1(babel-plugin-react-compiler@1.0.0)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))
-      vite-plus:
-        specifier: ^0.1.24
-        version: 0.1.24(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.0.1)(canvas@3.1.0))(terser@5.46.2)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0)
+      vite:
+        specifier: ^8.0.0
+        version: 8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0)
 
   examples/07-collaboration/07-ghost-writer:
     dependencies:
@@ -3904,9 +3904,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^6.0.1
         version: 6.0.1(babel-plugin-react-compiler@1.0.0)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))
-      vite-plus:
-        specifier: ^0.1.24
-        version: 0.1.24(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.0.1)(canvas@3.1.0))(terser@5.46.2)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0)
+      vite:
+        specifier: ^8.0.0
+        version: 8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0)
 
   examples/07-collaboration/08-forking:
     dependencies:
@@ -3953,9 +3953,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^6.0.1
         version: 6.0.1(babel-plugin-react-compiler@1.0.0)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))
-      vite-plus:
-        specifier: ^0.1.24
-        version: 0.1.24(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.0.1)(canvas@3.1.0))(terser@5.46.2)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0)
+      vite:
+        specifier: ^8.0.0
+        version: 8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0)
 
   examples/07-collaboration/09-comments-testing:
     dependencies:
@@ -3999,9 +3999,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^6.0.1
         version: 6.0.1(babel-plugin-react-compiler@1.0.0)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))
-      vite-plus:
-        specifier: ^0.1.24
-        version: 0.1.24(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.0.1)(canvas@3.1.0))(terser@5.46.2)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0)
+      vite:
+        specifier: ^8.0.0
+        version: 8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0)
 
   examples/07-collaboration/10-suggestion-multi-editor:
     dependencies:
@@ -4054,9 +4054,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^6.0.1
         version: 6.0.1(babel-plugin-react-compiler@1.0.0)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))
-      vite-plus:
-        specifier: ^0.1.24
-        version: 0.1.24(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.0.1)(canvas@3.1.0))(terser@5.46.2)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0)
+      vite:
+        specifier: ^8.0.0
+        version: 8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0)
 
   examples/07-collaboration/11-versioning-yjs13:
     dependencies:
@@ -4106,9 +4106,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^6.0.1
         version: 6.0.1(babel-plugin-react-compiler@1.0.0)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))
-      vite-plus:
-        specifier: ^0.1.24
-        version: 0.1.24(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.0.1)(canvas@3.1.0))(terser@5.46.2)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0)
+      vite:
+        specifier: ^8.0.0
+        version: 8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0)
 
   examples/07-collaboration/12-multi-doc-versioning:
     dependencies:
@@ -4161,9 +4161,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^6.0.1
         version: 6.0.1(babel-plugin-react-compiler@1.0.0)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))
-      vite-plus:
-        specifier: ^0.1.24
-        version: 0.1.24(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.0.1)(canvas@3.1.0))(terser@5.46.2)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0)
+      vite:
+        specifier: ^8.0.0
+        version: 8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0)
 
   examples/07-collaboration/13-versioning-yjs14:
     dependencies:
@@ -4219,9 +4219,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^6.0.1
         version: 6.0.1(babel-plugin-react-compiler@1.0.0)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))
-      vite-plus:
-        specifier: ^0.1.24
-        version: 0.1.24(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.0.1)(canvas@3.1.0))(terser@5.46.2)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0)
+      vite:
+        specifier: ^8.0.0
+        version: 8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0)
 
   examples/07-collaboration/14-suggestion-gallery:
     dependencies:
@@ -4274,9 +4274,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^6.0.1
         version: 6.0.1(babel-plugin-react-compiler@1.0.0)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))
-      vite-plus:
-        specifier: ^0.1.24
-        version: 0.1.24(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.0.1)(canvas@3.1.0))(terser@5.46.2)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0)
+      vite:
+        specifier: ^8.0.0
+        version: 8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0)
 
   examples/08-extensions/01-tiptap-arrow-conversion:
     dependencies:
@@ -4320,9 +4320,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^6.0.1
         version: 6.0.1(babel-plugin-react-compiler@1.0.0)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))
-      vite-plus:
-        specifier: ^0.1.24
-        version: 0.1.24(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.0.1)(canvas@3.1.0))(terser@5.46.2)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0)
+      vite:
+        specifier: ^8.0.0
+        version: 8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0)
 
   examples/08-extensions/02-versioning:
     dependencies:
@@ -4369,9 +4369,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^6.0.1
         version: 6.0.1(babel-plugin-react-compiler@1.0.0)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))
-      vite-plus:
-        specifier: ^0.1.24
-        version: 0.1.24(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.0.1)(canvas@3.1.0))(terser@5.46.2)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0)
+      vite:
+        specifier: ^8.0.0
+        version: 8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0)
 
   examples/09-ai/01-minimal:
     dependencies:
@@ -4418,9 +4418,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^6.0.1
         version: 6.0.1(babel-plugin-react-compiler@1.0.0)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))
-      vite-plus:
-        specifier: ^0.1.24
-        version: 0.1.24(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.0.1)(canvas@3.1.0))(terser@5.46.2)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0)
+      vite:
+        specifier: ^8.0.0
+        version: 8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0)
 
   examples/09-ai/02-playground:
     dependencies:
@@ -4467,9 +4467,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^6.0.1
         version: 6.0.1(babel-plugin-react-compiler@1.0.0)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))
-      vite-plus:
-        specifier: ^0.1.24
-        version: 0.1.24(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.0.1)(canvas@3.1.0))(terser@5.46.2)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0)
+      vite:
+        specifier: ^8.0.0
+        version: 8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0)
 
   examples/09-ai/03-custom-ai-menu-items:
     dependencies:
@@ -4519,9 +4519,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^6.0.1
         version: 6.0.1(babel-plugin-react-compiler@1.0.0)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))
-      vite-plus:
-        specifier: ^0.1.24
-        version: 0.1.24(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.0.1)(canvas@3.1.0))(terser@5.46.2)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0)
+      vite:
+        specifier: ^8.0.0
+        version: 8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0)
 
   examples/09-ai/04-with-collaboration:
     dependencies:
@@ -4574,9 +4574,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^6.0.1
         version: 6.0.1(babel-plugin-react-compiler@1.0.0)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))
-      vite-plus:
-        specifier: ^0.1.24
-        version: 0.1.24(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.0.1)(canvas@3.1.0))(terser@5.46.2)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0)
+      vite:
+        specifier: ^8.0.0
+        version: 8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0)
 
   examples/09-ai/05-manual-execution:
     dependencies:
@@ -4629,9 +4629,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^6.0.1
         version: 6.0.1(babel-plugin-react-compiler@1.0.0)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))
-      vite-plus:
-        specifier: ^0.1.24
-        version: 0.1.24(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.0.1)(canvas@3.1.0))(terser@5.46.2)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0)
+      vite:
+        specifier: ^8.0.0
+        version: 8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0)
 
   examples/09-ai/06-client-side-transport:
     dependencies:
@@ -4681,9 +4681,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^6.0.1
         version: 6.0.1(babel-plugin-react-compiler@1.0.0)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))
-      vite-plus:
-        specifier: ^0.1.24
-        version: 0.1.24(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.0.1)(canvas@3.1.0))(terser@5.46.2)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0)
+      vite:
+        specifier: ^8.0.0
+        version: 8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0)
 
   examples/09-ai/07-server-persistence:
     dependencies:
@@ -4730,9 +4730,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^6.0.1
         version: 6.0.1(babel-plugin-react-compiler@1.0.0)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))
-      vite-plus:
-        specifier: ^0.1.24
-        version: 0.1.24(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.0.1)(canvas@3.1.0))(terser@5.46.2)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0)
+      vite:
+        specifier: ^8.0.0
+        version: 8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0)
 
   examples/vanilla-js/react-vanilla-custom-blocks:
     dependencies:
@@ -4773,9 +4773,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^6.0.1
         version: 6.0.1(babel-plugin-react-compiler@1.0.0)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))
-      vite-plus:
-        specifier: ^0.1.24
-        version: 0.1.24(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.0.1)(canvas@3.1.0))(terser@5.46.2)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0)
+      vite:
+        specifier: ^8.0.0
+        version: 8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0)
 
   examples/vanilla-js/react-vanilla-custom-inline-content:
     dependencies:
@@ -4816,9 +4816,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^6.0.1
         version: 6.0.1(babel-plugin-react-compiler@1.0.0)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))
-      vite-plus:
-        specifier: ^0.1.24
-        version: 0.1.24(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.0.1)(canvas@3.1.0))(terser@5.46.2)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0)
+      vite:
+        specifier: ^8.0.0
+        version: 8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0)
 
   examples/vanilla-js/react-vanilla-custom-styles:
     dependencies:
@@ -4859,9 +4859,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^6.0.1
         version: 6.0.1(babel-plugin-react-compiler@1.0.0)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))
-      vite-plus:
-        specifier: ^0.1.24
-        version: 0.1.24(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.0.1)(canvas@3.1.0))(terser@5.46.2)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0)
+      vite:
+        specifier: ^8.0.0
+        version: 8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0)
 
   examples/vanilla-js/vanilla-custom-side-menu:
     dependencies:
@@ -4902,9 +4902,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^6.0.1
         version: 6.0.1(babel-plugin-react-compiler@1.0.0)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))
-      vite-plus:
-        specifier: ^0.1.24
-        version: 0.1.24(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(jsdom@29.0.2(@noble/hashes@2.0.1)(canvas@3.1.0))(terser@5.46.2)(tsx@4.21.0)(typescript@5.9.3)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0))(yaml@2.9.0)
+      vite:
+        specifier: ^8.0.0
+        version: 8.0.8(@types/node@25.6.0)(esbuild@0.27.5)(jiti@2.6.1)(terser@5.46.2)(tsx@4.21.0)(yaml@2.9.0)
 
   packages/ariakit:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -37,6 +37,7 @@ allowBuilds:
 patchedDependencies:
   { "@y/prosemirror@2.0.0-6": patches/@y__prosemirror@2.0.0-6.patch }
 catalog:
+  vite: ^8.0.0
   vite-plus: ^0.1.24
 minimumReleaseAgeExclude:
   - vite-plus


### PR DESCRIPTION
# Summary

Use plain `vite` instead of `vite-plus` in generated standalone examples so they work in StackBlitz's WebContainers environment.

Fixes #2916

## Rationale

`vite-plus` requires platform-specific native NAPI-RS bindings (`.node` files) that cannot run in StackBlitz's WebContainers (a browser-based Node.js runtime). This causes every example StackBlitz link to crash with `"Cannot find native binding"`. VoidZero has scaffolded a WASM fallback (`@voidzero-dev/vite-plus-wasm32-wasi`) in their binding loader but hasn't published it yet, and it's not on their Q3 2026 roadmap.

The examples only use standard Vite features (`defineConfig`, dev server, build) — none of the vite-plus extras (oxlint, oxfmt, task runner) — so plain `vite` is fully sufficient.

## Changes

- Updated example templates (`package.json.template.tsx`, `vite.config.ts.template.tsx`, `vite-env.d.ts.template.tsx`) to use `vite` instead of `vite-plus`
- Changed example scripts from `vp dev`/`vp build`/`vp preview` to `vite`/`vite build`/`vite preview`
- Added `vite: ^8.0.0` to the pnpm workspace catalog
- Regenerated all ~98 example projects

## Impact

- The monorepo's own packages continue to use `vite-plus` for development — only the standalone examples change
- Local development works identically (verified: dev server starts, build succeeds)
- StackBlitz examples will now work with `npm install && npm run dev`

## Testing

- Verified standalone `npm install && npm run dev` works for both the minimal example and the shadcn/tailwind example in isolated temp directories outside the monorepo
- Verified `vite build` succeeds standalone
- Verified local monorepo dev server starts correctly
- Verified `vp run build` passes for the full project
- Verified `vp run gen --force` produces stable output (changes survive regeneration)

## Checklist

- [x] Code follows the project's coding standards.
- [ ] Unit tests covering the new feature have been added.
- [x] All existing tests pass.
- [ ] The documentation has been updated to reflect the new feature

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated all example projects to use standard Vite development, build, and preview commands.
  * Aligned generated example templates with the same Vite workflow.
  * Updated environment references and configuration to ensure examples run consistently.
* **Chores**
  * Added Vite 8 support across the example workspace.
  * Preserved existing example behavior and configuration beyond the tooling updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->