### PR TITLE
fix(core): keep the browser's default link styling under CSS resets

### DIFF
--- a/docs/app/styles.css
+++ b/docs/app/styles.css
@@ -68,11 +68,6 @@ body {
   padding-block: 1rem;
 }
 
-.demo .bn-editor a {
-  color: revert;
-  text-decoration: revert;
-}
-
 .demo code.bn-inline-content {
   font-size: 1em;
   line-height: 1.5;

--- a/docs/content/docs/react/styling-theming/overriding-css.mdx
+++ b/docs/content/docs/react/styling-theming/overriding-css.mdx
@@ -42,3 +42,16 @@ BlockNote uses data attributes to target specific block types and properties:
 
 - `[data-content-type="blockType"]`: Targets blocks of type `blockType`.
 - `[data-propName="propValue"]`: Targets blocks with specific prop values. If the value is the same as the default value, the `data-propName` attribute will not be added.
+
+## Links
+
+Links in the editor use the browser's default link styling. BlockNote sets this with a rule of zero CSS specificity, so any `a` rule in your own stylesheet overrides it.
+
+Tailwind's preflight reset also targets `a`. In Tailwind v4 the reset lives in a cascade layer, so BlockNote's rule still applies. In Tailwind v3 the reset wins and links look like plain text; restore them with:
+
+```css
+.bn-editor a {
+  color: revert;
+  text-decoration: revert;
+}
+```

--- a/packages/core/src/editor/Block.css
+++ b/packages/core/src/editor/Block.css
@@ -106,6 +106,20 @@ NESTED BLOCKS
   font-family: monospace;
 }
 
+/* Links keep the browser's default look (#2398). CSS resets such as Tailwind's
+   preflight set `a { color: inherit; text-decoration: inherit }`, which makes
+   links indistinguishable from text; `revert` restores the user-agent values.
+   `:where()` keeps the specificity at zero, so any `a` rule a consumer writes
+   wins regardless of import order, while Tailwind v4's preflight still loses:
+   it lives in a cascade layer, and unlayered rules beat layered ones. Tailwind
+   v3's preflight is unlayered and still wins; the styling docs show the
+   override. The typst exporter mirrors the underline in its `show link` rule
+   (packages/xl-typst-exporter/src/typstExporter.ts). */
+:where(.bn-editor a) {
+  color: revert;
+  text-decoration: revert;
+}
+
 /* NESTED BLOCK ANIMATIONS (change in indent) */
 
 [data-prev-depth-change="1"] {

--- a/packages/diagram-block/src/typst-exporter/__snapshots__/withDiagramMappings/diagramDocument.typ
+++ b/packages/diagram-block/src/typst-exporter/__snapshots__/withDiagramMappings/diagramDocument.typ
@@ -22,7 +22,7 @@
 #set figure(numbering: none)
 #show figure: set block(breakable: false)
 #show figure.caption: set text(size: 9.6pt, fill: luma(110))
-#show link: set text(fill: rgb("#0b6e99"))
+#show link: it => underline(text(fill: rgb("#0b6e99"), it))
 #let _cb-box(fill, stroke, tick) = box(baseline: 0.13em, width: 0.9em, height: 0.9em, radius: 2pt, stroke: 0.08em + stroke, fill: fill, tick)
 #let _cb-unchecked = _cb-box(white, luma(148), none)
 #let _cb-checked = _cb-box(rgb("#3183c8"), rgb("#3183c8"), place(top + left, curve(

--- a/packages/math-block/src/typst-exporter/__snapshots__/withMathMappings/mathDocument.typ
+++ b/packages/math-block/src/typst-exporter/__snapshots__/withMathMappings/mathDocument.typ
@@ -22,7 +22,7 @@
 #set figure(numbering: none)
 #show figure: set block(breakable: false)
 #show figure.caption: set text(size: 9.6pt, fill: luma(110))
-#show link: set text(fill: rgb("#0b6e99"))
+#show link: it => underline(text(fill: rgb("#0b6e99"), it))
 #let _cb-box(fill, stroke, tick) = box(baseline: 0.13em, width: 0.9em, height: 0.9em, radius: 2pt, stroke: 0.08em + stroke, fill: fill, tick)
 #let _cb-unchecked = _cb-box(white, luma(148), none)
 #let _cb-checked = _cb-box(rgb("#3183c8"), rgb("#3183c8"), place(top + left, curve(

--- a/packages/xl-typst-exporter/src/__snapshots__/testDocument.typ
+++ b/packages/xl-typst-exporter/src/__snapshots__/testDocument.typ
@@ -22,7 +22,7 @@
 #set figure(numbering: none)
 #show figure: set block(breakable: false)
 #show figure.caption: set text(size: 9.6pt, fill: luma(110))
-#show link: set text(fill: rgb("#0b6e99"))
+#show link: it => underline(text(fill: rgb("#0b6e99"), it))
 #let _cb-box(fill, stroke, tick) = box(baseline: 0.13em, width: 0.9em, height: 0.9em, radius: 2pt, stroke: 0.08em + stroke, fill: fill, tick)
 #let _cb-unchecked = _cb-box(white, luma(148), none)
 #let _cb-checked = _cb-box(rgb("#3183c8"), rgb("#3183c8"), place(top + left, curve(

--- a/packages/xl-typst-exporter/src/typstExporter.ts
+++ b/packages/xl-typst-exporter/src/typstExporter.ts
@@ -558,8 +558,9 @@ export class TypstExporter<
       `#show figure: set block(breakable: false)`,
       // Figure captions: smaller, muted.
       `#show figure.caption: set text(size: 9.6pt, fill: luma(110))`,
-      // Links: BlockNote blue.
-      `#show link: set text(fill: rgb("#0b6e99"))`,
+      // Links: BlockNote blue, underlined like the editor's browser-default
+      // links (`:where(.bn-editor a)` in packages/core/src/editor/Block.css).
+      `#show link: it => underline(text(fill: rgb("#0b6e99"), it))`,
       // Check-list marker symbols (used as per-item list markers).
       CHECKBOX_MARKER_DEFS,
     ].join("\n");


### PR DESCRIPTION
## Summary

Links inside the editor lost their color and underline in apps that ship a CSS reset such as Tailwind's preflight (`a { color: inherit; text-decoration: inherit }`), including our own `/demo` page since the website redesign. Reported in #2398 (now discussion #2425).

- **Core stylesheet**: `:where(.bn-editor a) { color: revert; text-decoration: revert }` restores the user-agent link styling. `:where()` keeps the specificity at zero, so any `a` rule a consumer writes wins regardless of import order. Tailwind v4's preflight still loses because it lives in a cascade layer, and unlayered rules beat layered ones. Tailwind v3's preflight is unlayered and still wins; the docs show the one-line override. Consumers without a reset see no change.
- **Website**: drops the `.demo`-scoped workaround, which never covered the demo page.
- **Docs**: new "Links" section on Overriding CSS.
- **Typst exporter**: links are underlined like the editor's browser default (unit snapshots updated).

The shadcn skin keeps its own `.bn-shadcn .bn-editor a` rule, since that skin also serves Tailwind v3 apps where the zero-specificity rule loses.

## Verification

- Local docs app: the demo page's links compute to the browser default (blue, underlined) instead of the body text color. Example pages look the same as before.
- Cascade test against the live site's Tailwind v4 chunk: editor links revert in either stylesheet order, links outside the editor stay reset, a consumer rule inside `@layer base` loses, a bare consumer `a` rule wins, and `color-scheme: dark` yields the browser's dark link color.
- Docker e2e for static, typst PDF, links, theming, ariakit and shadcn: passing on chromium, firefox and webkit with no baseline changes.
- Lint, formatting and docs link validation are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Links in the BlockNote editor now display with browser-default visual styling, making them easier to distinguish from regular text.
  * Exported Typst documents now render links in BlockNote blue with underlining.

* **Documentation**
  * Added guidance on link styling, including compatibility considerations for Tailwind CSS and instructions for restoring link color and text decoration when needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->