### PR TITLE
fix(react): keep the inline math popup unclipped in table cells

### DIFF
--- a/packages/core/src/editor/Block.css
+++ b/packages/core/src/editor/Block.css
@@ -579,6 +579,8 @@ NESTED BLOCKS
 .bn-inline-content-section
   .bn-preview-with-source-popup[data-open="true"]
   .bn-source-block-popup {
+  margin-top: 0;
+  z-index: calc(var(--bn-ui-base-z-index, 0) + 15);
   width: 300px;
 }
 

--- a/packages/react/src/blocks/SourceWithPreview/SourceWithPreview.tsx
+++ b/packages/react/src/blocks/SourceWithPreview/SourceWithPreview.tsx
@@ -1,5 +1,12 @@
 import { BlockNoteEditor } from "@blocknote/core";
-import { MouseEvent, ReactNode, useId, useRef } from "react";
+import {
+  autoUpdate,
+  flip,
+  offset,
+  shift,
+  useFloating,
+} from "@floating-ui/react";
+import { MouseEvent, ReactNode, useCallback, useId, useRef } from "react";
 import { MdKeyboardReturn } from "react-icons/md";
 
 import { PreviewPlaceholder } from "./PreviewPlaceholder.js";
@@ -129,6 +136,20 @@ export const SourceWithPreview = (
       errorPreview
     );
 
+  const { refs, floatingStyles } = useFloating({
+    placement: "bottom-start",
+    strategy: "fixed",
+    middleware: [offset(4), flip(), shift({ padding: 8 })],
+    whileElementsMounted: autoUpdate,
+  });
+
+  const isFloating = inline === true && popup.isOpen;
+
+  const setAnchor = useCallback(
+    (node: HTMLElement | null) => refs.setPositionReference(node),
+    [refs],
+  );
+
   // Links the source input to the render error so screen readers announce it
   // when the input is focused.
   const errorId = useId();
@@ -182,13 +203,18 @@ export const SourceWithPreview = (
       <PreviewContainer
         className="bn-preview-container"
         contentEditable={false}
+        ref={setAnchor}
         // When no source code is available, the "Add source" button should have the appropriate role.
         role={previewIsButton ? "button" : undefined}
         onClick={handlePreviewClick}
       >
         {previewContent}
       </PreviewContainer>
-      <div className="bn-source-block-popup">
+      <div
+        className="bn-source-block-popup"
+        ref={isFloating ? refs.setFloating : undefined}
+        style={isFloating ? floatingStyles : undefined}
+      >
         <div className="bn-code-block-source-popup-body">
           <pre
             className={


### PR DESCRIPTION
# Summary

Editing an inline equation inside a table cell was cut off. The source popup opens below the equation preciew, which in a table cell is outside the table, and the table clips whatever leaves it, so the input and its OK button were partly or entirely invisible.

## Changes

- Position the inline source popup with floating-ui using a `fixed` strategy, so no ancestor's `overflow` can clip it.
- Raise the open inline popup above the table handles, which are portalled outside the editor at a higher `z-index` and would otherwise paint over it.

## Impact

- Inline source popups (math, diagram) now render fully in table cells.

### Before
https://github.com/user-attachments/assets/6876218b-bc60-4ebb-bc71-62c12f1bf520

### After
https://github.com/user-attachments/assets/5a2e95c6-c231-4790-8f98-8c99e1c1402c


## Testing
Current test pass, and i verified in the browser.

## Checklist

- [x] Code follows the project's coding standards.
- [ ] Unit tests covering the new feature have been added.
- [x] All existing tests pass.
- [ ] The documentation has been updated to reflect the new feature

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved positioning for inline source previews.
  * Prevented preview popups from being clipped or appearing off-screen.
  * Added automatic repositioning as surrounding content or viewport conditions change.
  * Improved popup layering and removed unwanted spacing when previews open.
  * Ensured previews remain correctly anchored to their associated content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->