### PR TITLE
fix(core): stop schema.extend() mutating the shared default specs

### DIFF
--- a/packages/core/src/schema/schema.test.ts
+++ b/packages/core/src/schema/schema.test.ts
@@ -1,0 +1,110 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { afterEach, describe, expect, it } from "vite-plus/test";
+
+import { BlockNoteSchema } from "../blocks/BlockNoteSchema.js";
+import {
+  defaultBlockSpecs,
+  defaultInlineContentSpecs,
+  defaultStyleSpecs,
+} from "../blocks/defaultBlocks.js";
+import { BlockNoteEditor } from "../editor/BlockNoteEditor.js";
+import { createExtension } from "../editor/BlockNoteExtension.js";
+import { createBlockSpec } from "./blocks/createSpec.js";
+import { createInlineContentSpec } from "./inlineContent/createSpec.js";
+import { createStyleSpec } from "./styles/createSpec.js";
+
+const editorsToCleanup: BlockNoteEditor<any, any, any>[] = [];
+
+afterEach(() => {
+  for (const editor of editorsToCleanup) {
+    editor.unmount();
+  }
+  editorsToCleanup.length = 0;
+});
+
+function createMountedEditor(
+  options: Parameters<typeof BlockNoteEditor.create>[0],
+) {
+  const editor = BlockNoteEditor.create(options);
+  editor.mount(document.createElement("div"));
+  editorsToCleanup.push(editor);
+  return editor;
+}
+
+// A block spec that registers an editor extension, like
+// `@blocknote/xl-multi-column`'s `ColumnBlock` does with its drop handler.
+const CustomBlockExtension = createExtension(() => ({
+  key: "customBlockExtension",
+}));
+
+const createCustomBlockSpec = createBlockSpec(
+  { type: "customBlock", propSchema: {}, content: "none" },
+  { render: () => ({ dom: document.createElement("div") }) },
+  [CustomBlockExtension()],
+);
+
+const customInlineContent = createInlineContentSpec(
+  { type: "customInlineContent", propSchema: {}, content: "none" },
+  { render: () => ({ dom: document.createElement("span") }) },
+);
+
+const customStyle = createStyleSpec(
+  { type: "customStyle", propSchema: "boolean" },
+  { render: () => ({ dom: document.createElement("span") }) },
+);
+
+describe("CustomBlockNoteSchema.extend", () => {
+  it("does not mutate the default specs shared by every default schema", () => {
+    const extended = BlockNoteSchema.create().extend({
+      blockSpecs: { customBlock: createCustomBlockSpec() },
+      inlineContentSpecs: { customInlineContent },
+      styleSpecs: { customStyle },
+    });
+
+    // The extended schema has the added specs...
+    expect(extended.blockSchema).toHaveProperty("customBlock");
+    expect(extended.inlineContentSchema).toHaveProperty("customInlineContent");
+    expect(extended.styleSchema).toHaveProperty("customStyle");
+
+    // ...the module-level defaults it was created from are untouched...
+    expect(defaultBlockSpecs).not.toHaveProperty("customBlock");
+    expect(defaultInlineContentSpecs).not.toHaveProperty("customInlineContent");
+    expect(defaultStyleSpecs).not.toHaveProperty("customStyle");
+
+    // ...so a default schema created afterwards doesn't inherit them.
+    const fresh = BlockNoteSchema.create();
+    expect(fresh.blockSchema).not.toHaveProperty("customBlock");
+    expect(fresh.inlineContentSchema).not.toHaveProperty("customInlineContent");
+    expect(fresh.styleSchema).not.toHaveProperty("customStyle");
+  });
+
+  it("does not mutate the spec objects passed to `create`", () => {
+    const blockSpecs = { paragraph: defaultBlockSpecs.paragraph };
+
+    BlockNoteSchema.create({ blockSpecs }).extend({
+      blockSpecs: { customBlock: createCustomBlockSpec() },
+    });
+
+    expect(Object.keys(blockSpecs)).toEqual(["paragraph"]);
+  });
+
+  it("keeps an extended schema's blocks and their extensions out of later default-schema editors", () => {
+    // Regression: extending a default schema used to write the added block
+    // specs into the shared default specs, so every editor created afterwards
+    // without an explicit schema silently got the extra block types - and the
+    // editor extensions they register (e.g. multi-column's drop handler).
+    const extendedEditor = createMountedEditor({
+      schema: BlockNoteSchema.create().extend({
+        blockSpecs: { customBlock: createCustomBlockSpec() },
+      }),
+    });
+    expect(extendedEditor.getExtension(CustomBlockExtension)).toBeDefined();
+
+    const defaultEditor = createMountedEditor({});
+    expect(defaultEditor.schema.blockSchema).not.toHaveProperty("customBlock");
+    expect(defaultEditor.pmSchema.nodes).not.toHaveProperty("customBlock");
+    expect(defaultEditor.getExtension(CustomBlockExtension)).toBeUndefined();
+  });
+});

--- a/packages/core/src/schema/schema.ts
+++ b/packages/core/src/schema/schema.ts
@@ -201,10 +201,19 @@ export class CustomBlockNoteSchema<
           [K in keyof AdditionalStyleSpecs]: AdditionalStyleSpecs[K]["config"];
         }
   > {
-    // Merge the new specs with existing ones
-    Object.assign(this.opts.blockSpecs, opts.blockSpecs);
-    Object.assign(this.opts.inlineContentSpecs, opts.inlineContentSpecs);
-    Object.assign(this.opts.styleSpecs, opts.styleSpecs);
+    // Merge the new specs with the existing ones into fresh objects. The
+    // existing spec objects must not be written to: `BlockNoteSchema.create()`
+    // passes the module-level default specs by reference, so mutating them
+    // would leak the added specs (and the editor extensions they register) into
+    // every default-schema editor created afterwards.
+    this.opts = {
+      blockSpecs: { ...this.opts.blockSpecs, ...opts.blockSpecs },
+      inlineContentSpecs: {
+        ...this.opts.inlineContentSpecs,
+        ...opts.inlineContentSpecs,
+      },
+      styleSpecs: { ...this.opts.styleSpecs, ...opts.styleSpecs },
+    };
 
     // Reinitialize the block specs with the merged specs
     const {


### PR DESCRIPTION
Fixes #2968

## Symptom

In the playground, open the multi-column example, then the basic example: you can now drop blocks side by side in the basic editor (no vertical drop indicator is shown, but columns get created).

## Root cause

Global state mutation, not editor cleanup. `CustomBlockNoteSchema.extend()` merged the added specs *into* the existing spec objects:

```ts
Object.assign(this.opts.blockSpecs, opts.blockSpecs);
```

`BlockNoteSchema.create()` with no arguments passes the module-level `defaultBlockSpecs` / `defaultInlineContentSpecs` / `defaultStyleSpecs` **by reference**, so `withMultiColumn(BlockNoteSchema.create())` wrote `column` and `columnList` into the shared defaults. Every editor created afterwards without an explicit schema (e.g. the basic example's `useCreateBlockNote()`) then inherited:

- the `column` / `columnList` node types, and
- the editor extensions those block specs register (`multiColumnDropHandler`, `columnResize`), which the `ExtensionManager` collects from `schema.blockSpecs`.

It did *not* inherit the `dropCursor: multiColumnDropCursor` editor option, which is why the drop works but no side indicator is shown.

This affects more than the playground: `BlockNoteSchema.create().extend({...})` is the pattern the docs recommend, and `withPageBreak` uses it too, so any app that creates one extended editor and later a default-schema editor got a polluted default schema.

## Fix

`extend()` merges into fresh objects and reassigns `this.opts` instead of writing into the inputs. This also stops it from mutating a caller-owned spec object passed to `create({ blockSpecs })`. The schema instance's builder semantics are unchanged (`extend` still mutates and returns `this`).

## Tests

New `packages/core/src/schema/schema.test.ts` with three cases — the shared defaults stay untouched, a caller-owned spec object stays untouched, and the end-to-end symptom (a default-schema editor created after an extended one has neither the block nor the extension it registers). All three fail on those assertions before the fix and pass after.

## Verification

- Core unit suite (766) and xl-multi-column unit suite (82) pass; `vp lint --type-aware` and `vp fmt` clean.
- Reproduced the real path in the source-aliased playground dev server (multi-column → "Basic Setup" via the sidebar, i.e. SPA navigation): **without** the fix the basic editor's schema has `["column","columnList"]` and tiptap extensions `["multiColumnDropHandler","columnResize","column","columnList"]`; **with** the fix all are empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed schema extensions so custom blocks, inline content, and styles no longer modify shared default configurations.
  - Prevented custom blocks and editor extensions from unexpectedly appearing in other editors using the default schema.

- **Tests**
  - Added coverage confirming schema extensions remain isolated and do not mutate provided specifications or later default-schema editors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->