### PR TITLE
fix(core): use the default language for a code block typed without one

### DIFF
--- a/packages/core/src/blocks/Code/block.test.ts
+++ b/packages/core/src/blocks/Code/block.test.ts
@@ -82,12 +82,12 @@ describe("Code block input rule", () => {
     expect((block.props as any).language).toBe("ts");
   });
 
-  it("converts ``` + space into a codeBlock with empty language", () => {
+  it("converts ``` + space into a codeBlock with the default language", () => {
     typeString(editor, "``` ");
 
     const block = editor.document[0];
     expect(block.type).toBe("codeBlock");
-    expect((block.props as any).language).toBe("");
+    expect((block.props as any).language).toBe("text");
   });
 
   it("converts ```javascript + space into a codeBlock", () => {
@@ -138,13 +138,13 @@ describe("Code block input rule", () => {
     expect(block.content).toEqual([]);
   });
 
-  it("converts ``` + Enter into a codeBlock with empty language", () => {
+  it("converts ``` + Enter into a codeBlock with the default language", () => {
     typeString(editor, "```");
     pressKey(editor, "Enter");
 
     const block = editor.document[0];
     expect(block.type).toBe("codeBlock");
-    expect((block.props as any).language).toBe("");
+    expect((block.props as any).language).toBe("text");
   });
 
   it("converts ```javascript + Enter into a codeBlock", () => {

--- a/packages/core/src/blocks/Code/helpers/extensions/CodeKeyboardShortcutsExtension.ts
+++ b/packages/core/src/blocks/Code/helpers/extensions/CodeKeyboardShortcutsExtension.ts
@@ -103,8 +103,13 @@ export const CodeKeyboardShortcutsExtension =
           find: /^```(.*?)\s$/,
           replace: ({ match }) => {
             const languageName = match[1].trim();
+            // Without a language suffix there is nothing to resolve, so fall
+            // back to the default rather than storing an empty language that
+            // no highlighter can render.
             const attributes = {
-              language: getLanguageId(options, languageName) ?? languageName,
+              language:
+                getLanguageId(options, languageName) ??
+                (languageName || options.defaultLanguage || "text"),
             };
 
             return {


### PR DESCRIPTION
Fixes #3005.

Typing ` ``` ` with no language suffix stored an **empty string** as the code block's
language. The input rule fell back to the raw match when there was nothing to resolve:

```ts
const languageName = match[1].trim();          // "" for a bare ```
const attributes = {
  language: getLanguageId(options, languageName) ?? languageName,   // -> ""
};
```

`createLanguageSelect` then threw ``Language  is not supported.`` — the double space in the
message is the empty language — and because it threw partway through creating the block,
the block was left half-initialised, which is what produced the misplaced cursor and the
broken Backspace/Delete the reporter saw afterwards.

The fix falls back to the configured `defaultLanguage` (`"text"`) when no language is
given, so the block is created with something a highlighter can actually render.

## Two existing tests encoded the bug

`"converts ``` + space into a codeBlock with empty language"` and the `+ Enter` equivalent
both asserted `language === ""`. They now assert the default, and they are the regression
tests — both fail on `main` with `expected '' to be 'text'`.

## One case I deliberately did not change

An **unrecognised** language still passes through as-is: ` ```notalanguage ` produces
`language: "notalanguage"`, which `createLanguageSelect` will also reject. I left that
alone because it is a different call from the empty case — there the user typed a name and
silently replacing it with `text` would discard what they asked for, and a custom
highlighter registered later could legitimately support it. Happy to handle it here, or in
its own issue, if you would rather it fall back too.

## Testing

```
packages/core: pnpm vp test --run src/blocks/Code/block.test.ts   # 19 passed
packages/core: pnpm vp test --run                                 # 759 passed, 9 skipped
```

`pnpm vp run lint` reports 49 errors both with and without this change — all
`Cannot find module '@blocknote/…'` from unbuilt workspace packages, none in the files
touched here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Code blocks created without a language now consistently default to `text`.
  * Unrecognized language suffixes fall back to the configured default language instead of producing an empty language value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->