### PR TITLE
fix(xl-docx-exporter): use distinct bullet symbols per nesting level

### DIFF
--- a/packages/xl-docx-exporter/src/docx/docxExporter.test.ts
+++ b/packages/xl-docx-exporter/src/docx/docxExporter.test.ts
@@ -281,6 +281,59 @@ describe("exporter", () => {
     },
   );
 
+  it(
+    "should use distinct bullet symbols per nesting level",
+    { timeout: 10000 },
+    async () => {
+      const schema = BlockNoteSchema.create({
+        blockSpecs: { ...defaultBlockSpecs },
+      });
+
+      const exporter = new DOCXExporter(schema, docxDefaultSchemaMappings, {
+        resolveFileUrl: testResolveFileUrl,
+      });
+
+      const doc = await exporter.toDocxJsDocument(
+        partialBlocksToBlocksForTesting(schema, [
+          { type: "bulletListItem", content: "level 0" },
+        ]),
+        { sectionOptions: {}, documentOptions: {}, locale: "en-US" },
+      );
+
+      const numberingXml = await getZIPEntryContent(
+        await new ZipReader(
+          new BlobReader(await Packer.toBlob(doc)),
+        ).getEntries(),
+        "word/numbering.xml",
+      );
+
+      // numbering.xml defines both the numbered and bullet abstract numberings,
+      // each with a `w:lvl` per depth. Pick out the bullet levels (numFmt
+      // "bullet") and read each level's glyph (`w:lvlText`) by depth (`w:ilvl`).
+      const bulletTextByLevel = new Map<number, string>();
+      for (const block of numberingXml.matchAll(
+        /<w:lvl\b[^>]*w:ilvl="(\d+)"[^>]*>([\s\S]*?)<\/w:lvl>/g,
+      )) {
+        const body = block[2];
+        if (!/<w:numFmt w:val="bullet"\/>/.test(body)) {
+          continue;
+        }
+        const text = body.match(/<w:lvlText w:val="([^"]*)"/);
+        if (text) {
+          bulletTextByLevel.set(Number(block[1]), text[1]);
+        }
+      }
+
+      // The first three levels must be visually distinct (not all "•"), matching
+      // how Word/LibreOffice/Google Docs render nested bullets (#2226).
+      expect([0, 1, 2].map((level) => bulletTextByLevel.get(level))).toEqual([
+        "•",
+        "○",
+        "▪",
+      ]);
+    },
+  );
+
   async function exportAndGetStylesEntries(locale?: string) {
     const exporter = new DOCXExporter(
       BlockNoteSchema.create({

--- a/packages/xl-docx-exporter/src/docx/docxExporter.ts
+++ b/packages/xl-docx-exporter/src/docx/docxExporter.ts
@@ -211,7 +211,12 @@ export class DOCXExporter<
       externalStyles = externalStyles.replace(/\s*<w:lang\b[^>]*\/>/g, "");
     }
 
-    const bullets = ["•"]; //, "◦", "▪"]; (these don't look great, just use solid bullet for now)
+    // Cycle bullet symbols by depth (filled disc, hollow circle, filled
+    // square), the same convention Word/LibreOffice/Google Docs use, so nested
+    // bullet levels are visually distinct instead of all rendering as "•"
+    // (#2226). These Unicode glyphs render in the document font, so they don't
+    // depend on Symbol/Wingdings being installed.
+    const bullets = ["•", "○", "▪"];
     return {
       numbering: {
         config: [


### PR DESCRIPTION
Closes #2226

## Problem

Every bullet list level was exported with the same `•` glyph, so nested bullet lists were visually indistinguishable from their parents. Word, LibreOffice and Google Docs all cycle the bullet by depth.

## Fix

Cycle the glyph by nesting level — filled disc, hollow circle, filled square (`•` / `○` / `▪`) — in the `blocknote-bullet-list` numbering config. These are Unicode characters that render in the document font, so there's no dependency on the Symbol or Wingdings fonts being installed (which is what made the previously-commented-out `◦`/`▪` attempt look inconsistent).

## Test

`should use distinct bullet symbols per nesting level` exports a bullet list, reads the generated `word/numbering.xml`, and asserts the first three bullet levels are `•`, `○`, `▪`. It fails on `main` (all three are `•`) and passes with this change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved nested DOCX bullet lists with distinct symbols for each of the first three nesting levels: filled disc, hollow circle, and filled square.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->