### PR TITLE
fix(core): don't throw when the suggestion menu opens while not editable

### DIFF
--- a/packages/core/src/extensions/SuggestionMenu/SuggestionMenu.test.ts
+++ b/packages/core/src/extensions/SuggestionMenu/SuggestionMenu.test.ts
@@ -306,4 +306,23 @@ describe("SuggestionMenu", () => {
 
     editor._tiptapEditor.destroy();
   });
+
+  it("does not throw when the menu opens while not editable (#2701)", () => {
+    const editor = createEditor();
+    editor.setTextCursorPosition(editor.document[0].id, "end");
+
+    // Toggling to non-editable right before the menu opens (as a controlled
+    // `editable` prop does under load) means the menu view never gets shown, so
+    // its `state` stays undefined. The stop/non-editable update path used to
+    // call `emitUpdate` unconditionally and throw.
+    editor.isEditable = false;
+
+    expect(() =>
+      editor
+        .getExtension(SuggestionMenu)!
+        .openSuggestionMenu("/", { deleteTriggerCharacter: true }),
+    ).not.toThrow();
+
+    editor._tiptapEditor.destroy();
+  });
 });

--- a/packages/core/src/extensions/SuggestionMenu/SuggestionMenu.ts
+++ b/packages/core/src/extensions/SuggestionMenu/SuggestionMenu.ts
@@ -84,10 +84,15 @@ class SuggestionMenuView {
     this.pluginState = stopped ? prev : next;
 
     if (stopped || !this.editor.isEditable) {
+      // If the menu was never actually shown (`state` is still undefined - e.g.
+      // it was opened while the editor was not editable, which happens when the
+      // editable prop is toggled right before the menu opens), there is nothing
+      // to hide, and calling `emitUpdate` here would throw "Attempting to update
+      // uninitialized suggestions menu" (#2701).
       if (this.state) {
         this.state.show = false;
+        this.emitUpdate(this.pluginState!.triggerCharacter);
       }
-      this.emitUpdate(this.pluginState!.triggerCharacter);
 
       return;
     }


### PR DESCRIPTION
Closes #2701

## Problem

Toggling the editor to non-editable right as the suggestion (slash) menu opens — which a controlled `editable` prop can do under load — leaves `SuggestionMenuView` without a `state`, because the menu never gets shown. The stop / non-editable branch of `update()` then called `emitUpdate` unconditionally, which throws:

```
Error: Attempting to update uninitialized suggestions menu
```

## Fix

Only hide the menu and emit an update when it actually has a `state`. If it was never shown there is nothing to update, so we return without calling `emitUpdate`.

## Test

`does not throw when the menu opens while not editable (#2701)` sets `editor.isEditable = false` and then opens the suggestion menu, reproducing the crash deterministically. It throws on `main` and passes with this change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an error that could occur when opening a suggestion menu after the editor became non-editable.
  * Improved handling when a suggestion ends before its menu has been displayed.

* **Tests**
  * Added regression coverage for suggestion menus without initialized state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->