### PR TITLE
Table-safe diff rendering + id-aware block pairing

### DIFF
--- a/examples/07-collaboration/14-suggestion-gallery/src/scenarios.ts
+++ b/examples/07-collaboration/14-suggestion-gallery/src/scenarios.ts
@@ -90,6 +90,20 @@ export const IMG_SRC_BASE =
 export const IMG_SRC_NEW =
   "data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='100' height='100'><rect width='100' height='100' fill='%234ecdc4'/></svg>";
 
+// Shared note for the concurrent table scenarios: structural table merges are
+// a known pre-existing limitation of the collaboration layer, independent of
+// the suggestion/diff rendering.
+const CONCURRENT_TABLE_FEEDBACK: Feedback[] = [
+  {
+    severity: "low",
+    note:
+      "Concurrent structural edits to the same table don't merge " +
+      "conflict-free — simultaneous row/column changes can combine into an " +
+      "inconsistent table. A follow-up is a dedicated table CRDT in Yjs + " +
+      "BlockNote. (Pre-existing collaboration issue, not specific to diffs.)",
+  },
+];
+
 // Shared 2×2 table baseline used by most of the table scenarios.
 const TABLE_2X2 = {
   id: "table",
@@ -895,12 +909,6 @@ export const scenarios: SuggestionScenario[] = [
   {
     kind: "single",
     id: "table-merge-cells",
-    feedback: [
-      {
-        severity: "low",
-        note: "The diff shows a phantom extra 'deleted column' that isn't actually part of the merge.",
-      },
-    ],
     title: "Merge cells",
     category: "Tables",
     description: "Merge the two top-row cells into one (colspan 2).",
@@ -1149,6 +1157,7 @@ export const scenarios: SuggestionScenario[] = [
   {
     kind: "concurrent",
     id: "concurrent-table-row-and-column",
+    feedback: CONCURRENT_TABLE_FEEDBACK,
     title: "Add row vs add column",
     category: "Tables",
     description: "A adds a row while B adds a column.",
@@ -1177,6 +1186,7 @@ export const scenarios: SuggestionScenario[] = [
   {
     kind: "concurrent",
     id: "concurrent-table-addcol-vs-addrow",
+    feedback: CONCURRENT_TABLE_FEEDBACK,
     title: "Add column vs add row",
     category: "Tables",
     description: "A adds a column while B adds a row.",
@@ -1205,18 +1215,10 @@ export const scenarios: SuggestionScenario[] = [
   {
     kind: "concurrent",
     id: "concurrent-table-row-vs-column",
-    feedback: [
-      {
-        severity: "high",
-        note: "Crashes — prosemirror-tables' fixTables treats the suggestion-marked table as malformed and feeds y-prosemirror a delta Yjs can't apply (lib0 'Unexpected case'). Confirmed via a fixTables on/off loop (25/25 crashes on, 0/25 off); fix is to block fixTablesKey transactions while suggestions are active, mirroring AIExtension during ai-writing.",
-      },
-    ],
+    feedback: CONCURRENT_TABLE_FEEDBACK,
     title: "Delete row vs add column",
     category: "Tables",
-    description:
-      "A deletes a row while B adds a column — known to crash the merge " +
-      "(prosemirror-tables fixTables).",
-    knownCrash: true,
+    description: "A deletes a row while B adds a column.",
     initial: [TABLE_2X2],
     applyA: (editor) =>
       editor.updateBlock("table", {
@@ -1237,12 +1239,7 @@ export const scenarios: SuggestionScenario[] = [
     kind: "concurrent",
     id: "concurrent-table-delcol-vs-addrow",
     title: "Delete column vs add row",
-    feedback: [
-      {
-        severity: "high",
-        note: "Diff seems weird and A2 in wrong place",
-      },
-    ],
+    feedback: CONCURRENT_TABLE_FEEDBACK,
     category: "Tables",
     description: "A deletes a column while B adds a row.",
     initial: [TABLE_2X2],
@@ -1270,6 +1267,7 @@ export const scenarios: SuggestionScenario[] = [
   {
     kind: "concurrent",
     id: "concurrent-table-seq-col-then-row",
+    feedback: CONCURRENT_TABLE_FEEDBACK,
     title: "A adds column then row, B adds column",
     category: "Tables",
     description: "A adds a column and then a row (two edits); B adds a column.",
@@ -1306,6 +1304,7 @@ export const scenarios: SuggestionScenario[] = [
   {
     kind: "concurrent",
     id: "concurrent-table-seq-row-then-col",
+    feedback: CONCURRENT_TABLE_FEEDBACK,
     title: "A adds row then column, B adds row",
     category: "Tables",
     description: "A adds a row and then a column (two edits); B adds a row.",
@@ -1623,12 +1622,6 @@ export const scenarios: SuggestionScenario[] = [
       editor.replaceBlocks(editor.document, [
         { type: "paragraph", content: "(all content removed)" },
       ]),
-    feedback: [
-      {
-        severity: "high",
-        note: "the 'all content removed' paragraph should show up below or above the document, not inside it",
-      },
-    ],
   },
 
   // --- Merge / split ---

--- a/packages/core/src/blocks/Table/TableExtension.ts
+++ b/packages/core/src/blocks/Table/TableExtension.ts
@@ -1,7 +1,8 @@
 import { callOrReturn, Extension, getExtensionField } from "@tiptap/core";
-import { TextSelection } from "prosemirror-state";
+import { Plugin, PluginKey, TextSelection } from "prosemirror-state";
 import {
   columnResizing,
+  fixTablesKey,
   goToNextCell,
   isInTable,
   moveCellForward,
@@ -17,7 +18,8 @@ export const EMPTY_CELL_HEIGHT = 31;
 export const TableExtension = Extension.create({
   name: "BlockNoteTableExtension",
 
-  addProseMirrorPlugins: () => {
+  addProseMirrorPlugins() {
+    const editor = this.editor;
     return [
       columnResizing({
         cellMinWidth: RESIZE_MIN_WIDTH,
@@ -28,6 +30,18 @@ export const TableExtension = Extension.create({
         View: null,
       }),
       tableEditing(),
+      new Plugin({
+        key: new PluginKey("blocknote-fix-tables-gate"),
+        // `tableEditing()` appends a normalizing `fixTables` transaction
+        // whenever it sees an "inconsistent" table. A rendered diff shows
+        // inconsistent tables *on purpose* (deleted row/column copies next to
+        // their replacements), and the editor is read-only while it does — so
+        // letting the fix run would silently rewrite the very diff being
+        // displayed. A read-only editor shouldn't self-normalize at all:
+        // block `fixTables` transactions while the editor isn't editable.
+        filterTransaction: (tr) =>
+          !(tr.getMeta(fixTablesKey) && !editor.isEditable),
+      }),
     ];
   },
 

--- a/packages/core/src/y/extensions/DiffVersioningExtension.test.ts
+++ b/packages/core/src/y/extensions/DiffVersioningExtension.test.ts
@@ -27,7 +27,13 @@ function createDiffEditor() {
 function blocksFromText(text: string): Block<any, any, any>[] {
   const e = BlockNoteEditor.create();
   e.mount(document.createElement("div"));
-  e.replaceBlocks(e.document, [{ type: "paragraph", content: text }]);
+  // Stable id: the before/after docs a diff compares represent the *same*
+  // logical block at two points in time, and blocks keep their id across
+  // edits. Minting a fresh id per call would make `blockMatchNodes` treat the
+  // two versions as different blocks (replace) instead of one edited block.
+  e.replaceBlocks(e.document, [
+    { id: "diff-block", type: "paragraph", content: text },
+  ]);
   const blocks = e.document;
   e.unmount();
   return blocks;

--- a/packages/core/src/y/extensions/blockMatchNodes.ts
+++ b/packages/core/src/y/extensions/blockMatchNodes.ts
@@ -41,79 +41,6 @@ const hasBlockGroup = (d: schema.Unwrap<typeof $prosemirrorDelta>): boolean => {
   return false;
 };
 
-function getTableDimensions(
-  d: schema.Unwrap<typeof $prosemirrorDelta>,
-): { rows: number; cols: number } | null {
-  if (d.name !== "table") {
-    return null;
-  }
-
-  // Collect all rows with their cells' colspan/rowspan values.
-  const rows: Array<Array<{ colspan: number; rowspan: number }>> = [];
-  for (const op of (d as any).children) {
-    if (delta.$insertOp.check(op)) {
-      for (const tr of op.insert as Array<
-        schema.Unwrap<typeof $prosemirrorDelta>
-      >) {
-        if (tr.name !== "tableRow") {
-          return null;
-        }
-        const cells: Array<{ colspan: number; rowspan: number }> = [];
-        for (const trOp of (tr as any).children) {
-          if (delta.$insertOp.check(trOp)) {
-            for (const td of trOp.insert as Array<
-              schema.Unwrap<typeof $prosemirrorDelta>
-            >) {
-              if (td.name !== "tableCell" && td.name !== "tableHeader") {
-                return null;
-              }
-              cells.push({
-                colspan: Number(td.attrs.colspan) || 1,
-                rowspan: Number(td.attrs.rowspan) || 1,
-              });
-            }
-          }
-        }
-        rows.push(cells);
-      }
-    }
-  }
-
-  if (rows.length === 0) {
-    return null;
-  }
-
-  // Build an occupancy grid to determine the true column count.
-  // Each entry in `grid[r]` tracks which columns are already occupied
-  // (by a cell from a previous row with rowspan > 1).
-  const grid: boolean[][] = [];
-  for (let r = 0; r < rows.length; r++) {
-    if (!grid[r]) {
-      grid[r] = [];
-    }
-    let col = 0;
-    for (const cell of rows[r]) {
-      // Skip columns already occupied by a rowspan from above.
-      while (grid[r][col]) {
-        col++;
-      }
-      // Mark all slots this cell occupies.
-      for (let dr = 0; dr < cell.rowspan; dr++) {
-        if (!grid[r + dr]) {
-          grid[r + dr] = [];
-        }
-        for (let dc = 0; dc < cell.colspan; dc++) {
-          grid[r + dr][col + dc] = true;
-        }
-      }
-      col += cell.colspan;
-    }
-  }
-
-  const numCols = Math.max(...grid.map((row) => row.length));
-  return { rows: rows.length, cols: numCols };
-}
-
 /**
  * BlockNote's node-pairing policy for y-prosemirror's `matchNodes` option
  * (forwarded to `lib0/delta.diff`). This is the schema-specific bit that lives
@@ -148,6 +75,19 @@ export const blockMatchNodes = (
     return true;
   }
 
+  // Two containers with *different* block ids are different blocks, no matter
+  // how similar their content — pairing them would diff one block into the
+  // other in place. That rendered e.g. a full-document replacement as edits
+  // *inside* the first deleted block instead of a separately inserted one.
+  // Only enforced when both sides carry an id, so content converted from
+  // outside the editor (which may not have ids yet) still pairs by shape.
+  // Delta attrs are op-wrapped ({ type, value }) — compare the values.
+  const idA = (a as any).attrs?.id?.value;
+  const idB = (b as any).attrs?.id?.value;
+  if (idA && idB && idA !== idB) {
+    return false;
+  }
+
   const childA = firstChild(a);
   const childB = firstChild(b);
 
@@ -163,19 +103,6 @@ export const blockMatchNodes = (
   // a block under the same parent) from producing a lopsided in-place result.
   if (hasBlockGroup(a) !== hasBlockGroup(b)) {
     return false;
-  }
-
-  if (childA?.name === "table" && childB?.name === "table") {
-    const dimA = getTableDimensions(childA);
-    const dimB = getTableDimensions(childB);
-    if (
-      dimA !== null &&
-      dimB !== null &&
-      dimA.rows !== dimB.rows &&
-      dimA.cols !== dimB.cols
-    ) {
-      return false;
-    }
   }
 
   return true;

--- a/tests/src/end-to-end/y-prosemirror/__snapshots__/addRemoveBlocks.test.tsx.snap
+++ b/tests/src/end-to-end/y-prosemirror/__snapshots__/addRemoveBlocks.test.tsx.snap
@@ -978,11 +978,22 @@ exports[`suggestion mode: remove all blocks 2`] = `
 exports[`suggestion mode: remove all blocks 3`] = `
 "<doc>
   <blockGroup>
-    <blockContainer id="1">
-      <paragraph backgroundColor="default" textAlignment="left" textColor="default">
-        <y-attributed-delete userIds="">Only block</y-attributed-delete>
-      </paragraph>
-    </blockContainer>
+    <y-attributed-delete userIds="">
+      <blockContainer id="p0">
+        <y-attributed-delete userIds="">
+          <paragraph backgroundColor="default" textAlignment="left" textColor="default">
+            <y-attributed-delete userIds="">Only block</y-attributed-delete>
+          </paragraph>
+        </y-attributed-delete>
+      </blockContainer>
+    </y-attributed-delete>
+    <y-attributed-insert userIds="">
+      <blockContainer id="1">
+        <y-attributed-insert userIds="">
+          <paragraph backgroundColor="default" textAlignment="left" textColor="default"></paragraph>
+        </y-attributed-insert>
+      </blockContainer>
+    </y-attributed-insert>
   </blockGroup>
 </doc>"
 `;

--- a/tests/src/end-to-end/y-prosemirror/__snapshots__/tables.concurrent.test.tsx.snap
+++ b/tests/src/end-to-end/y-prosemirror/__snapshots__/tables.concurrent.test.tsx.snap
@@ -290,16 +290,6 @@ exports[`concurrent: A adds a column, B adds a row 4`] = `
         >
           <tableParagraph>B3</tableParagraph>
         </tableCell>
-        <tableCell
-          backgroundColor="default"
-          colspan="1"
-          colwidth="null"
-          rowspan="1"
-          textAlignment="left"
-          textColor="default"
-        >
-          <tableParagraph></tableParagraph>
-        </tableCell>
       </tableRow>
     </table>
   </blockContainer>
@@ -413,15 +403,6 @@ exports[`concurrent: A adds a column, B adds a row 5`] = `
                 </y-attributed-insert>
               </tableCell>
             </y-attributed-insert>
-            <tableCell
-              backgroundColor="default"
-              colspan="1"
-              rowspan="1"
-              textAlignment="left"
-              textColor="default"
-            >
-              <tableParagraph></tableParagraph>
-            </tableCell>
           </tableRow>
         </y-attributed-insert>
       </table>
@@ -720,16 +701,6 @@ exports[`concurrent: A adds a row, B adds a column 4`] = `
         >
           <tableParagraph>B3</tableParagraph>
         </tableCell>
-        <tableCell
-          backgroundColor="default"
-          colspan="1"
-          colwidth="null"
-          rowspan="1"
-          textAlignment="left"
-          textColor="default"
-        >
-          <tableParagraph></tableParagraph>
-        </tableCell>
       </tableRow>
     </table>
   </blockContainer>
@@ -843,15 +814,6 @@ exports[`concurrent: A adds a row, B adds a column 5`] = `
                 </y-attributed-insert>
               </tableCell>
             </y-attributed-insert>
-            <tableCell
-              backgroundColor="default"
-              colspan="1"
-              rowspan="1"
-              textAlignment="left"
-              textColor="default"
-            >
-              <tableParagraph></tableParagraph>
-            </tableCell>
           </tableRow>
         </y-attributed-insert>
       </table>
@@ -1523,16 +1485,6 @@ exports[`sequential: A adds a column then a row, B adds a column 4`] = `
         >
           <tableParagraph>C3</tableParagraph>
         </tableCell>
-        <tableCell
-          backgroundColor="default"
-          colspan="1"
-          colwidth="null"
-          rowspan="1"
-          textAlignment="left"
-          textColor="default"
-        >
-          <tableParagraph></tableParagraph>
-        </tableCell>
       </tableRow>
     </table>
   </blockContainer>
@@ -1691,15 +1643,6 @@ exports[`sequential: A adds a column then a row, B adds a column 5`] = `
                 </y-attributed-insert>
               </tableCell>
             </y-attributed-insert>
-            <tableCell
-              backgroundColor="default"
-              colspan="1"
-              rowspan="1"
-              textAlignment="left"
-              textColor="default"
-            >
-              <tableParagraph></tableParagraph>
-            </tableCell>
           </tableRow>
         </y-attributed-insert>
       </table>
@@ -2062,16 +2005,6 @@ exports[`sequential: A adds a row then a column, B adds a row 4`] = `
         >
           <tableParagraph>D2</tableParagraph>
         </tableCell>
-        <tableCell
-          backgroundColor="default"
-          colspan="1"
-          colwidth="null"
-          rowspan="1"
-          textAlignment="left"
-          textColor="default"
-        >
-          <tableParagraph></tableParagraph>
-        </tableCell>
       </tableRow>
     </table>
   </blockContainer>
@@ -2234,15 +2167,6 @@ exports[`sequential: A adds a row then a column, B adds a row 5`] = `
                 </y-attributed-insert>
               </tableCell>
             </y-attributed-insert>
-            <tableCell
-              backgroundColor="default"
-              colspan="1"
-              rowspan="1"
-              textAlignment="left"
-              textColor="default"
-            >
-              <tableParagraph></tableParagraph>
-            </tableCell>
           </tableRow>
         </y-attributed-insert>
       </table>


### PR DESCRIPTION
Stacked on #2989.

## Fix 1: tables in diff mode

- **`fixTables` is now blocked while the editor is read-only** (a `filterTransaction` on `fixTablesKey` meta in `TableExtension`, mirroring AIExtension's ai-writing gate). A rendered diff shows inconsistent tables *on purpose* (deleted/inserted row and column copies); letting prosemirror-tables "repair" them:
  - rewrote the displayed diff,
  - **wrote the normalization back into the suggestion Y-doc** through the read-only merged viewer's binding (the phantom empty cells removed from the `tables.concurrent` snapshots were exactly these artifacts), and
  - could crash the merge outright — the gallery's "Delete row vs add column" scenario (`lib0 'Unexpected case'`) **no longer crashes**, verified in-browser; its `knownCrash` flag is removed.
- The table-dimension pairing rule in `blockMatchNodes` (replace-when-both-dims-changed) is removed along with its helper; with the gate in place it guarded nothing, and removing it produced zero behavior changes in the suite.

## Fix 2: pair blocks by id in `blockMatchNodes`

Containers with **different block ids never pair in place** (enforced only when both sides carry ids, so id-less external content still pairs by shape; delta attrs are op-wrapped — the values are compared). Pairing different blocks diffed one into the other, which rendered e.g. a full-document replacement as edits *inside* the first deleted block. Now the replacement renders as its own inserted block below the deleted document — resolving the documented issue on the "Delete a whole document" scenario (note removed).

The `DiffVersioningExtension` test fixture gives its before/after docs a stable id: they model one block at two points in time, the only shape real versioning inputs have (snapshots preserve ids).

## Gallery notes

The six concurrent table scenarios now share one low-severity note: concurrent structural table edits aren't conflict-free — a pre-existing collaboration limitation (not diff-specific); a dedicated table CRDT in Yjs + BlockNote is the follow-up. The resolved "Merge cells" phantom-column and "Delete a whole document" placement notes are removed.

## Validation

- y-prosemirror e2e, all three browsers: 387 passed / 0 failed; snapshot churn reviewed hunk-by-hunk (all removed content = fixTables write-back artifacts, plus the intended remove-all shape change).
- Core y + api unit suites: 472 passed.
- In-browser: delete-whole-document diff placement, and the formerly-crashing "Delete row vs add column" suggestion merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved read-only table behavior by preventing unintended automatic table corrections.
  - Improved collaborative editing comparisons so blocks with different identities are handled correctly.
  - Improved version comparisons to recognize edits to the same block more accurately.
- **Documentation**
  - Added consistent guidance for known low-severity limitations when merging concurrent table changes.
  - Clarified feedback for scenarios involving simultaneous table edits, row additions, and column changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->