### PR TITLE
fix: Mod+A not selecting all when first block is a check list item (BLO-1314)

### DIFF
--- a/packages/core/src/extensions/tiptap-extensions/KeyboardShortcuts/KeyboardShortcutsExtension.test.ts
+++ b/packages/core/src/extensions/tiptap-extensions/KeyboardShortcuts/KeyboardShortcutsExtension.test.ts
@@ -1,6 +1,8 @@
 import { Selection, TextSelection } from "prosemirror-state";
 import { describe, expect, it } from "vite-plus/test";
 
+import { getBlockInfo } from "../../../api/getBlockInfoFromPos.js";
+import { getNodeById } from "../../../api/nodeUtil.js";
 import { BlockNoteSchema } from "../../../blocks/BlockNoteSchema.js";
 import { defaultBlockSpecs } from "../../../blocks/defaultBlocks.js";
 import { BlockNoteEditor } from "../../../editor/BlockNoteEditor.js";
@@ -146,6 +148,15 @@ describe("KeyboardShortcutsExtension Mod-a (select all)", () => {
     view.someProp("handleKeyDown", (handler) => handler(view, event));
   }
 
+  function pressBackspace(editor: BlockNoteEditor<any, any, any>) {
+    const view = editor._tiptapEditor.view;
+    const event = new KeyboardEvent("keydown", {
+      key: "Backspace",
+      code: "Backspace",
+    });
+    view.someProp("handleKeyDown", (handler) => handler(view, event));
+  }
+
   function expectWholeDocSelected(editor: BlockNoteEditor<any, any, any>) {
     const { selection, doc } = editor._tiptapEditor.state;
     // Select-all spans all content as a `TextSelection` (from the first
@@ -155,7 +166,27 @@ describe("KeyboardShortcutsExtension Mod-a (select all)", () => {
     expect(selection.to).toBe(Selection.atEnd(doc).to);
   }
 
-  it("selects the whole document", () => {
+  function expectBlockContentSelected(
+    editor: BlockNoteEditor<any, any, any>,
+    blockId: string,
+  ) {
+    const { selection, doc } = editor._tiptapEditor.state;
+    const blockInfo = getBlockInfo(getNodeById(blockId, doc)!);
+    if (!blockInfo.isBlockContainer) {
+      throw new Error(`Block ${blockId} is not a block container`);
+    }
+    // The current block's content is selected as a `TextSelection` spanning its
+    // full content, without reaching into neighbouring blocks.
+    expect(selection).toBeInstanceOf(TextSelection);
+    expect(selection.from).toBe(blockInfo.blockContent.beforePos + 1);
+    expect(selection.to).toBe(blockInfo.blockContent.afterPos - 1);
+  }
+
+  // Each test walks the full Notion-style flow: the first `Mod-a` selects the
+  // current block, the second expands to the whole document, and Backspace
+  // clears it (issue #2973 - the bug was specific to documents starting with a
+  // check list item).
+  it("escalates the selection and clears a paragraph-first document", () => {
     const editor = createSelectAllEditor([
       { type: "paragraph", content: "First" },
       { type: "paragraph", content: "Second" },
@@ -163,24 +194,102 @@ describe("KeyboardShortcutsExtension Mod-a (select all)", () => {
     editor.setTextCursorPosition("block-0", "end");
 
     pressSelectAll(editor);
+    expectBlockContentSelected(editor, "block-0");
 
+    pressSelectAll(editor);
     expectWholeDocSelected(editor);
+
+    pressBackspace(editor);
+    expect(editor.document).toEqual([
+      expect.objectContaining({ type: "paragraph", content: [] }),
+    ]);
 
     editor._tiptapEditor.destroy();
   });
 
-  it("selects the whole document when the first block is a check list item", () => {
+  it("escalates the selection and clears a check-list-first document", () => {
     const editor = createSelectAllEditor([
       { type: "checkListItem", content: "First" },
       { type: "paragraph", content: "Second" },
     ]);
-    // Place the cursor in a later block to make sure select-all still spans the
-    // whole document, not just the current block.
+    // Cursor starts in a later block to check select-all still spans the whole
+    // document, not just the current block.
     editor.setTextCursorPosition("block-1", "end");
 
     pressSelectAll(editor);
+    expectBlockContentSelected(editor, "block-1");
 
+    pressSelectAll(editor);
     expectWholeDocSelected(editor);
+
+    pressBackspace(editor);
+    expect(editor.document).toEqual([
+      expect.objectContaining({ type: "paragraph", content: [] }),
+    ]);
+
+    editor._tiptapEditor.destroy();
+  });
+
+  it("escalates the selection and clears an all-check-list document", () => {
+    const editor = createSelectAllEditor([
+      { type: "checkListItem", content: "First" },
+      { type: "checkListItem", content: "Second" },
+    ]);
+    editor.setTextCursorPosition("block-0", "end");
+
+    pressSelectAll(editor);
+    expectBlockContentSelected(editor, "block-0");
+
+    pressSelectAll(editor);
+    expectWholeDocSelected(editor);
+
+    pressBackspace(editor);
+    expect(editor.document).toEqual([
+      expect.objectContaining({ type: "paragraph", content: [] }),
+    ]);
+
+    editor._tiptapEditor.destroy();
+  });
+
+  it("escalates the selection and clears a document ending in a check list item", () => {
+    const editor = createSelectAllEditor([
+      { type: "paragraph", content: "First" },
+      { type: "checkListItem", content: "Second" },
+    ]);
+    editor.setTextCursorPosition("block-0", "end");
+
+    pressSelectAll(editor);
+    expectBlockContentSelected(editor, "block-0");
+
+    pressSelectAll(editor);
+    expectWholeDocSelected(editor);
+
+    pressBackspace(editor);
+    expect(editor.document).toEqual([
+      expect.objectContaining({ type: "paragraph", content: [] }),
+    ]);
+
+    editor._tiptapEditor.destroy();
+  });
+
+  it("keeps the block type when clearing a single-block document", () => {
+    const editor = createSelectAllEditor([
+      { type: "checkListItem", content: "Only" },
+    ]);
+    editor.setTextCursorPosition("block-0", "end");
+
+    pressSelectAll(editor);
+    expectBlockContentSelected(editor, "block-0");
+
+    pressSelectAll(editor);
+    expectWholeDocSelected(editor);
+
+    // A single block can only ever have its content selected, so Backspace
+    // clears the content but (correctly) leaves the block type unchanged.
+    pressBackspace(editor);
+    expect(editor.document).toEqual([
+      expect.objectContaining({ type: "checkListItem", content: [] }),
+    ]);
 
     editor._tiptapEditor.destroy();
   });

--- a/packages/core/src/extensions/tiptap-extensions/KeyboardShortcuts/KeyboardShortcutsExtension.test.ts
+++ b/packages/core/src/extensions/tiptap-extensions/KeyboardShortcuts/KeyboardShortcutsExtension.test.ts
@@ -1,3 +1,4 @@
+import { Selection, TextSelection } from "prosemirror-state";
 import { describe, expect, it } from "vite-plus/test";
 
 import { BlockNoteSchema } from "../../../blocks/BlockNoteSchema.js";
@@ -109,6 +110,81 @@ function getTextContent(editor: BlockNoteEditor<any, any, any>) {
   });
   return text;
 }
+
+describe("KeyboardShortcutsExtension Mod-a (select all)", () => {
+  // BlockNote disables TipTap's core extensions, so it has no default `Mod-a`
+  // binding and select-all used to rely on the browser's native behaviour. That
+  // native select-all collapses to a cursor when the editor's first element is
+  // non-editable - e.g. the checkbox `<div>` of a check list item as the first
+  // block - so `Mod-a` is now handled explicitly. These tests exercise the
+  // keymap path (not native selection) and would collapse before the fix.
+  function createSelectAllEditor(
+    blocks: { type: "paragraph" | "checkListItem"; content: string }[],
+  ) {
+    const editor = BlockNoteEditor.create({
+      schema,
+      initialContent: blocks.map((block, index) => ({
+        id: `block-${index}`,
+        ...block,
+      })),
+    });
+    editor.mount(document.createElement("div"));
+    return editor;
+  }
+
+  // Dispatches a real `Mod-a` keydown through ProseMirror's `handleKeyDown`, the
+  // path browsers use to invoke the keymap. TipTap's `keyboardShortcut` command
+  // doesn't reliably simulate modifier combos in jsdom, and prosemirror-keymap
+  // resolves `Mod` to `Ctrl` outside of a Mac environment (jsdom reports none).
+  function pressSelectAll(editor: BlockNoteEditor<any, any, any>) {
+    const view = editor._tiptapEditor.view;
+    const event = new KeyboardEvent("keydown", {
+      key: "a",
+      code: "KeyA",
+      ctrlKey: true,
+    });
+    view.someProp("handleKeyDown", (handler) => handler(view, event));
+  }
+
+  function expectWholeDocSelected(editor: BlockNoteEditor<any, any, any>) {
+    const { selection, doc } = editor._tiptapEditor.state;
+    // Select-all spans all content as a `TextSelection` (from the first
+    // selectable position to the last), not an `AllSelection`.
+    expect(selection).toBeInstanceOf(TextSelection);
+    expect(selection.from).toBe(Selection.atStart(doc).from);
+    expect(selection.to).toBe(Selection.atEnd(doc).to);
+  }
+
+  it("selects the whole document", () => {
+    const editor = createSelectAllEditor([
+      { type: "paragraph", content: "First" },
+      { type: "paragraph", content: "Second" },
+    ]);
+    editor.setTextCursorPosition("block-0", "end");
+
+    pressSelectAll(editor);
+
+    expectWholeDocSelected(editor);
+
+    editor._tiptapEditor.destroy();
+  });
+
+  it("selects the whole document when the first block is a check list item", () => {
+    const editor = createSelectAllEditor([
+      { type: "checkListItem", content: "First" },
+      { type: "paragraph", content: "Second" },
+    ]);
+    // Place the cursor in a later block to make sure select-all still spans the
+    // whole document, not just the current block.
+    editor.setTextCursorPosition("block-1", "end");
+
+    pressSelectAll(editor);
+
+    expectWholeDocSelected(editor);
+
+    editor._tiptapEditor.destroy();
+  });
+});
 
 describe("KeyboardShortcutsExtension hardBreakShortcut", () => {
   it("inserts a hard break on Shift-Enter by default", () => {

--- a/packages/core/src/extensions/tiptap-extensions/KeyboardShortcuts/KeyboardShortcutsExtension.ts
+++ b/packages/core/src/extensions/tiptap-extensions/KeyboardShortcuts/KeyboardShortcutsExtension.ts
@@ -1,6 +1,6 @@
 import { Extension } from "@tiptap/core";
 import { Fragment, Node } from "prosemirror-model";
-import { TextSelection } from "prosemirror-state";
+import { Selection, TextSelection } from "prosemirror-state";
 
 import {
   getBottomNestedBlockInfo,
@@ -997,6 +997,20 @@ export const KeyboardShortcutsExtension = Extension.create<{
       "Mod-z": () => this.options.editor.undo(),
       "Mod-y": () => this.options.editor.redo(),
       "Shift-Mod-z": () => this.options.editor.redo(),
+      "Mod-a": () => {
+        const view = this.editor.view;
+        const { doc, tr } = view.state;
+        // Use a `TextSelection` from the document start to end as an `AllSelection` creates from/
+        // to positions outside a block, causing errors when calling e.g. `getBlock`.
+        const selection = TextSelection.between(
+          Selection.atStart(doc).$from,
+          Selection.atEnd(doc).$to,
+        );
+
+        view.dispatch(tr.setSelection(selection).scrollIntoView());
+
+        return true;
+      },
     };
   },
 });

--- a/packages/core/src/extensions/tiptap-extensions/KeyboardShortcuts/KeyboardShortcutsExtension.ts
+++ b/packages/core/src/extensions/tiptap-extensions/KeyboardShortcuts/KeyboardShortcutsExtension.ts
@@ -999,15 +999,43 @@ export const KeyboardShortcutsExtension = Extension.create<{
       "Shift-Mod-z": () => this.options.editor.redo(),
       "Mod-a": () => {
         const view = this.editor.view;
-        const { doc, tr } = view.state;
-        // Use a `TextSelection` from the document start to end as an `AllSelection` creates from/
-        // to positions outside a block, causing errors when calling e.g. `getBlock`.
-        const selection = TextSelection.between(
-          Selection.atStart(doc).$from,
-          Selection.atEnd(doc).$to,
-        );
+        const { doc, selection, tr } = view.state;
 
-        view.dispatch(tr.setSelection(selection).scrollIntoView());
+        // Follows Notion: the first `Mod-a` selects the current block's content,
+        // and any subsequent `Mod-a` expands the selection to the whole
+        // document. We use `TextSelection`s rather than an `AllSelection` for the
+        // whole-document case as the latter creates from/to positions outside a
+        // block, causing errors when calling e.g. `getBlock`.
+        const blockInfo = getBlockInfoFromSelection(view.state);
+        const blockContentRange = blockInfo.isBlockContainer
+          ? {
+              from: blockInfo.blockContent.beforePos + 1,
+              to: blockInfo.blockContent.afterPos - 1,
+            }
+          : undefined;
+
+        // Expands to the whole document when there's no selectable block content
+        // to select first, when the selection already extends beyond the current
+        // block, or when the current block's content is already fully selected.
+        const selectWholeDoc =
+          blockContentRange === undefined ||
+          selection.from < blockContentRange.from ||
+          selection.to > blockContentRange.to ||
+          (selection.from === blockContentRange.from &&
+            selection.to === blockContentRange.to);
+
+        const nextSelection = selectWholeDoc
+          ? TextSelection.between(
+              Selection.atStart(doc).$from,
+              Selection.atEnd(doc).$to,
+            )
+          : TextSelection.create(
+              doc,
+              blockContentRange.from,
+              blockContentRange.to,
+            );
+
+        view.dispatch(tr.setSelection(nextSelection).scrollIntoView());
 
         return true;
       },

--- a/packages/math-block/src/block/createReactMathBlockSpec.test.tsx
+++ b/packages/math-block/src/block/createReactMathBlockSpec.test.tsx
@@ -264,12 +264,15 @@ describe("Math block source popup keyboard handling", () => {
       expect(isPopupOpen("math")).toBe(false);
 
       // Single-character keys are only blocked when no Ctrl/Cmd is held, so
-      // shortcuts pass through - keeping copy/select-all/find working.
+      // shortcuts pass through - keeping copy/find working.
       // (Cut/paste also pass through; that's a known limitation.)
       expect(pressKey("c", { ctrlKey: true })).toBe(false);
-      expect(pressKey("a", { ctrlKey: true })).toBe(false);
       expect(pressKey("f", { ctrlKey: true })).toBe(false);
       expect(pressKey("v", { metaKey: true })).toBe(false);
+      // Ctrl/Cmd-a is the exception: select-all is handled explicitly by
+      // the global keymap (see KeyboardShortcutsExtension), not deferred to the
+      // browser, so it reports as handled rather than passing through.
+      expect(pressKey("a", { ctrlKey: true })).toBe(true);
     });
 
     it("defers deletion keys to the default while the popup is open", async () => {


### PR DESCRIPTION
# Summary

<!-- Briefly describe the feature being introduced. -->

This PR adds a proper Mod+A shortcut to select all blocks. Previously, this would defer to browser behaviour as we disable TipTap's own handling with `enableCoreExtensions: false`. This causes issues in some cases, like when the first block is a check list item.

Additionally, the behaviour is changed slightly. The first Mod+A press selects the full block, and pressing it again selects the whole document.

Closes #2973 

## Rationale

<!-- Explain the reasoning behind this feature and its benefits to the project. -->

This is a bug.

## Changes

<!-- List the major changes made in this pull request. -->

- Added explicit Mod+A handler.

## Impact

<!-- Discuss any potential impacts this feature may have on existing functionalities. -->

N/A

## Testing

<!-- Describe how the feature has been tested, including both automated and manual testing strategies. -->

Added unit tests.

## Screenshots/Video

<!-- Include screenshots or video demonstrating the new feature, if applicable. -->

N/A

## Checklist

- [X] Code follows the project's coding standards.
- [X] Unit tests covering the new feature have been added.
- [X] All existing tests pass.
- [ ] The documentation has been updated to reflect the new feature

## Additional Notes

<!-- Any additional information or context relevant to this PR. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the select-all shortcut to select the current block on the first press and the entire document on the second.
  * Improved selection behavior for paragraphs, checklists, and documents containing only checklist items.
  * Ensured selections remain within valid content boundaries and preserve checklist formatting.
  * Pressing Backspace now correctly clears the active selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->