### PR TITLE
fix: ignore only Dark Reader's writes in node views

### DIFF
--- a/packages/core/src/schema/blocks/createSpec.ts
+++ b/packages/core/src/schema/blocks/createSpec.ts
@@ -12,7 +12,7 @@ import {
   ExtensionFactoryInstance,
 } from "../../editor/BlockNoteExtension.js";
 import { nonFormattingMarks } from "../markGroups.js";
-import { ignoreNonContentMutations } from "../nodeViewMutations.js";
+import { ignoreDarkReaderMutations } from "../nodeViewMutations.js";
 import { PropSchema } from "../propTypes.js";
 import {
   getBlockFromNodeView,
@@ -279,10 +279,9 @@ export function addNodeAndExtensionsToSpec<
             applyNonSelectableBlockFix(typedNodeView, this.editor);
           }
 
-          // Ignores DOM mutations that don't affect the block's content, so
-          // that browser extensions which rewrite the DOM (e.g. Dark Reader)
-          // can't trigger an infinite re-render loop that freezes the tab.
-          ignoreNonContentMutations(typedNodeView);
+          // Ignores Dark Reader's rewrites of the block's DOM, which would
+          // otherwise trigger an infinite re-render loop that freezes the tab.
+          ignoreDarkReaderMutations(typedNodeView);
 
           // See explanation for why `update` is not implemented for NodeViews
           // https://github.com/TypeCellOS/BlockNote/pull/1904#discussion_r2313461464

--- a/packages/core/src/schema/inlineContent/createSpec.ts
+++ b/packages/core/src/schema/inlineContent/createSpec.ts
@@ -10,7 +10,7 @@ import {
 import { inlineContentToNodes } from "../../api/nodeConversions/blockToNode.js";
 import { nodeToCustomInlineContent } from "../../api/nodeConversions/nodeToBlock.js";
 import type { BlockNoteEditor } from "../../editor/BlockNoteEditor.js";
-import { ignoreNonContentMutations } from "../nodeViewMutations.js";
+import { ignoreDarkReaderMutations } from "../nodeViewMutations.js";
 import { propsToAttributes } from "../blocks/internal.js";
 import { nonFormattingMarks } from "../markGroups.js";
 import { Props } from "../propTypes.js";
@@ -366,10 +366,9 @@ export function createInlineContentSpec<
           inlineContentConfig.propSchema,
         );
 
-        // Ignores DOM mutations that don't affect the inline content, so that
-        // browser extensions which rewrite the DOM (e.g. Dark Reader) can't
-        // trigger an infinite re-render loop that freezes the tab.
-        ignoreNonContentMutations(nodeView);
+        // Ignores Dark Reader's rewrites of the inline content's DOM, which
+        // would otherwise trigger an infinite re-render loop that freezes the tab.
+        ignoreDarkReaderMutations(nodeView);
 
         return nodeView;
       };

--- a/packages/core/src/schema/nodeViewMutations.test.ts
+++ b/packages/core/src/schema/nodeViewMutations.test.ts
@@ -2,15 +2,20 @@ import { NodeView, ViewMutationRecord } from "@tiptap/pm/view";
 import { describe, expect, it } from "vite-plus/test";
 
 import {
-  ignoreNonContentMutations,
-  isNonContentMutation,
+  ignoreDarkReaderMutations,
+  isDarkReaderMutation,
 } from "./nodeViewMutations.js";
 
-function attributeMutation(target: Node): ViewMutationRecord {
+function attributeMutation(
+  target: Element,
+  attributeName: string,
+  oldValue: string | null = null,
+): ViewMutationRecord {
   return {
     type: "attributes",
     target,
-    attributeName: "style",
+    attributeName,
+    oldValue,
   } as unknown as ViewMutationRecord;
 }
 
@@ -25,97 +30,102 @@ function childListMutation(target: Node): ViewMutationRecord {
 
 const selectionMutation = { type: "selection" } as ViewMutationRecord;
 
-describe("isNonContentMutation", () => {
+describe("isDarkReaderMutation", () => {
   it("never ignores selection mutations", () => {
-    expect(isNonContentMutation(selectionMutation, null)).toBe(false);
-    expect(
-      isNonContentMutation(selectionMutation, document.createElement("div")),
-    ).toBe(false);
+    expect(isDarkReaderMutation(selectionMutation)).toBe(false);
   });
 
-  it("ignores everything for a node view without content", () => {
-    const target = document.createElement("span");
-    expect(isNonContentMutation(attributeMutation(target), null)).toBe(true);
-    expect(isNonContentMutation(childListMutation(target), null)).toBe(true);
-  });
-
-  it("ignores attribute mutations even inside the content DOM", () => {
-    const contentDOM = document.createElement("div");
+  it("ignores the attributes Dark Reader stamps on recoloured elements", () => {
     const span = document.createElement("span");
-    contentDOM.appendChild(span);
-
-    // e.g. Dark Reader rewriting the inline style of a highlight span.
-    expect(isNonContentMutation(attributeMutation(span), contentDOM)).toBe(
-      true,
-    );
+    span.setAttribute("data-darkreader-inline-bgcolor", "");
     expect(
-      isNonContentMutation(attributeMutation(contentDOM), contentDOM),
+      isDarkReaderMutation(
+        attributeMutation(span, "data-darkreader-inline-bgcolor"),
+      ),
     ).toBe(true);
   });
 
-  it("reads content mutations inside the content DOM", () => {
-    const contentDOM = document.createElement("div");
-    const textNode = document.createTextNode("hello");
-    contentDOM.appendChild(textNode);
-
-    // childList directly on the content DOM (e.g. a node inserted while typing).
+  it("ignores inline style writes that add or remove Dark Reader declarations", () => {
+    const span = document.createElement("span");
+    span.setAttribute(
+      "style",
+      "color: #f00; --darkreader-inline-color: #ff8080;",
+    );
+    // Added: the old value had none.
     expect(
-      isNonContentMutation(childListMutation(contentDOM), contentDOM),
-    ).toBe(false);
-    // characterData-style mutation on a text node inside the content DOM.
-    expect(isNonContentMutation(childListMutation(textNode), contentDOM)).toBe(
+      isDarkReaderMutation(attributeMutation(span, "style", "color: #f00;")),
+    ).toBe(true);
+
+    // Removed (the extension toggled off): only the old value had them.
+    span.setAttribute("style", "color: #f00;");
+    expect(
+      isDarkReaderMutation(
+        attributeMutation(
+          span,
+          "style",
+          "color: #f00; --darkreader-inline-color: #ff8080;",
+        ),
+      ),
+    ).toBe(true);
+  });
+
+  it("reads every other attribute mutation", () => {
+    const span = document.createElement("span");
+    span.setAttribute("style", "color: #f00;");
+    expect(isDarkReaderMutation(attributeMutation(span, "style", null))).toBe(
+      false,
+    );
+    expect(isDarkReaderMutation(attributeMutation(span, "class", null))).toBe(
+      false,
+    );
+    expect(isDarkReaderMutation(attributeMutation(span, "data-id", null))).toBe(
       false,
     );
   });
 
-  it("ignores content mutations outside the content DOM (node view chrome)", () => {
+  it("reads child list mutations anywhere in the node view", () => {
     const dom = document.createElement("div");
-    const contentDOM = document.createElement("div");
-    const chrome = document.createElement("button"); // e.g. toggle button
-    dom.append(chrome, contentDOM);
+    const contentDOM = document.createElement("p");
+    dom.append(document.createElement("button"), contentDOM);
 
-    expect(isNonContentMutation(childListMutation(dom), contentDOM)).toBe(true);
-    expect(isNonContentMutation(childListMutation(chrome), contentDOM)).toBe(
-      true,
-    );
+    expect(isDarkReaderMutation(childListMutation(contentDOM))).toBe(false);
+    // A browser's native paragraph split on Android and iOS inserts the new
+    // paragraph next to the content DOM, not inside it.
+    expect(isDarkReaderMutation(childListMutation(dom))).toBe(false);
   });
 });
 
-describe("ignoreNonContentMutations", () => {
-  it("ignores non-content mutations while reading content ones", () => {
-    const contentDOM = document.createElement("div");
+describe("ignoreDarkReaderMutations", () => {
+  it("ignores Dark Reader writes while reading everything else", () => {
+    const contentDOM = document.createElement("p");
     const span = document.createElement("span");
+    span.setAttribute("style", "--darkreader-inline-color: #ff8080;");
     contentDOM.appendChild(span);
     const nodeView: NodeView = {
       dom: document.createElement("div"),
       contentDOM,
     };
 
-    ignoreNonContentMutations(nodeView);
+    ignoreDarkReaderMutations(nodeView);
 
-    // Non-content (attribute) mutation is ignored...
-    expect(nodeView.ignoreMutation!(attributeMutation(span))).toBe(true);
-    // ...content mutation is read...
+    expect(nodeView.ignoreMutation!(attributeMutation(span, "style"))).toBe(
+      true,
+    );
     expect(nodeView.ignoreMutation!(childListMutation(contentDOM))).toBe(false);
-    // ...and selection is read.
     expect(nodeView.ignoreMutation!(selectionMutation)).toBe(false);
   });
 
-  it("still defers to an existing ignoreMutation for content mutations", () => {
-    const contentDOM = document.createElement("div");
+  it("still defers to an existing ignoreMutation", () => {
+    const contentDOM = document.createElement("p");
     const nodeView: NodeView = {
       dom: document.createElement("div"),
       contentDOM,
-      // Pretend this node view wants to ignore all of its content mutations.
+      // Pretend this node view wants to ignore all of its mutations.
       ignoreMutation: () => true,
     };
 
-    ignoreNonContentMutations(nodeView);
+    ignoreDarkReaderMutations(nodeView);
 
-    // A content mutation the filter would read is still ignored by the
-    // original `ignoreMutation`.
     expect(nodeView.ignoreMutation!(childListMutation(contentDOM))).toBe(true);
-    // Non-content mutations are ignored by the filter regardless.
-    expect(nodeView.ignoreMutation!(attributeMutation(contentDOM))).toBe(true);
   });
 });

--- a/packages/core/src/schema/nodeViewMutations.test.ts
+++ b/packages/core/src/schema/nodeViewMutations.test.ts
@@ -115,6 +115,21 @@ describe("ignoreDarkReaderMutations", () => {
     expect(nodeView.ignoreMutation!(selectionMutation)).toBe(false);
   });
 
+  it("keeps prosemirror-view's default for a node view without a content DOM", () => {
+    const dom = document.createElement("div");
+    const nodeView: NodeView = { dom };
+
+    ignoreDarkReaderMutations(nodeView);
+
+    // Nothing to read back: every mutation but the selection is ignored, as
+    // prosemirror-view does when a node view defines no `ignoreMutation`.
+    expect(nodeView.ignoreMutation!(attributeMutation(dom, "class"))).toBe(
+      true,
+    );
+    expect(nodeView.ignoreMutation!(childListMutation(dom))).toBe(true);
+    expect(nodeView.ignoreMutation!(selectionMutation)).toBe(false);
+  });
+
   it("still defers to an existing ignoreMutation", () => {
     const contentDOM = document.createElement("p");
     const nodeView: NodeView = {

--- a/packages/core/src/schema/nodeViewMutations.ts
+++ b/packages/core/src/schema/nodeViewMutations.ts
@@ -1,42 +1,36 @@
 import { NodeView, ViewMutationRecord } from "@tiptap/pm/view";
 
-// Ignores all mutations, except those which modify content. ProseMirror by default allows for
-// bidirectional updates between state & view i.e., mutating the view can cause a state update.
-// This means that basically any DOM mutation in a node view will trigger a re-render, which can
-// cause issues with certain browser extensions and interactive elements which aren't linked to
-// the node or editor state.
-export function isNonContentMutation(
-  mutation: ViewMutationRecord,
-  contentDOM: HTMLElement | null | undefined,
-): boolean {
-  // Let ProseMirror handle selection changes.
-  if (mutation.type === "selection") {
+// Dark Reader recolours a page by rewriting inline styles (every declaration
+// it adds starts with `--darkreader`) and stamping `data-darkreader-*`
+// attributes on the elements it touched. ProseMirror re-reads a node view on
+// any DOM mutation inside it and re-renders it, after which the extension
+// rewrites it again: an endless loop that froze the tab on code blocks and
+// toggles (#2818). Only those writes are ignored. Every other mutation must
+// reach ProseMirror, including a browser's native paragraph split, which lands
+// next to the content DOM on Android and iOS: ignoring it left the split
+// unread and a stray paragraph in the block (#3001).
+export function isDarkReaderMutation(mutation: ViewMutationRecord): boolean {
+  if (mutation.type !== "attributes" || !mutation.attributeName) {
     return false;
   }
-
-  // Ignore all mutations for nodes without content.
-  if (!contentDOM) {
+  if (mutation.attributeName.startsWith("data-darkreader")) {
     return true;
   }
-
-  // Ignore all changes to DOM attributes. If a DOM attribute value depends on the value of a
-  // ProseMirror node's attribute, the change should be made to the ProseMirror node directly,
-  // which will trigger a re-render. We don't propagate changes to the DOM back to the node.
-  if (mutation.type === "attributes") {
-    return true;
+  if (mutation.attributeName !== "style") {
+    return false;
   }
-
-  // Everything left is a `childList` or `characterData` mutation (i.e., a content mutation). Only
-  // those inside the content DOM are actual content edits that ProseMirror needs to read.
-  return !contentDOM.contains(mutation.target);
+  const style = (mutation.target as Element).getAttribute("style") ?? "";
+  return (
+    style.includes("--darkreader") ||
+    (mutation.oldValue ?? "").includes("--darkreader")
+  );
 }
 
-export function ignoreNonContentMutations(nodeView: NodeView): void {
+export function ignoreDarkReaderMutations(nodeView: NodeView): void {
   const originalIgnoreMutation = nodeView.ignoreMutation?.bind(nodeView);
-  const contentDOM = nodeView.contentDOM;
 
   nodeView.ignoreMutation = (mutation: ViewMutationRecord) => {
-    if (isNonContentMutation(mutation, contentDOM)) {
+    if (isDarkReaderMutation(mutation)) {
       return true;
     }
 

--- a/packages/core/src/schema/nodeViewMutations.ts
+++ b/packages/core/src/schema/nodeViewMutations.ts
@@ -28,6 +28,7 @@ export function isDarkReaderMutation(mutation: ViewMutationRecord): boolean {
 
 export function ignoreDarkReaderMutations(nodeView: NodeView): void {
   const originalIgnoreMutation = nodeView.ignoreMutation?.bind(nodeView);
+  const contentDOM = nodeView.contentDOM;
 
   nodeView.ignoreMutation = (mutation: ViewMutationRecord) => {
     if (isDarkReaderMutation(mutation)) {
@@ -35,6 +36,14 @@ export function ignoreDarkReaderMutations(nodeView: NodeView): void {
     }
 
     // Defer to the node view's own `ignoreMutation` for additional filtering.
-    return originalIgnoreMutation ? originalIgnoreMutation(mutation) : false;
+    if (originalIgnoreMutation) {
+      return originalIgnoreMutation(mutation);
+    }
+
+    // Defining `ignoreMutation` replaces prosemirror-view's default, so keep
+    // it: a node view without a content DOM (an image block, say) has nothing
+    // to read back, and reading its own DOM changes (the selected-node class,
+    // for one) resets a node selection, which broke copying an image.
+    return !contentDOM && mutation.type !== "selection";
   };
 }


### PR DESCRIPTION
## Summary

#2912 made every block and inline content node view ignore all DOM mutations outside its content DOM and every attribute mutation, to stop the Dark Reader re-render loop (#2818). That also hid the browser's native paragraph split from ProseMirror. On Android and iOS, prosemirror-view leaves Enter to the browser and reads the split back from the DOM; the new paragraph lands next to the content DOM, so it was never read. On iOS the 200 ms fallback then split the document while the stray paragraph stayed in the block, rendered next to the text by the flex block content (the "two columns" after Enter on the demo). On Android, Enter, Backspace and Delete broke (#3001).

What Dark Reader actually writes, measured with Brave and Dark Reader on the code block and toggleable blocks examples: attribute changes only, inline `style` declarations starting with `--darkreader` and `data-darkreader-*` attributes. The filter now ignores exactly those and lets everything else reach ProseMirror.

## Testing

- `nodeViewMutations.test.ts` rewritten for the new rule.
- Android e2e instance, on the `mobile/android-enter` branch with its Enter interception switched off: with #2912's filter, 14 keyboard-handler cases fail (Enter, Backspace, Delete); with this filter only Enter on a non-empty selection fails, which #3031's interception covers.
- iOS simulator: with the blanket filter out of the way the native split is read and the DOM stays clean; this rule only ignores attribute writes, so the split (a child-list mutation) reaches ProseMirror the same way.
- Dark Reader by hand: `vp run dev`, open the code block example and the toggleable blocks example with Dark Reader on, type in the code block and change its language; the tab must stay responsive.

## Node views without a content DOM

Defining `ignoreMutation` replaces prosemirror-view's default, which ignores every mutation but the selection in a node view without a content DOM (an image block, say). The first revision answered "read it" there, so the image block's own DOM changes during a resize drag were read back, which reset the node selection and copied nothing: `copypaste` "Images should keep props" failed in CI, and in Docker without the restored default (green with it). #2912 had kept that default explicitly. With it restored, core node views behave as before #2912 in everything except Dark Reader's writes. React block and inline content specs are untouched by all of this: they never used the filter and run on tiptap's `NodeView` default.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved editor handling of Dark Reader-generated DOM changes to prevent unnecessary re-render loops.
  - Restored proper processing of native paragraph-split mutations on Android and iOS.
  - Ensured unrelated attribute, selection, and content mutations continue to reach the editor correctly.

- **Tests**
  - Expanded coverage for Dark Reader attributes, inline styles, child-list changes, selection mutations, and existing mutation handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
