### PR TITLE
fix(xl-docx-exporter): clamp list nesting to the levels DOCX defines

### DIFF
--- a/packages/xl-docx-exporter/src/docx/defaultSchema/blocks.ts
+++ b/packages/xl-docx-exporter/src/docx/defaultSchema/blocks.ts
@@ -22,6 +22,7 @@ import {
   TableRow,
   TextRun,
 } from "docx";
+import { clampListLevel } from "../listLevels.js";
 import { Table } from "../util/Table.js";
 
 function blockPropsToStyles(
@@ -103,7 +104,7 @@ export const docxBlockMappingForDefaultSchema: BlockMapping<
       children: exporter.transformInlineContent(block.content),
       numbering: {
         reference: "blocknote-numbered-list",
-        level: nestingLevel,
+        level: clampListLevel(nestingLevel),
       },
     });
   },
@@ -113,7 +114,7 @@ export const docxBlockMappingForDefaultSchema: BlockMapping<
       children: exporter.transformInlineContent(block.content),
       numbering: {
         reference: "blocknote-bullet-list",
-        level: nestingLevel,
+        level: clampListLevel(nestingLevel),
       },
     });
   },

--- a/packages/xl-docx-exporter/src/docx/docxExporter.test.ts
+++ b/packages/xl-docx-exporter/src/docx/docxExporter.test.ts
@@ -2,6 +2,7 @@ import {
   BlockNoteSchema,
   defaultBlockSpecs,
   createPageBreakBlockSpec,
+  PartialBlock,
 } from "@blocknote/core";
 import { testDocument } from "@shared/testDocument.js";
 import {
@@ -220,6 +221,66 @@ describe("exporter", () => {
       await expect(
         prettify(await getZIPEntryContent(entries, "word/styles.xml")),
       ).toMatchFileSnapshot("__snapshots__/withMultiColumn/styles.xml");
+    },
+  );
+
+  it(
+    "should clamp list nesting deeper than DOCX supports",
+    { timeout: 10000 },
+    async () => {
+      const schema = BlockNoteSchema.create({
+        blockSpecs: { ...defaultBlockSpecs },
+      });
+
+      // A list nested `depth` items deep, i.e. nesting levels 0..depth-1.
+      const nestedList = (depth: number) => {
+        type SchemaPartialBlock = PartialBlock<
+          typeof schema.blockSchema,
+          typeof schema.inlineContentSchema,
+          typeof schema.styleSchema
+        >;
+
+        let block: SchemaPartialBlock = {
+          type: "bulletListItem",
+          content: `level ${depth}`,
+        };
+        for (let i = depth - 1; i >= 1; i--) {
+          block = {
+            type: "bulletListItem",
+            content: `level ${i}`,
+            children: [block],
+          };
+        }
+        return [block];
+      };
+      const exporter = new DOCXExporter(schema, docxDefaultSchemaMappings, {
+        resolveFileUrl: testResolveFileUrl,
+      });
+
+      // Deeper than the 9 levels the numbering config defines. Without
+      // clamping, `docx` throws "Level cannot be greater than 9" and the whole
+      // export fails.
+      const doc = await exporter.toDocxJsDocument(
+        partialBlocksToBlocksForTesting(schema, nestedList(12)),
+        { sectionOptions: {}, documentOptions: {}, locale: "en-US" },
+      );
+
+      const blob = await Packer.toBlob(doc);
+      const zip = new ZipReader(new BlobReader(blob));
+      const entries = await zip.getEntries();
+      const documentXml = await getZIPEntryContent(
+        entries,
+        "word/document.xml",
+      );
+
+      const levels = [...documentXml.matchAll(/<w:ilvl w:val="(\d+)"\/>/g)].map(
+        (match) => Number(match[1]),
+      );
+
+      // Every item is still exported, and every level it references is one the
+      // numbering config actually defines (0-8) - levels past that are pinned
+      // to the deepest defined level rather than dropped or left undefined.
+      expect(levels).toEqual([0, 1, 2, 3, 4, 5, 6, 7, 8, 8, 8, 8]);
     },
   );
 

--- a/packages/xl-docx-exporter/src/docx/docxExporter.ts
+++ b/packages/xl-docx-exporter/src/docx/docxExporter.ts
@@ -24,6 +24,7 @@ import {
 import { Exporter, ExporterOptions } from "@blocknote/core";
 import { corsProxyResolveFileUrl } from "@shared/api/corsProxy.js";
 import { loadFileBuffer } from "@shared/util/fileUtil.js";
+import { DOCX_LIST_LEVEL_COUNT } from "./listLevels.js";
 
 // get constructor arg type from Document
 type DocumentOptions = Partial<ConstructorParameters<typeof Document>[0]>;
@@ -216,7 +217,7 @@ export class DOCXExporter<
         config: [
           {
             reference: "blocknote-numbered-list",
-            levels: Array.from({ length: 9 }, (_, i) => ({
+            levels: Array.from({ length: DOCX_LIST_LEVEL_COUNT }, (_, i) => ({
               start: 1,
               level: i,
               format: LevelFormat.DECIMAL,
@@ -234,7 +235,7 @@ export class DOCXExporter<
           },
           {
             reference: "blocknote-bullet-list",
-            levels: Array.from({ length: 9 }, (_, i) => ({
+            levels: Array.from({ length: DOCX_LIST_LEVEL_COUNT }, (_, i) => ({
               start: 1,
               level: i,
               format: LevelFormat.BULLET,

--- a/packages/xl-docx-exporter/src/docx/listLevels.ts
+++ b/packages/xl-docx-exporter/src/docx/listLevels.ts
@@ -1,0 +1,24 @@
+/**
+ * The number of levels defined for the `blocknote-numbered-list` and
+ * `blocknote-bullet-list` numbering configs in
+ * `DOCXExporter.createDefaultDocumentOptions`.
+ *
+ * OOXML numbering definitions cap out at 9 levels (`w:ilvl` 0-8), which is also
+ * the nesting limit Word itself exposes.
+ */
+export const DOCX_LIST_LEVEL_COUNT = 9;
+
+/**
+ * Clamps a block's nesting level to the deepest list level the numbering config
+ * actually defines.
+ *
+ * BlockNote allows lists to nest arbitrarily deep, so a `nestingLevel` can
+ * exceed what DOCX supports. Passing such a level straight through makes `docx`
+ * throw ("Level cannot be greater than 9"), which aborts the whole export, and
+ * a level with no matching definition renders without its bullet or indent.
+ * Deeper items are rendered at the deepest defined level instead, matching how
+ * Word collapses nesting past its own limit.
+ */
+export function clampListLevel(nestingLevel: number) {
+  return Math.min(nestingLevel, DOCX_LIST_LEVEL_COUNT - 1);
+}


### PR DESCRIPTION
Fixes #2228.

## The bug

`numberedListItem` and `bulletListItem` pass the block's `nestingLevel` straight into docx's `numbering.level`:

```ts
numbering: {
  reference: "blocknote-bullet-list",
  level: nestingLevel,
},
```

But the numbering configs built in `createDefaultDocumentOptions` define only 9 levels (`w:ilvl` 0-8):

```ts
levels: Array.from({ length: 9 }, (_, i) => ({ ... }))
```

Nothing reconciles the two, so a deeply nested list asks for a level that doesn't exist.

## Two failures, not one

While writing the regression test I found the reported crash is the louder of two problems:

| Nesting depth | `nestingLevel` | Behaviour on `main` |
| --- | --- | --- |
| ≤ 9 | 0-8 | correct |
| **10** | 9 | **no crash, but silently wrong** |
| **11+** | 10+ | **throws, whole export fails** |

At 11 levels or more, `docx` throws `Level cannot be greater than 9` and the entire export is lost — matching the report, where the only feedback is a console error.

At exactly 10 levels it doesn't throw, which is why this half is easy to miss. `docx` permits level 9, so the export "succeeds" and writes `<w:ilvl w:val="9"/>` — but `numbering.xml` defines no level 9. I confirmed this on `main` by exporting a 10-deep list and comparing the two files:

```
document.xml   uses  w:ilvl [0,1,2,3,4,5,6,7,8,9]
numbering.xml  defines      0-8  (max defined: 8)
```

So that last item references an undefined numbering level and loses its bullet and indent.

## The fix

Clamp the level to the deepest one the numbering config actually defines. Deeper items render at that level rather than crashing or dangling — the same way Word collapses nesting past its own 9-level limit (the limit `docx` points at in its error message).

The level count now lives in one shared constant used by both the numbering config and the mappings, so they can't drift apart if the config ever gains levels.

An alternative would be synthesising extra indentation for levels past 8 to keep deep nesting visually distinct. I left that out deliberately: it would fight the indent defined on the numbering level itself, and Word doesn't do it either. Happy to add it if you'd prefer that behaviour.

## Testing

Added `should clamp list nesting deeper than DOCX supports` to `docxExporter.test.ts`. It exports a 12-deep bullet list and asserts on the emitted `w:ilvl` sequence:

```ts
expect(levels).toEqual([0, 1, 2, 3, 4, 5, 6, 7, 8, 8, 8, 8]);
```

Asserting the sequence rather than just "did not throw" covers both failures at once — the crash *and* the undefined-level case — and confirms all 12 items still make it into the document.

Verified in both directions: with only the two source files reverted (test kept), the new test fails with the upstream `Level cannot be greater than 9`, while the other five tests still pass, so nothing is masking the result. With the fix, all 6 pass.

No snapshots changed, which is the intended outcome — lists within 9 levels are byte-for-byte unaffected.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed DOCX export for deeply nested numbered and bulleted lists.
  * List nesting is now capped at the supported ninth level while preserving all list items.

* **Tests**
  * Added regression coverage for exporting lists nested beyond the DOCX nesting limit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->