### PR TITLE
refactor(core): implement built-in toggles with renderFrame

### DIFF
--- a/packages/core/src/api/blockManipulation/commands/materializeChildren/materializeChildren.ts
+++ b/packages/core/src/api/blockManipulation/commands/materializeChildren/materializeChildren.ts
@@ -1,0 +1,59 @@
+import { Fragment, type Node } from "prosemirror-model";
+import { TextSelection, type Transaction } from "prosemirror-state";
+import {
+  getBlockInfoAt,
+  getInsertionPos,
+} from "../../../getBlockInfoFromPos.js";
+import { getPmSchema } from "../../../pmUtil.js";
+
+/** Prepends children, creating their group together with its first child.
+ * Returns undefined without changing the transaction if the content cannot fit. */
+export function materializeChildren(
+  tr: Transaction,
+  blockPos: number,
+  nodes: readonly Node[],
+): number | undefined {
+  if (!nodes.length) {
+    return undefined;
+  }
+  const target = getInsertionPos(
+    tr.doc,
+    getBlockInfoAt(tr.doc, blockPos),
+    "first-child",
+    nodes[0].type,
+  );
+  if (!target) {
+    return undefined;
+  }
+  const content = Fragment.from(nodes);
+  if (target.wrapIn && !target.wrapIn.validContent(content)) {
+    return undefined;
+  }
+  const fragment = target.wrapIn
+    ? Fragment.from(target.wrapIn.create(null, content))
+    : content;
+  const $pos = tr.doc.resolve(target.pos);
+  if (!$pos.parent.canReplace($pos.index(), $pos.index(), fragment)) {
+    return undefined;
+  }
+  tr.insert(target.pos, fragment);
+  return target.pos + (target.wrapIn ? 1 : 0);
+}
+
+/** Shared by Enter and the empty-toggle button. */
+export function insertEmptyFirstChild(
+  tr: Transaction,
+  blockPos: number,
+): boolean {
+  const schema = getPmSchema(tr);
+  const child = schema.nodes.blockContainer.create(
+    null,
+    schema.nodes.paragraph.create(),
+  );
+  const pos = materializeChildren(tr, blockPos, [child]);
+  if (pos === undefined) {
+    return false;
+  }
+  tr.setSelection(TextSelection.near(tr.doc.resolve(pos), 1)).scrollIntoView();
+  return true;
+}

--- a/packages/core/src/blocks/Heading/block.ts
+++ b/packages/core/src/blocks/Heading/block.ts
@@ -7,7 +7,7 @@ import {
   parseDefaultProps,
 } from "../defaultProps.js";
 import { getDetailsContent } from "../getDetailsContent.js";
-import { createToggleWrapper } from "../ToggleWrapper/createToggleWrapper.js";
+import { createToggleFrame } from "../ToggleFrame/createToggleFrame.js";
 
 const HEADING_LEVELS = [1, 2, 3, 4, 5, 6] as const;
 
@@ -126,18 +126,15 @@ export const createHeadingBlockSpec = createBlockSpec(
         }
       : {}),
     runsBefore: ["toggleListItem"],
-    render(block, editor) {
+    render(block) {
       const dom = document.createElement(`h${block.props.level}`);
-
-      if (allowToggleHeadings) {
-        const toggleWrapper = createToggleWrapper(block, editor, dom);
-        return { ...toggleWrapper, contentDOM: dom };
+      return { dom, contentDOM: dom };
+    },
+    renderFrame(block, editor) {
+      if (!allowToggleHeadings || !block.props.isToggleable) {
+        return undefined;
       }
-
-      return {
-        dom,
-        contentDOM: dom,
-      };
+      return createToggleFrame(block, editor, this.renderType);
     },
     toExternalHTML(block) {
       const dom = document.createElement(`h${block.props.level}`);

--- a/packages/core/src/blocks/ListItem/ToggleListItem/block.ts
+++ b/packages/core/src/blocks/ListItem/ToggleListItem/block.ts
@@ -6,7 +6,7 @@ import {
   parseDefaultProps,
 } from "../../defaultProps.js";
 import { getDetailsContent } from "../../getDetailsContent.js";
-import { createToggleWrapper } from "../../ToggleWrapper/createToggleWrapper.js";
+import { createToggleFrame } from "../../ToggleFrame/createToggleFrame.js";
 import { handleEnter } from "../../utils/listItemEnterHandler.js";
 
 export type ToggleListItemBlockConfig = ReturnType<
@@ -71,14 +71,12 @@ export const createToggleListItemBlockSpec = createBlockSpec(
       );
     },
     runsBefore: ["bulletListItem"],
-    render(block, editor) {
-      const paragraphEl = document.createElement("p");
-      const toggleWrapper = createToggleWrapper(
-        block as any,
-        editor,
-        paragraphEl,
-      );
-      return { ...toggleWrapper, contentDOM: paragraphEl };
+    render() {
+      const dom = document.createElement("p");
+      return { dom, contentDOM: dom };
+    },
+    renderFrame(block, editor) {
+      return createToggleFrame(block, editor, this.renderType);
     },
     toExternalHTML(block) {
       const li = document.createElement("li");

--- a/packages/core/src/blocks/ToggleFrame/createToggleFrame.test.ts
+++ b/packages/core/src/blocks/ToggleFrame/createToggleFrame.test.ts
@@ -1,0 +1,438 @@
+import { Fragment, Slice } from "prosemirror-model";
+import { getNodeById } from "../../api/nodeUtil.js";
+import { getBlockInfoAt } from "../../api/getBlockInfoFromPos.js";
+import { handleToggleDrop } from "../../extensions/Toggle/toggleDrop.js";
+import { NodeSelection, TextSelection } from "prosemirror-state";
+import { ToggleExtension } from "../../extensions/Toggle/Toggle.js";
+import { afterEach, describe, expect, it, vi } from "vite-plus/test";
+
+import { BlockNoteEditor } from "../../editor/BlockNoteEditor.js";
+import type { PartialBlock } from "../defaultBlocks.js";
+import { defaultToggledState } from "./toggledState.js";
+
+const editors: BlockNoteEditor[] = [];
+
+function mount(initialContent: PartialBlock[]) {
+  const editor = BlockNoteEditor.create({ initialContent });
+  editors.push(editor);
+  editor.mount(document.createElement("div"));
+  return editor;
+}
+
+function frame(editor: BlockNoteEditor, id = "toggle") {
+  return editor.domElement!.querySelector<HTMLElement>(
+    `[data-id="${id}"] > .bn-block > .bn-toggle-frame`,
+  )!;
+}
+
+function clickToggle(element: HTMLElement) {
+  element
+    .querySelector<HTMLButtonElement>(":scope > .bn-toggle-button")!
+    .click();
+}
+
+afterEach(() => {
+  for (const editor of editors.splice(0)) {
+    editor._tiptapEditor.destroy();
+  }
+  vi.restoreAllMocks();
+  window.localStorage.clear();
+});
+
+describe("built-in toggle frames", () => {
+  it("keeps nested DOM and document state when toggling", async () => {
+    const editor = mount([
+      {
+        id: "toggle",
+        type: "toggleListItem",
+        content: "Title",
+        children: [
+          {
+            id: "nested",
+            type: "toggleListItem",
+            content: "Nested",
+            children: [{ id: "body", type: "paragraph", content: "Body" }],
+          },
+        ],
+      },
+    ]);
+    const outer = frame(editor);
+    const nested = frame(editor, "nested");
+    const body = editor.domElement!.querySelector('[data-id="body"]');
+    const before = editor.document;
+    clickToggle(outer);
+    clickToggle(nested);
+    clickToggle(outer);
+    clickToggle(outer);
+    // Let the DOM observer process the UI mutations as it would in an editor.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(frame(editor)).toBe(outer);
+    expect(frame(editor, "nested")).toBe(nested);
+    expect(editor.domElement!.querySelector('[data-id="body"]')).toBe(body);
+    expect(nested.dataset.showChildren).toBe("true");
+    expect(editor.document).toEqual(before);
+    expect(outer.querySelector("button")!.getAttribute("aria-expanded")).toBe(
+      "true",
+    );
+  });
+
+  it("opens on child insertion and closes when the last child is removed", () => {
+    const editor = mount([
+      { id: "toggle", type: "toggleListItem", content: "Title" },
+    ]);
+    const original = frame(editor);
+    expect(original.dataset.showChildren).toBe("false");
+    const [child] = editor.insertBlocks([{}], "toggle", "first-child");
+    expect(frame(editor)).toBe(original);
+    expect(original.dataset.showChildren).toBe("true");
+    editor.removeBlocks([child]);
+    expect(original.dataset.showChildren).toBe("false");
+  });
+
+  it("adds the first child and focuses it in a single undo step", () => {
+    const editor = mount([
+      { id: "toggle", type: "toggleListItem", content: "Title" },
+    ]);
+    const before = editor.document;
+    clickToggle(frame(editor));
+    frame(editor)
+      .querySelector<HTMLButtonElement>(".bn-toggle-add-block-button")!
+      .click();
+    const child = editor.getBlock("toggle")!.children[0];
+    expect(child.type).toBe("paragraph");
+    expect(editor.getTextCursorPosition().block.id).toBe(child.id);
+    editor.undo();
+    expect(editor.document).toEqual(before);
+  });
+
+  it("adds and removes a heading frame when toggleability changes", () => {
+    const editor = mount([
+      {
+        id: "toggle",
+        type: "heading",
+        props: { level: 2 },
+        content: "Title",
+        children: [{ id: "body", type: "paragraph", content: "Body" }],
+      },
+    ]);
+    expect(frame(editor)).toBeNull();
+    editor.updateBlock("toggle", { props: { isToggleable: true } });
+    expect(frame(editor)).not.toBeNull();
+    editor.updateBlock("toggle", { props: { isToggleable: false } });
+    expect(frame(editor)).toBeNull();
+    expect(editor.getBlock("body")!.content).toEqual([
+      { type: "text", text: "Body", styles: {} },
+    ]);
+    editor.updateBlock("toggle", { type: "toggleListItem" });
+    expect(frame(editor)).not.toBeNull();
+    editor.updateBlock("toggle", { type: "paragraph" });
+    expect(frame(editor)).toBeNull();
+  });
+
+  it("keeps the frame through heading level and text edits", () => {
+    const editor = mount([
+      {
+        id: "toggle",
+        type: "heading",
+        props: { isToggleable: true },
+        content: "Title",
+      },
+    ]);
+    const original = frame(editor);
+    clickToggle(original);
+    editor.updateBlock("toggle", { props: { level: 3 }, content: "Edited" });
+    expect(frame(editor)).toBe(original);
+    expect(original.querySelector("h3")!.textContent).toBe("Edited");
+    expect(original.dataset.showChildren).toBe("true");
+  });
+
+  it("does not insert children in read-only mode", () => {
+    const editor = mount([
+      { id: "toggle", type: "toggleListItem", content: "Title" },
+    ]);
+    editor.isEditable = false;
+    clickToggle(frame(editor));
+    frame(editor)
+      .querySelector<HTMLButtonElement>(".bn-toggle-add-block-button")!
+      .click();
+    expect(editor.getBlock("toggle")!.children).toEqual([]);
+    editor.isEditable = true;
+    frame(editor)
+      .querySelector<HTMLButtonElement>(".bn-toggle-add-block-button")!
+      .click();
+    expect(editor.getBlock("toggle")!.children).toHaveLength(1);
+  });
+
+  it("exports expanded static frames without reading localStorage and round-trips them", () => {
+    const editor = mount([
+      {
+        id: "toggle",
+        type: "toggleListItem",
+        content: "Title",
+        children: [{ type: "paragraph", content: "Body" }],
+      },
+      {
+        type: "heading",
+        props: { isToggleable: true, level: 2 },
+        content: "Heading",
+        children: [{ type: "paragraph", content: "Heading body" }],
+      },
+    ]);
+    const get = vi.spyOn(defaultToggledState, "get").mockImplementation(() => {
+      throw new Error("Storage must not be read while serializing");
+    });
+    const html = editor.blocksToFullHTML(editor.document);
+    expect(get).not.toHaveBeenCalled();
+    const dom = document.createElement("div");
+    dom.innerHTML = html;
+    expect(
+      dom.querySelectorAll('.bn-toggle-frame[data-show-children="true"]'),
+    ).toHaveLength(2);
+    expect(dom.querySelector(".bn-toggle-add-block-button")).toBeNull();
+    get.mockRestore();
+    expect(editor.tryParseHTMLToBlocks(html)).toEqual(editor.document);
+    const external = editor.blocksToHTMLLossy(editor.document);
+    dom.innerHTML = external;
+    expect(dom.querySelectorAll("details[open]")).toHaveLength(2);
+    expect(dom.textContent).toContain("Heading body");
+  });
+});
+
+function pressEnter(editor: BlockNoteEditor, shiftKey = false) {
+  const event = new KeyboardEvent("keydown", {
+    key: "Enter",
+    code: "Enter",
+    bubbles: true,
+    cancelable: true,
+    shiftKey,
+  });
+  editor.prosemirrorView.someProp("handleKeyDown", (handler) =>
+    handler(editor.prosemirrorView, event),
+  );
+}
+
+it.each(["toggleListItem", "heading"] as const)(
+  "Enter starts a child in an expanded %s and undoes once",
+  (type) => {
+    const editor = mount([
+      {
+        id: "toggle",
+        ...(type === "heading"
+          ? { type, props: { isToggleable: true } }
+          : { type }),
+        content: "Title",
+        children: [{ id: "existing", content: "Existing" }],
+      },
+    ]);
+    const before = editor.document;
+    const controller = editor.getExtension(ToggleExtension)!;
+    expect(controller.setExpanded("toggle", true)).toBe(true);
+    expect(frame(editor).dataset.showChildren).toBe("true");
+    editor.setTextCursorPosition("toggle", "end");
+    pressEnter(editor);
+    const children = editor.getBlock("toggle")!.children;
+    expect(children).toHaveLength(2);
+    expect(children[0].content).toEqual([]);
+    expect(children[1].id).toBe("existing");
+    expect(editor.getTextCursorPosition().block.id).toBe(children[0].id);
+    editor.undo();
+    expect(editor.document).toEqual(before);
+  },
+);
+
+it("Enter materializes children for an expanded childless toggle", () => {
+  const editor = mount([
+    { id: "toggle", type: "toggleListItem", content: "Title" },
+  ]);
+  editor.getExtension(ToggleExtension)!.setExpanded("toggle", true);
+  editor.setTextCursorPosition("toggle", "end");
+  pressEnter(editor);
+  expect(editor.getBlock("toggle")!.children).toHaveLength(1);
+  expect(editor.getTextCursorPosition().block.id).toBe(
+    editor.getBlock("toggle")!.children[0].id,
+  );
+  expect(() => editor.prosemirrorState.doc.check()).not.toThrow();
+});
+
+it.each([0, 2, 5])(
+  "splits a collapsed title at offset %s with children following the intended half",
+  (offset) => {
+    const editor = mount([
+      {
+        id: "toggle",
+        type: "toggleListItem",
+        content: "Title",
+        children: [{ id: "child", content: "Child" }],
+      },
+    ]);
+    const before = editor.document;
+    editor.setTextCursorPosition("toggle", "start");
+    editor.transact((tr) =>
+      tr.setSelection(TextSelection.create(tr.doc, tr.selection.from + offset)),
+    );
+    pressEnter(editor);
+    const [first, second] = editor.document;
+    expect(
+      (offset === 0 ? second : first).children.map((child) => child.id),
+    ).toEqual(["child"]);
+    expect((offset === 0 ? first : second).children).toEqual([]);
+    expect(editor.getTextCursorPosition().block.id).toBe(second.id);
+    editor.undo();
+    expect(editor.document).toEqual(before);
+  },
+);
+
+it("preserves Shift-Enter and empty-title list behavior", () => {
+  const editor = mount([
+    { id: "toggle", type: "toggleListItem", content: "Title" },
+  ]);
+  editor.getExtension(ToggleExtension)!.setExpanded("toggle", true);
+  editor.setTextCursorPosition("toggle", "end");
+  pressEnter(editor, true);
+  expect(editor.getBlock("toggle")!.children).toEqual([]);
+  expect(editor.getBlock("toggle")!.content).toEqual([
+    { type: "text", text: "Title\n", styles: {} },
+  ]);
+  editor.updateBlock("toggle", { content: [] });
+  editor.setTextCursorPosition("toggle", "end");
+  pressEnter(editor);
+  expect(editor.getBlock("toggle")!.type).toBe("paragraph");
+  expect(
+    editor.getExtension(ToggleExtension)!.isExpanded("toggle"),
+  ).toBeUndefined();
+});
+
+it("unregisters frames on conversion and destruction", () => {
+  const editor = mount([
+    {
+      id: "toggle",
+      type: "heading",
+      props: { isToggleable: true },
+      content: "Title",
+    },
+  ]);
+  const controller = editor.getExtension(ToggleExtension)!;
+  controller.setExpanded("toggle", true);
+  editor.updateBlock("toggle", { props: { isToggleable: false } });
+  expect(controller.isExpanded("toggle")).toBeUndefined();
+  expect(controller.setExpanded("toggle", false)).toBe(false);
+  editor.updateBlock("toggle", { props: { isToggleable: true } });
+  expect(controller.isExpanded("toggle")).toBe(true);
+  editor.unmount();
+  expect(controller.isExpanded("toggle")).toBeUndefined();
+});
+
+it("keeps failed storage writes authoritative even when reads still succeed", () => {
+  const block = { id: "quota-fallback" };
+  window.localStorage.setItem(`toggle-${block.id}`, "false");
+  vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+    throw new DOMException("Full", "QuotaExceededError");
+  });
+  defaultToggledState.set(block, true);
+  expect(defaultToggledState.get(block)).toBe(true);
+  defaultToggledState.set(block, false);
+  expect(defaultToggledState.get(block)).toBe(false);
+});
+
+it("handles unavailable storage while letting unexpected failures propagate", () => {
+  const spy = vi.spyOn(window, "localStorage", "get").mockImplementation(() => {
+    throw new DOMException("Blocked", "SecurityError");
+  });
+  const block = { id: "blocked-storage" };
+  expect(defaultToggledState.get(block)).toBe(false);
+  defaultToggledState.set(block, true);
+  expect(defaultToggledState.get(block)).toBe(true);
+  spy.mockImplementation(() => {
+    throw new Error("Unexpected");
+  });
+  expect(() => defaultToggledState.get({ id: "unexpected-storage" })).toThrow(
+    "Unexpected",
+  );
+});
+
+it.each([false, true])(
+  "drops whole blocks into an empty toggle (move: %s) in one undo step",
+  (moved) => {
+    const editor = mount([
+      { id: "toggle", type: "toggleListItem", content: "Title" },
+      { id: "source", content: "Source" },
+    ]);
+    const before = editor.document;
+    const view = editor.prosemirrorView;
+    const source = getNodeById("source", view.state.doc)!;
+    view.dispatch(
+      view.state.tr.setSelection(
+        NodeSelection.create(view.state.doc, source.posBeforeNode),
+      ),
+    );
+    const slice = view.state.selection.content();
+    const target = getNodeById("toggle", view.state.doc)!.posBeforeNode;
+    const info = getBlockInfoAt(view.state.doc, target);
+    if (!info.hasContent) {
+      throw new Error("Expected title");
+    }
+    vi.spyOn(view, "posAtCoords").mockReturnValue({
+      pos: info.contentStart,
+      inside: info.content.beforePos,
+    });
+    vi.spyOn(
+      frame(editor).querySelector<HTMLElement>(".bn-block-content")!,
+      "getBoundingClientRect",
+    ).mockReturnValue(new DOMRect(0, 0, 200, 30));
+    const controller = editor.getExtension(ToggleExtension)!;
+    const event = new MouseEvent("drop", {
+      clientX: 100,
+      clientY: 15,
+      cancelable: true,
+    });
+    expect(controller.getDropTargetPos(view, event, slice)).toBeUndefined();
+    controller.setExpanded("toggle", true);
+    expect(
+      controller.getDropTargetPos(
+        view,
+        event,
+        new Slice(Fragment.from(view.state.schema.text("text")), 0, 0),
+      ),
+    ).toBeUndefined();
+    expect(
+      controller.getDropTargetPos(view, { clientX: 100, clientY: 40 }, slice),
+    ).toBeUndefined();
+    editor.isEditable = false;
+    expect(controller.getDropTargetPos(view, event, slice)).toBeUndefined();
+    editor.isEditable = true;
+    expect(controller.getDropTargetPos(view, event, slice)).toBe(target);
+    // The helper only consumes preventDefault, shared by mouse and drag events.
+    expect(handleToggleDrop(target, view, event, slice, moved)).toBe(true);
+    expect(editor.getBlock("toggle")!.children[0].content).toEqual(
+      before[1].content,
+    );
+    expect(
+      editor.document.filter((block) => block.id === "source"),
+    ).toHaveLength(moved ? 0 : 1);
+    expect(() => view.state.doc.check()).not.toThrow();
+    editor.undo();
+    expect(editor.document).toEqual(before);
+  },
+);
+
+it("rejects a drop whose source contains its target", () => {
+  const editor = mount([
+    { id: "toggle", type: "toggleListItem", content: "Title" },
+  ]);
+  const view = editor.prosemirrorView;
+  const target = getNodeById("toggle", view.state.doc)!.posBeforeNode;
+  view.dispatch(
+    view.state.tr.setSelection(NodeSelection.create(view.state.doc, target)),
+  );
+  const before = editor.document;
+  expect(
+    handleToggleDrop(
+      target,
+      view,
+      new MouseEvent("drop"),
+      view.state.selection.content(),
+      true,
+    ),
+  ).toBe(false);
+  expect(editor.document).toEqual(before);
+});

--- a/packages/core/src/blocks/ToggleFrame/createToggleFrame.ts
+++ b/packages/core/src/blocks/ToggleFrame/createToggleFrame.ts
@@ -1,0 +1,132 @@
+import { insertEmptyFirstChild } from "../../api/blockManipulation/commands/materializeChildren/materializeChildren.js";
+import { getNodeById } from "../../api/nodeUtil.js";
+import { ToggleExtension } from "../../extensions/Toggle/Toggle.js";
+import type { BlockNoteEditor } from "../../editor/BlockNoteEditor.js";
+import type {
+  BlockSchema,
+  InlineContentSchema,
+  StyleSchema,
+} from "../../schema/index.js";
+import { defaultToggledState, type ToggledState } from "./toggledState.js";
+
+type ToggleBlock = {
+  id: string;
+  type: string;
+  props: Record<string, unknown>;
+  children: readonly { id: string }[];
+};
+
+/** A disclosure frame around a block's editable title and ordinary children. */
+export function createToggleFrame<
+  B extends ToggleBlock,
+  BS extends BlockSchema,
+  I extends InlineContentSchema,
+  S extends StyleSchema,
+>(
+  block: B,
+  editor: BlockNoteEditor<BS, I, S>,
+  renderType: "nodeView" | "dom" = "nodeView",
+  toggledState: ToggledState<B> = defaultToggledState,
+) {
+  const dom = document.createElement("div");
+  dom.className = "bn-toggle-frame";
+  dom.dataset.toggleHeading = String(block.type === "heading");
+  const slot = document.createElement("div");
+  slot.className = "bn-toggle-slot";
+
+  const button = document.createElement("button");
+  button.className = "bn-toggle-button";
+  button.type = "button";
+  button.setAttribute(
+    "aria-label",
+    editor.dictionary.slash_menu.toggle_list.title,
+  );
+  button.innerHTML =
+    // Same Material Symbols chevron as the legacy ToggleWrapper.
+    '<svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 -960 960 960" width="24px" fill="currentColor" aria-hidden="true"><path d="M320-200v-560l440 280-440 280Z"/></svg>';
+  dom.append(button, slot);
+
+  // Static HTML is always expanded and never reads per-user browser storage.
+  if (renderType === "dom") {
+    dom.dataset.showChildren = "true";
+    button.setAttribute("aria-expanded", "true");
+    button.disabled = true;
+    return { dom, slot };
+  }
+
+  const addBlock = document.createElement("button");
+  addBlock.className = "bn-toggle-add-block-button";
+  addBlock.type = "button";
+  addBlock.textContent = editor.dictionary.toggle_blocks.add_block_button;
+  dom.append(addBlock);
+
+  let currentBlock = block;
+  const controller = editor.getExtension(ToggleExtension);
+  if (!controller) {
+    throw new Error("Toggle frames require ToggleExtension");
+  }
+  const updateExpanded = controller.setExpanded;
+  let expanded = toggledState.get(block);
+  const unregister = controller.register(
+    block.id,
+    expanded,
+    (value) => toggledState.set(currentBlock, value),
+    (value) => {
+      expanded = value;
+      paint();
+    },
+  );
+
+  function paint() {
+    dom.dataset.showChildren = String(expanded);
+    button.setAttribute("aria-expanded", String(expanded));
+    addBlock.hidden = !expanded || currentBlock.children.length > 0;
+  }
+
+  function setExpanded(value: boolean) {
+    updateExpanded(currentBlock.id, value);
+  }
+
+  // Author chrome lives outside the slot, so the frame node view already
+  // handles its events and mutations. These handlers die with their DOM.
+  button.onmousedown = addBlock.onmousedown = (event) => event.preventDefault();
+  button.onclick = () => setExpanded(!expanded);
+  addBlock.onclick = () => {
+    const current = editor.getBlock(block.id);
+    if (!editor.isEditable || !current || current.children.length > 0) {
+      return;
+    }
+    editor.transact((tr) => {
+      const target = getNodeById(block.id, tr.doc);
+      if (target && insertEmptyFirstChild(tr, target.posBeforeNode)) {
+        editor.focus();
+      }
+    });
+  };
+  paint();
+
+  return {
+    dom,
+    slot,
+    destroy: unregister,
+    update(updatedBlock: B) {
+      // A heading converted back to plain must also lose its frame.
+      if (
+        "isToggleable" in updatedBlock.props &&
+        !updatedBlock.props.isToggleable
+      ) {
+        return false;
+      }
+      const previousCount = currentBlock.children.length;
+      currentBlock = updatedBlock;
+      if (currentBlock.children.length > previousCount) {
+        setExpanded(true);
+      } else if (currentBlock.children.length === 0 && previousCount > 0) {
+        setExpanded(false);
+      } else {
+        paint();
+      }
+      return true;
+    },
+  };
+}

--- a/packages/core/src/blocks/ToggleFrame/toggledState.ts
+++ b/packages/core/src/blocks/ToggleFrame/toggledState.ts
@@ -1,0 +1,50 @@
+/** Expansion is per-user view state, outside the document and undo history. */
+export type ToggledState<B extends { id: string } = { id: string }> = {
+  set: (block: B, expanded: boolean) => void;
+  get: (block: B) => boolean;
+};
+
+// Only keys that cannot be persisted live here. Once a write fails, reads of
+// that key must not return an older value from otherwise-readable storage.
+const fallback = new Map<string, boolean>();
+
+function isStorageUnavailable(error: unknown) {
+  return (
+    error instanceof DOMException &&
+    (error.name === "SecurityError" || error.name === "QuotaExceededError")
+  );
+}
+
+export const defaultToggledState: ToggledState = {
+  set(block, expanded) {
+    if (fallback.has(block.id) || typeof window === "undefined") {
+      fallback.set(block.id, expanded);
+      return;
+    }
+    try {
+      window.localStorage.setItem(`toggle-${block.id}`, String(expanded));
+    } catch (error) {
+      if (!isStorageUnavailable(error)) {
+        throw error;
+      }
+      fallback.set(block.id, expanded);
+    }
+  },
+  get(block) {
+    const value = fallback.get(block.id);
+    if (value !== undefined) {
+      return value;
+    }
+    if (typeof window === "undefined") {
+      return false;
+    }
+    try {
+      return window.localStorage.getItem(`toggle-${block.id}`) === "true";
+    } catch (error) {
+      if (!isStorageUnavailable(error)) {
+        throw error;
+      }
+      return false;
+    }
+  },
+};

--- a/packages/core/src/blocks/ToggleWrapper/createToggleWrapper.ts
+++ b/packages/core/src/blocks/ToggleWrapper/createToggleWrapper.ts
@@ -3,25 +3,19 @@ import { ViewMutationRecord } from "@tiptap/pm/view";
 import { BlockNoteEditor } from "../../editor/BlockNoteEditor.js";
 import { Block } from "../defaultBlocks.js";
 
-type ToggledState = {
-  set: (block: Block<any, any, any>, isToggled: boolean) => void;
-  get: (block: Block<any, any, any>) => boolean;
-};
+import {
+  defaultToggledState,
+  type ToggledState,
+} from "../ToggleFrame/toggledState.js";
 
-export const defaultToggledState: ToggledState = {
-  set: (block, isToggled: boolean) =>
-    window.localStorage.setItem(
-      `toggle-${block.id}`,
-      isToggled ? "true" : "false",
-    ),
-  get: (block) => window.localStorage.getItem(`toggle-${block.id}`) === "true",
-};
+export { defaultToggledState } from "../ToggleFrame/toggledState.js";
 
+/** @deprecated Use `createToggleFrame` in the block's `renderFrame` instead. */
 export const createToggleWrapper = (
   block: Block<any, any, any>,
   editor: BlockNoteEditor<any, any, any>,
   renderedElement: HTMLElement,
-  toggledState: ToggledState = defaultToggledState,
+  toggledState: ToggledState<Block<any, any, any>> = defaultToggledState,
 ): {
   dom: HTMLElement;
   contentDOM?: HTMLElement;

--- a/packages/core/src/blocks/index.ts
+++ b/packages/core/src/blocks/index.ts
@@ -27,3 +27,6 @@ export * from "./defaultBlockHelpers.js";
 export * from "./defaultBlocks.js";
 export * from "./defaultBlockTypeGuards.js";
 export * from "./defaultProps.js";
+
+export * from "./ToggleFrame/createToggleFrame.js";
+export type { ToggledState } from "./ToggleFrame/toggledState.js";

--- a/packages/core/src/blocks/utils/listItemEnterHandler.ts
+++ b/packages/core/src/blocks/utils/listItemEnterHandler.ts
@@ -1,3 +1,4 @@
+import { handleToggleEnter } from "../../extensions/Toggle/toggleEnter.js";
 import { splitBlockTr } from "../../api/blockManipulation/commands/splitBlock/splitBlock.js";
 import { updateBlockTr } from "../../api/blockManipulation/commands/updateBlock/updateBlock.js";
 import { getBlockInfoFromSelection } from "../../api/getBlockInfoFromPos.js";
@@ -21,6 +22,10 @@ export const handleEnter = (
 
   if (!(content.node.type.name === listItemType) || !selectionEmpty) {
     return false;
+  }
+
+  if (editor.transact((tr) => handleToggleEnter(editor, tr))) {
+    return true;
   }
 
   if (blockInfo.isContentEmpty) {

--- a/packages/core/src/editor/Block.css
+++ b/packages/core/src/editor/Block.css
@@ -189,13 +189,23 @@ NESTED BLOCKS
   --prev-level: 0.8em;
 }
 
-.bn-block-outer[data-prev-type="heading"] > .bn-block > .bn-block-content {
+.bn-block-outer[data-prev-type="heading"] > .bn-block > .bn-block-content,
+.bn-block-outer[data-prev-type="heading"]
+  > .bn-block
+  > .bn-toggle-frame
+  > .bn-toggle-slot
+  > .bn-block-content {
   font-size: var(--prev-level);
   font-weight: bold;
 }
 
 .bn-block-outer:not([data-prev-type])
   > .bn-block
+  > .bn-block-content[data-content-type="heading"],
+.bn-block-outer:not([data-prev-type])
+  > .bn-block
+  > .bn-toggle-frame
+  > .bn-toggle-slot
   > .bn-block-content[data-content-type="heading"],
 .bn-block-outer:not([data-prev-type])
   > .bn-block
@@ -307,6 +317,59 @@ NESTED BLOCKS
 }
 
 /* Toggle */
+/* The slot owns the title and child group. Its children participate in the
+   frame's grid so the chevron aligns with the title, even over a long body.
+   Child indentation remains the shared 24px block-group indentation above. */
+.bn-toggle-frame {
+  display: grid;
+  grid-template-columns: 24px minmax(0, 1fr);
+}
+
+.bn-toggle-slot {
+  display: contents;
+}
+
+.bn-toggle-slot > :not(.bn-block-group) {
+  grid-column: 2;
+  grid-row: 1;
+  min-width: 0;
+}
+
+.bn-toggle-slot > .bn-block-group {
+  grid-column: 1 / -1;
+}
+
+.bn-toggle-frame > .bn-toggle-button {
+  grid-column: 1;
+  grid-row: 1;
+  align-self: center;
+}
+
+/* Headings have 18px top and 3px bottom padding (see HEADINGS above). */
+.bn-toggle-frame[data-toggle-heading="true"] > .bn-toggle-button {
+  margin-top: 15px;
+}
+
+.bn-toggle-frame[data-show-children="true"] > .bn-toggle-button > svg {
+  transform: rotate(90deg);
+}
+
+.bn-toggle-frame > .bn-toggle-add-block-button {
+  grid-column: 2;
+  margin-left: 0;
+}
+
+.bn-toggle-frame[data-show-children="false"]
+  > .bn-toggle-slot
+  > .bn-block-group,
+.bn-toggle-frame > .bn-toggle-add-block-button[hidden],
+.bn-editor:not([contenteditable="true"])
+  .bn-toggle-frame
+  > .bn-toggle-add-block-button {
+  display: none;
+}
+
+/* Compatibility for custom blocks still using the legacy ToggleWrapper. */
 .bn-block:has(
     > .bn-block-content > div > .bn-toggle-wrapper[data-show-children="false"]
   )

--- a/packages/core/src/editor/managers/ExtensionManager/extensions.ts
+++ b/packages/core/src/editor/managers/ExtensionManager/extensions.ts
@@ -12,6 +12,7 @@ import { createCopyToClipboardExtension } from "../../../api/clipboard/toClipboa
 import {
   BlockChangeExtension,
   DropCursorExtension,
+  ToggleExtension,
   FilePanelExtension,
   FormattingToolbarExtension,
   HistoryExtension,
@@ -163,6 +164,7 @@ export function getDefaultExtensions(
   const extensions = [
     BlockChangeExtension(),
     DropCursorExtension(options),
+    ToggleExtension(),
     FilePanelExtension(options),
     FormattingToolbarExtension(options),
     LinkExtension({

--- a/packages/core/src/extensions/DropCursor/DropCursor.ts
+++ b/packages/core/src/extensions/DropCursor/DropCursor.ts
@@ -1,3 +1,5 @@
+import { ToggleExtension } from "../Toggle/Toggle.js";
+import { getBlockInfoAt } from "../../api/getBlockInfoFromPos.js";
 import { dropPoint } from "prosemirror-transform";
 import type { EditorView } from "prosemirror-view";
 import {
@@ -186,6 +188,16 @@ export const DropCursorExtension = createExtension<
         const point = dropPoint(view.state.doc, target, view.dragging.slice);
         if (point != null) {
           target = point;
+        }
+      }
+
+      const toggleTarget = editor
+        .getExtension(ToggleExtension)
+        ?.getDropTargetPos(view, e, view.dragging?.slice);
+      if (toggleTarget !== undefined) {
+        const info = getBlockInfoAt(view.state.doc, toggleTarget);
+        if (info.hasContent) {
+          target = info.content.afterPos;
         }
       }
 

--- a/packages/core/src/extensions/Toggle/Toggle.ts
+++ b/packages/core/src/extensions/Toggle/Toggle.ts
@@ -1,0 +1,78 @@
+import type { Slice } from "prosemirror-model";
+import type { EditorView } from "prosemirror-view";
+import { Plugin } from "prosemirror-state";
+import { createExtension } from "../../editor/BlockNoteExtension.js";
+import { getToggleDropTargetPos, handleToggleDrop } from "./toggleDrop.js";
+
+/** Rendering opts a block into toggle interactions by registering its frame.
+ * State is scoped to the editor view, never written into the document. */
+export const ToggleExtension = createExtension(() => {
+  const frames = new Map<
+    string,
+    {
+      expanded: boolean;
+      persist: (expanded: boolean) => void;
+      paint: (expanded: boolean) => void;
+    }
+  >();
+  /** Undefined when this block has no mounted toggle frame. */
+  function isExpanded(id: string): boolean | undefined {
+    return frames.get(id)?.expanded;
+  }
+  /** Updates the mounted frame and its persistence provider; false if absent. */
+  function setExpanded(id: string, expanded: boolean): boolean {
+    const frame = frames.get(id);
+    if (!frame) {
+      return false;
+    }
+    frame.persist(expanded);
+    frame.expanded = expanded;
+    frame.paint(expanded);
+    return true;
+  }
+  function register(
+    id: string,
+    expanded: boolean,
+    persist: (expanded: boolean) => void,
+    paint: (expanded: boolean) => void,
+  ) {
+    const frame = { expanded, persist, paint };
+    frames.set(id, frame);
+    paint(expanded);
+    return () => {
+      // A replacement frame may have registered before the old one is destroyed.
+      if (frames.get(id) === frame) {
+        frames.delete(id);
+      }
+    };
+  }
+  function getDropTargetPos(
+    view: EditorView,
+    event: { clientX: number; clientY: number },
+    slice: Slice | undefined | null,
+  ) {
+    return getToggleDropTargetPos(isExpanded, view, event, slice);
+  }
+  return {
+    key: "toggleInteraction",
+    isExpanded,
+    setExpanded,
+    register,
+    getDropTargetPos,
+    prosemirrorPlugins: [
+      new Plugin({
+        props: {
+          handleDrop(view, event, slice, moved) {
+            return handleToggleDrop(
+              getDropTargetPos(view, event, slice),
+              view,
+              event,
+              slice,
+              moved,
+            );
+          },
+        },
+      }),
+    ],
+  } as const;
+});

--- a/packages/core/src/extensions/Toggle/toggleDrop.ts
+++ b/packages/core/src/extensions/Toggle/toggleDrop.ts
@@ -1,0 +1,119 @@
+import type { Node as PMNode, Slice } from "prosemirror-model";
+import type { EditorView } from "prosemirror-view";
+
+import { materializeChildren } from "../../api/blockManipulation/commands/materializeChildren/materializeChildren.js";
+import {
+  getBlockInfoFromNode,
+  getNearestBlockPos,
+} from "../../api/getBlockInfoFromPos.js";
+
+/** The whole blocks `slice` consists of, if that's all it is. */
+function getSliceBlocks(slice: Slice | undefined | null): PMNode[] | undefined {
+  if (!slice || slice.openStart !== 0 || slice.openEnd !== 0) {
+    return undefined;
+  }
+
+  const blocks: PMNode[] = [];
+  slice.content.forEach((node) => blocks.push(node));
+
+  return blocks.length > 0 &&
+    blocks.every((node) => node.type.isInGroup("blockGroupChild"))
+    ? blocks
+    : undefined;
+}
+
+/**
+ * The position of a block a drop should land *inside* of rather than next to —
+ * an expanded, childless collapsible block, whose missing `blockGroup` leaves
+ * `dropPoint` nothing to find. The drop cursor and the drop handler both come
+ * through here, so they can't disagree.
+ */
+export function getToggleDropTargetPos(
+  isExpanded: (id: string) => boolean | undefined,
+  view: EditorView,
+  event: { clientX: number; clientY: number },
+  slice: Slice | undefined | null,
+): number | undefined {
+  if (!view.editable || !getSliceBlocks(slice)) {
+    return undefined;
+  }
+
+  const coords = view.posAtCoords({ left: event.clientX, top: event.clientY });
+  if (!coords) {
+    return undefined;
+  }
+
+  const blockPos = getNearestBlockPos(
+    view.state.doc,
+    coords.inside >= 0 ? coords.inside : coords.pos,
+  );
+  const info = getBlockInfoFromNode(blockPos.node, blockPos.posBeforeNode);
+
+  if (
+    !info.hasContent ||
+    info.children ||
+    !info.block.node.attrs.id ||
+    !isExpanded(info.block.node.attrs.id)
+  ) {
+    return undefined;
+  }
+
+  // Only over the block's own content, so the space below it stays a normal
+  // "drop as a sibling" region.
+  const contentDOM = view.nodeDOM(info.content.beforePos);
+  if (!(contentDOM instanceof HTMLElement)) {
+    return undefined;
+  }
+
+  const rect = contentDOM.getBoundingClientRect();
+
+  return event.clientY < rect.top || event.clientY > rect.bottom
+    ? undefined
+    : blockPos.posBeforeNode;
+}
+
+/**
+ * Drops the dragged blocks into the block under the pointer, as its children.
+ *
+ * @returns Whether the drop was handled.
+ */
+export function handleToggleDrop(
+  targetPos: number | undefined,
+  view: EditorView,
+  event: Pick<DragEvent, "preventDefault">,
+  slice: Slice | undefined | null,
+  moved: boolean,
+): boolean {
+  const blocks = getSliceBlocks(slice);
+  if (targetPos === undefined || !blocks) {
+    return false;
+  }
+
+  // Without one there's nothing to check the target against below, so the drop
+  // would land at a position nothing has vouched for.
+  const targetId = view.state.doc.nodeAt(targetPos)?.attrs.id;
+  if (!targetId) {
+    return false;
+  }
+
+  const tr = view.state.tr;
+
+  if (moved) {
+    tr.deleteSelection();
+  }
+
+  const mappedPos = tr.mapping.map(targetPos);
+  // Dragging a block onto itself deletes the drop target, so there's nothing
+  // left to drop into.
+  if (tr.doc.nodeAt(mappedPos)?.attrs.id !== targetId) {
+    return false;
+  }
+
+  if (materializeChildren(tr, mappedPos, blocks) === undefined) {
+    return false;
+  }
+  view.dispatch(tr.setMeta("uiEvent", "drop"));
+  event.preventDefault();
+
+  return true;
+}

--- a/packages/core/src/extensions/Toggle/toggleEnter.ts
+++ b/packages/core/src/extensions/Toggle/toggleEnter.ts
@@ -1,0 +1,25 @@
+import type { Transaction } from "prosemirror-state";
+import { insertEmptyFirstChild } from "../../api/blockManipulation/commands/materializeChildren/materializeChildren.js";
+import { getBlockInfoFromSelection } from "../../api/getBlockInfoFromPos.js";
+import type { BlockNoteEditor } from "../../editor/BlockNoteEditor.js";
+import { ToggleExtension } from "./Toggle.js";
+
+/** Only plain Enter at the end of a nonempty, expanded title starts a child. */
+export function handleToggleEnter(
+  editor: Pick<BlockNoteEditor, "getExtension">,
+  tr: Transaction,
+): boolean {
+  const info = getBlockInfoFromSelection(tr);
+  if (
+    !info.hasContent ||
+    !tr.selection.empty ||
+    info.isContentEmpty ||
+    tr.selection.from !== info.contentEnd ||
+    editor
+      .getExtension(ToggleExtension)
+      ?.isExpanded(info.block.node.attrs.id) !== true
+  ) {
+    return false;
+  }
+  return insertEmptyFirstChild(tr, info.block.beforePos);
+}

--- a/packages/core/src/extensions/index.ts
+++ b/packages/core/src/extensions/index.ts
@@ -23,3 +23,5 @@ export * from "./SuggestionMenu/SuggestionMenu.js";
 export * from "./TableHandles/TableHandles.js";
 export * from "./TrailingNode/TrailingNode.js";
 export * from "./Versioning/index.js";
+
+export * from "./Toggle/Toggle.js";

--- a/packages/core/src/extensions/tiptap-extensions/KeyboardShortcuts/KeyboardShortcutsExtension.ts
+++ b/packages/core/src/extensions/tiptap-extensions/KeyboardShortcuts/KeyboardShortcutsExtension.ts
@@ -1,3 +1,4 @@
+import { handleToggleEnter } from "../../Toggle/toggleEnter.js";
 import { type ChainedCommands, Extension } from "@tiptap/core";
 import { Fragment } from "prosemirror-model";
 import { TextSelection, Transaction } from "prosemirror-state";
@@ -881,6 +882,11 @@ export const KeyboardShortcutsExtension = Extension.create<{
 
             return true;
           }),
+        () =>
+          !withShift &&
+          commands.command(({ tr }) =>
+            handleToggleEnter(this.options.editor, tr),
+          ),
         // Splits the current block, moving content inside that's after the cursor to a new text block below. Also
         // deletes the selection beforehand, if it's not empty.
         () =>

--- a/packages/react/src/blocks/ToggleWrapper/ToggleWrapper.tsx
+++ b/packages/react/src/blocks/ToggleWrapper/ToggleWrapper.tsx
@@ -38,6 +38,7 @@ const showChildrenReducer = (
   throw new UnreachableCaseError(action);
 };
 
+/** @deprecated Render disclosure UI around the children with `renderFrame`. */
 export const ToggleWrapper = (
   props: Omit<
     ReactCustomBlockRenderProps<BlockConfig<any, any, any>>,

--- a/packages/react/src/editor/styles.css
+++ b/packages/react/src/editor/styles.css
@@ -120,7 +120,7 @@
 
 /* Indent line styling */
 .bn-block-group
-  .bn-block:not(:has(.bn-toggle-wrapper))
+  .bn-block:not(:has(.bn-toggle-wrapper, .bn-toggle-frame))
   .bn-block-group
   .bn-block-outer:not([data-prev-depth-changed])::before {
   border-left: 1px solid var(--bn-colors-side-menu);

--- a/tests/src/end-to-end/toggle/toggleFrame.test.tsx
+++ b/tests/src/end-to-end/toggle/toggleFrame.test.tsx
@@ -1,0 +1,200 @@
+import { DRAG_HANDLE_SELECTOR } from "../../utils/const.js";
+import {
+  getRect,
+  mouseSequence,
+  moveMouseOverElement,
+} from "../../utils/mouse.js";
+import { browserName } from "../../utils/context.js";
+import { sleep } from "../../utils/editor.js";
+import { BlockNoteEditor, type PartialBlock } from "@blocknote/core";
+import "@blocknote/core/fonts/inter.css";
+import { BlockNoteView } from "@blocknote/mantine";
+import "@blocknote/mantine/style.css";
+import { afterEach, expect, test } from "vite-plus/test";
+import { render } from "vitest-browser-react";
+import { page, userEvent } from "../../utils/context.js";
+import { waitForSelector } from "../../utils/editor.js";
+
+const editors: BlockNoteEditor[] = [];
+const unmountViews: (() => Promise<void>)[] = [];
+
+async function mount(initialContent: PartialBlock[]) {
+  window.localStorage.clear();
+  const editor = BlockNoteEditor.create({ initialContent });
+  editors.push(editor);
+  const rendered = await render(<BlockNoteView editor={editor} />);
+  unmountViews.push(() => rendered.unmount());
+  await waitForSelector(".bn-toggle-frame");
+  return editor;
+}
+
+function frame(id: string) {
+  return document.querySelector<HTMLElement>(
+    `[data-id="${id}"] > .bn-block > .bn-toggle-frame`,
+  )!;
+}
+
+function button(element: HTMLElement) {
+  return page.elementLocator(
+    element.querySelector<HTMLButtonElement>(":scope > .bn-toggle-button")!,
+  );
+}
+
+afterEach(async () => {
+  for (const unmount of unmountViews.splice(0)) {
+    await unmount();
+  }
+  for (const editor of editors.splice(0)) {
+    editor._tiptapEditor.destroy();
+  }
+  window.localStorage.clear();
+});
+
+test("real pointer clicks reach nested toggles beside the side menu", async () => {
+  const editor = await mount([
+    {
+      id: "parent",
+      type: "toggleListItem",
+      content: "Parent",
+      children: [
+        {
+          id: "nested",
+          type: "heading",
+          props: { level: 2, isToggleable: true },
+          content: "Nested heading",
+          children: [
+            { id: "body", type: "paragraph", content: "Editable body" },
+          ],
+        },
+      ],
+    },
+  ]);
+  const outer = frame("parent");
+  await button(outer).click();
+  const nested = frame("nested");
+  await button(nested).click();
+  const childDOM = document.querySelector('[data-id="body"]');
+  editor.setTextCursorPosition("body", "end");
+  editor.focus();
+  await userEvent.keyboard(" edited");
+  const before = editor.document;
+  await button(outer).click();
+  expect(nested.getClientRects()).toHaveLength(0);
+  await button(outer).click();
+  expect(nested.getClientRects().length).toBeGreaterThan(0);
+  expect(document.querySelector('[data-id="body"]')).toBe(childDOM);
+  expect(editor.document).toEqual(before);
+  expect(editor.getBlock("body")!.content).toEqual([
+    { type: "text", text: "Editable body edited", styles: {} },
+  ]);
+  // Check the whole clickable area, not just the center of the chevron.
+  await button(nested).hover();
+  const rect = nested.querySelector("button")!.getBoundingClientRect();
+  for (const x of [rect.left + 1, rect.right - 1]) {
+    expect(
+      nested
+        .querySelector("button")!
+        .contains(document.elementFromPoint(x, rect.top + rect.height / 2)),
+    ).toBe(true);
+  }
+});
+
+test("read-only changes hide and restore the empty-state button without remounting", async () => {
+  const editor = await mount([
+    { id: "empty", type: "toggleListItem", content: "Empty" },
+  ]);
+  const original = frame("empty");
+  await button(original).click();
+  const add = original.querySelector<HTMLButtonElement>(
+    ".bn-toggle-add-block-button",
+  )!;
+  expect(getComputedStyle(add).display).not.toBe("none");
+  editor.isEditable = false;
+  expect(getComputedStyle(add).display).toBe("none");
+  editor.isEditable = true;
+  expect(frame("empty")).toBe(original);
+  await page.elementLocator(add).click();
+  expect(editor.getBlock("empty")!.children).toHaveLength(1);
+});
+
+test("an empty toggle title does not trap arrow-key navigation", async () => {
+  const editor = await mount([
+    { id: "empty", type: "toggleListItem" },
+    { id: "next", type: "paragraph", content: "Next" },
+  ]);
+  editor.setTextCursorPosition("empty", "end");
+  editor.focus();
+  await userEvent.keyboard("{ArrowDown}");
+  expect(editor.getTextCursorPosition().block.id).toBe("next");
+});
+
+test("Enter creates a child in an expanded toggle heading and undoes once", async () => {
+  const editor = await mount([
+    {
+      id: "heading",
+      type: "heading",
+      props: { isToggleable: true },
+      content: "Heading",
+    },
+  ]);
+  const before = editor.document;
+  await button(frame("heading")).click();
+  editor.setTextCursorPosition("heading", "end");
+  editor.focus();
+  await userEvent.keyboard("{Enter}Child");
+  expect(editor.getBlock("heading")!.children[0].content).toEqual([
+    { type: "text", text: "Child", styles: {} },
+  ]);
+  editor.undo();
+  expect(editor.document).toEqual(before);
+});
+
+// Playwright's native drag simulation does not reliably fire dragover in Firefox.
+test.skipIf(browserName === "firefox")(
+  "drag cursor agrees with dropping into an expanded childless toggle",
+  async () => {
+    const editor = await mount([
+      { id: "toggle", type: "toggleListItem", content: "Toggle" },
+      { id: "source", content: "Drag me" },
+    ]);
+    const before = editor.document;
+    await button(frame("toggle")).click();
+    await moveMouseOverElement('[data-id="source"] .bn-block-content');
+    await sleep(100);
+    await moveMouseOverElement(await waitForSelector(DRAG_HANDLE_SELECTOR));
+    await sleep(100);
+    await mouseSequence([{ type: "down" }]);
+    const rect = getRect('[data-id="toggle"] .bn-block-content');
+    await mouseSequence([
+      {
+        type: "move",
+        x: rect.left + rect.width / 2,
+        y: rect.top + 1,
+        steps: 5,
+      },
+    ]);
+    await sleep(300);
+    await mouseSequence([
+      {
+        type: "move",
+        x: rect.left + rect.width / 2,
+        y: rect.top + rect.height / 2,
+        steps: 5,
+      },
+    ]);
+    await sleep(300);
+    const cursorRect = getRect(
+      await waitForSelector('[class*="prosemirror-dropcursor"]'),
+    );
+    await mouseSequence([{ type: "up" }]);
+    await sleep(300);
+    expect(
+      editor.getBlock("toggle")!.children.map((child) => child.id),
+    ).toEqual(["source"]);
+    const childRect = getRect('[data-id="source"]');
+    expect(Math.abs(cursorRect.top - childRect.top)).toBeLessThan(16);
+    expect(Math.abs(cursorRect.left - childRect.left)).toBeLessThan(32);
+    editor.undo();
+    expect(editor.document).toEqual(before);
+  },
+);

--- a/tests/src/unit/core/formatConversion/export/__snapshots__/blocknoteHTML/heading/toggleable.html
+++ b/tests/src/unit/core/formatConversion/export/__snapshots__/blocknoteHTML/heading/toggleable.html
@@ -2,33 +2,44 @@
   <div class="bn-block-outer" data-node-type="blockOuter" data-id="1">
     <div class="bn-block" data-node-type="blockContainer" data-id="1">
       <div
-        class="bn-block-content"
-        data-content-type="heading"
-        data-level="2"
-        data-is-toggleable="true"
+        class="bn-toggle-frame"
+        data-toggle-heading="true"
+        data-show-children="true"
       >
-        <div>
-          <div class="bn-toggle-wrapper" data-show-children="true">
-            <button class="bn-toggle-button" type="button">
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                height="24px"
-                viewBox="0 -960 960 960"
-                width="24px"
-                fill="CURRENTCOLOR"
-              >
-                <path d="M320-200v-560l440 280-440 280Z"></path>
-              </svg>
-            </button>
+        <button
+          class="bn-toggle-button"
+          type="button"
+          aria-label="Toggle List"
+          aria-expanded="true"
+          disabled=""
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            height="24px"
+            viewBox="0 -960 960 960"
+            width="24px"
+            fill="currentColor"
+            aria-hidden="true"
+          >
+            <path d="M320-200v-560l440 280-440 280Z"></path>
+          </svg>
+        </button>
+        <div class="bn-toggle-slot">
+          <div
+            class="bn-block-content"
+            data-content-type="heading"
+            data-level="2"
+            data-is-toggleable="true"
+          >
             <h2 class="bn-inline-content">Toggle Heading</h2>
           </div>
-        </div>
-      </div>
-      <div class="bn-block-group" data-node-type="blockGroup">
-        <div class="bn-block-outer" data-node-type="blockOuter" data-id="2">
-          <div class="bn-block" data-node-type="blockContainer" data-id="2">
-            <div class="bn-block-content" data-content-type="paragraph">
-              <p class="bn-inline-content">Child content</p>
+          <div class="bn-block-group" data-node-type="blockGroup">
+            <div class="bn-block-outer" data-node-type="blockOuter" data-id="2">
+              <div class="bn-block" data-node-type="blockContainer" data-id="2">
+                <div class="bn-block-content" data-content-type="paragraph">
+                  <p class="bn-inline-content">Child content</p>
+                </div>
+              </div>
             </div>
           </div>
         </div>

--- a/tests/src/unit/core/formatConversion/export/__snapshots__/blocknoteHTML/lists/basic.html
+++ b/tests/src/unit/core/formatConversion/export/__snapshots__/blocknoteHTML/lists/basic.html
@@ -61,20 +61,31 @@
   </div>
   <div class="bn-block-outer" data-node-type="blockOuter" data-id="7">
     <div class="bn-block" data-node-type="blockContainer" data-id="7">
-      <div class="bn-block-content" data-content-type="toggleListItem">
-        <div>
-          <div class="bn-toggle-wrapper" data-show-children="true">
-            <button class="bn-toggle-button" type="button">
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                height="24px"
-                viewBox="0 -960 960 960"
-                width="24px"
-                fill="CURRENTCOLOR"
-              >
-                <path d="M320-200v-560l440 280-440 280Z"></path>
-              </svg>
-            </button>
+      <div
+        class="bn-toggle-frame"
+        data-toggle-heading="false"
+        data-show-children="true"
+      >
+        <button
+          class="bn-toggle-button"
+          type="button"
+          aria-label="Toggle List"
+          aria-expanded="true"
+          disabled=""
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            height="24px"
+            viewBox="0 -960 960 960"
+            width="24px"
+            fill="currentColor"
+            aria-hidden="true"
+          >
+            <path d="M320-200v-560l440 280-440 280Z"></path>
+          </svg>
+        </button>
+        <div class="bn-toggle-slot">
+          <div class="bn-block-content" data-content-type="toggleListItem">
             <p class="bn-inline-content">Toggle List Item 1</p>
           </div>
         </div>

--- a/tests/src/unit/core/formatConversion/export/__snapshots__/blocknoteHTML/lists/nested.html
+++ b/tests/src/unit/core/formatConversion/export/__snapshots__/blocknoteHTML/lists/nested.html
@@ -58,20 +58,31 @@
                   <div class="bn-block-group" data-node-type="blockGroup">
                     <div class="bn-block-outer" data-node-type="blockOuter" data-id="7">
                       <div class="bn-block" data-node-type="blockContainer" data-id="7">
-                        <div class="bn-block-content" data-content-type="toggleListItem">
-                          <div>
-                            <div class="bn-toggle-wrapper" data-show-children="true">
-                              <button class="bn-toggle-button" type="button">
-                                <svg
-                                  xmlns="http://www.w3.org/2000/svg"
-                                  height="24px"
-                                  viewBox="0 -960 960 960"
-                                  width="24px"
-                                  fill="CURRENTCOLOR"
-                                >
-                                  <path d="M320-200v-560l440 280-440 280Z"></path>
-                                </svg>
-                              </button>
+                        <div
+                          class="bn-toggle-frame"
+                          data-toggle-heading="false"
+                          data-show-children="true"
+                        >
+                          <button
+                            class="bn-toggle-button"
+                            type="button"
+                            aria-label="Toggle List"
+                            aria-expanded="true"
+                            disabled=""
+                          >
+                            <svg
+                              xmlns="http://www.w3.org/2000/svg"
+                              height="24px"
+                              viewBox="0 -960 960 960"
+                              width="24px"
+                              fill="currentColor"
+                              aria-hidden="true"
+                            >
+                              <path d="M320-200v-560l440 280-440 280Z"></path>
+                            </svg>
+                          </button>
+                          <div class="bn-toggle-slot">
+                            <div class="bn-block-content" data-content-type="toggleListItem">
                               <p class="bn-inline-content">Toggle List Item 1</p>
                             </div>
                           </div>

--- a/tests/src/unit/core/formatConversion/export/__snapshots__/blocknoteHTML/lists/toggleWithChildren.html
+++ b/tests/src/unit/core/formatConversion/export/__snapshots__/blocknoteHTML/lists/toggleWithChildren.html
@@ -1,36 +1,47 @@
 <div class="bn-block-group" data-node-type="blockGroup">
   <div class="bn-block-outer" data-node-type="blockOuter" data-id="1">
     <div class="bn-block" data-node-type="blockContainer" data-id="1">
-      <div class="bn-block-content" data-content-type="toggleListItem">
-        <div>
-          <div class="bn-toggle-wrapper" data-show-children="true">
-            <button class="bn-toggle-button" type="button">
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                height="24px"
-                viewBox="0 -960 960 960"
-                width="24px"
-                fill="CURRENTCOLOR"
-              >
-                <path d="M320-200v-560l440 280-440 280Z"></path>
-              </svg>
-            </button>
+      <div
+        class="bn-toggle-frame"
+        data-toggle-heading="false"
+        data-show-children="true"
+      >
+        <button
+          class="bn-toggle-button"
+          type="button"
+          aria-label="Toggle List"
+          aria-expanded="true"
+          disabled=""
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            height="24px"
+            viewBox="0 -960 960 960"
+            width="24px"
+            fill="currentColor"
+            aria-hidden="true"
+          >
+            <path d="M320-200v-560l440 280-440 280Z"></path>
+          </svg>
+        </button>
+        <div class="bn-toggle-slot">
+          <div class="bn-block-content" data-content-type="toggleListItem">
             <p class="bn-inline-content">Toggle List Item</p>
           </div>
-        </div>
-      </div>
-      <div class="bn-block-group" data-node-type="blockGroup">
-        <div class="bn-block-outer" data-node-type="blockOuter" data-id="2">
-          <div class="bn-block" data-node-type="blockContainer" data-id="2">
-            <div class="bn-block-content" data-content-type="paragraph">
-              <p class="bn-inline-content">Toggle Child 1</p>
+          <div class="bn-block-group" data-node-type="blockGroup">
+            <div class="bn-block-outer" data-node-type="blockOuter" data-id="2">
+              <div class="bn-block" data-node-type="blockContainer" data-id="2">
+                <div class="bn-block-content" data-content-type="paragraph">
+                  <p class="bn-inline-content">Toggle Child 1</p>
+                </div>
+              </div>
             </div>
-          </div>
-        </div>
-        <div class="bn-block-outer" data-node-type="blockOuter" data-id="3">
-          <div class="bn-block" data-node-type="blockContainer" data-id="3">
-            <div class="bn-block-content" data-content-type="paragraph">
-              <p class="bn-inline-content">Toggle Child 2</p>
+            <div class="bn-block-outer" data-node-type="blockOuter" data-id="3">
+              <div class="bn-block" data-node-type="blockContainer" data-id="3">
+                <div class="bn-block-content" data-content-type="paragraph">
+                  <p class="bn-inline-content">Toggle Child 2</p>
+                </div>
+              </div>
             </div>
           </div>
         </div>
@@ -40,33 +51,44 @@
   <div class="bn-block-outer" data-node-type="blockOuter" data-id="4">
     <div class="bn-block" data-node-type="blockContainer" data-id="4">
       <div
-        class="bn-block-content"
-        data-content-type="heading"
-        data-level="2"
-        data-is-toggleable="true"
+        class="bn-toggle-frame"
+        data-toggle-heading="true"
+        data-show-children="true"
       >
-        <div>
-          <div class="bn-toggle-wrapper" data-show-children="true">
-            <button class="bn-toggle-button" type="button">
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                height="24px"
-                viewBox="0 -960 960 960"
-                width="24px"
-                fill="CURRENTCOLOR"
-              >
-                <path d="M320-200v-560l440 280-440 280Z"></path>
-              </svg>
-            </button>
+        <button
+          class="bn-toggle-button"
+          type="button"
+          aria-label="Toggle List"
+          aria-expanded="true"
+          disabled=""
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            height="24px"
+            viewBox="0 -960 960 960"
+            width="24px"
+            fill="currentColor"
+            aria-hidden="true"
+          >
+            <path d="M320-200v-560l440 280-440 280Z"></path>
+          </svg>
+        </button>
+        <div class="bn-toggle-slot">
+          <div
+            class="bn-block-content"
+            data-content-type="heading"
+            data-level="2"
+            data-is-toggleable="true"
+          >
             <h2 class="bn-inline-content">Toggle Heading</h2>
           </div>
-        </div>
-      </div>
-      <div class="bn-block-group" data-node-type="blockGroup">
-        <div class="bn-block-outer" data-node-type="blockOuter" data-id="5">
-          <div class="bn-block" data-node-type="blockContainer" data-id="5">
-            <div class="bn-block-content" data-content-type="paragraph">
-              <p class="bn-inline-content">Heading Child 1</p>
+          <div class="bn-block-group" data-node-type="blockGroup">
+            <div class="bn-block-outer" data-node-type="blockOuter" data-id="5">
+              <div class="bn-block" data-node-type="blockContainer" data-id="5">
+                <div class="bn-block-content" data-content-type="paragraph">
+                  <p class="bn-inline-content">Heading Child 1</p>
+                </div>
+              </div>
             </div>
           </div>
         </div>

--- a/tests/src/unit/core/formatConversion/parse/__snapshots__/html/legacyToggleWrapperBlockNoteHTML.json
+++ b/tests/src/unit/core/formatConversion/parse/__snapshots__/html/legacyToggleWrapperBlockNoteHTML.json
@@ -1,0 +1,74 @@
+[
+  {
+    "children": [
+      {
+        "children": [],
+        "content": [
+          {
+            "styles": {},
+            "text": "Toggle Child",
+            "type": "text",
+          },
+        ],
+        "id": "2",
+        "props": {
+          "backgroundColor": "default",
+          "textAlignment": "left",
+          "textColor": "default",
+        },
+        "type": "paragraph",
+      },
+    ],
+    "content": [
+      {
+        "styles": {},
+        "text": "Toggle List Item",
+        "type": "text",
+      },
+    ],
+    "id": "1",
+    "props": {
+      "backgroundColor": "default",
+      "textAlignment": "left",
+      "textColor": "default",
+    },
+    "type": "toggleListItem",
+  },
+  {
+    "children": [
+      {
+        "children": [],
+        "content": [
+          {
+            "styles": {},
+            "text": "Heading Child",
+            "type": "text",
+          },
+        ],
+        "id": "4",
+        "props": {
+          "backgroundColor": "default",
+          "textAlignment": "left",
+          "textColor": "default",
+        },
+        "type": "paragraph",
+      },
+    ],
+    "content": [
+      {
+        "styles": {},
+        "text": "Toggle Heading",
+        "type": "text",
+      },
+    ],
+    "id": "3",
+    "props": {
+      "backgroundColor": "default",
+      "isToggleable": true,
+      "level": 2,
+      "textAlignment": "left",
+      "textColor": "default",
+    },
+    "type": "heading",
+  },
+]

--- a/tests/src/unit/core/formatConversion/parse/parseTestInstances.ts
+++ b/tests/src/unit/core/formatConversion/parse/parseTestInstances.ts
@@ -1238,6 +1238,68 @@ l'utilisateur (bouton bleu en haut à droite de la conversation)<o:p></o:p></spa
     },
     executeTest: testParseHTML,
   },
+  {
+    // BlockNote HTML stored before toggles moved from a node view wrapper to
+    // `renderFrame`. The chevron used to sit inside
+    // `.bn-block-content`, wrapped in `.bn-toggle-wrapper`; props were, and
+    // still are, `data-*` attributes on `.bn-block-content`.
+    testCase: {
+      name: "legacyToggleWrapperBlockNoteHTML",
+      content: `<div class="bn-block-group" data-node-type="blockGroup">
+  <div class="bn-block-outer" data-node-type="blockOuter" data-id="1">
+    <div class="bn-block" data-node-type="blockContainer" data-id="1">
+      <div class="bn-block-content" data-content-type="toggleListItem">
+        <div>
+          <div class="bn-toggle-wrapper" data-show-children="true">
+            <button class="bn-toggle-button" type="button">
+              <svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 -960 960 960" width="24px" fill="CURRENTCOLOR">
+                <path d="M320-200v-560l440 280-440 280Z"></path>
+              </svg>
+            </button>
+            <p class="bn-inline-content">Toggle List Item</p>
+          </div>
+        </div>
+      </div>
+      <div class="bn-block-group" data-node-type="blockGroup">
+        <div class="bn-block-outer" data-node-type="blockOuter" data-id="2">
+          <div class="bn-block" data-node-type="blockContainer" data-id="2">
+            <div class="bn-block-content" data-content-type="paragraph">
+              <p class="bn-inline-content">Toggle Child</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="bn-block-outer" data-node-type="blockOuter" data-id="3">
+    <div class="bn-block" data-node-type="blockContainer" data-id="3">
+      <div class="bn-block-content" data-content-type="heading" data-level="2" data-is-toggleable="true">
+        <div>
+          <div class="bn-toggle-wrapper" data-show-children="false">
+            <button class="bn-toggle-button" type="button">
+              <svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 -960 960 960" width="24px" fill="CURRENTCOLOR">
+                <path d="M320-200v-560l440 280-440 280Z"></path>
+              </svg>
+            </button>
+            <h2 class="bn-inline-content">Toggle Heading</h2>
+          </div>
+        </div>
+      </div>
+      <div class="bn-block-group" data-node-type="blockGroup">
+        <div class="bn-block-outer" data-node-type="blockOuter" data-id="4">
+          <div class="bn-block" data-node-type="blockContainer" data-id="4">
+            <div class="bn-block-content" data-content-type="paragraph">
+              <p class="bn-inline-content">Heading Child</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>`,
+    },
+    executeTest: testParseHTML,
+  },
 ];
 
 export const parseTestInstancesMarkdown: TestInstance<

--- a/tests/tsconfig.json
+++ b/tests/tsconfig.json
@@ -27,6 +27,9 @@
   "include": ["src"],
   "references": [
     {
+      "path": "../packages/mantine"
+    },
+    {
       "path": "../packages/core"
     },
     {


### PR DESCRIPTION
Not to merge, experiment on using renderFrame for toggle blocks

# Summary

Render built-in toggle list items and toggle headings through `renderFrame`. Collapsing hides the existing child group while preserving its node views and editable title.

Stacked on #3059 (`container-blocks/unified`). The base PR contains the generic frame lifecycle, static serialization, frame-aware side-menu anchoring, and child-preserving split changes.

## Rationale

Frames provide a shared place for disclosure controls around a title and its children. A small editor-scoped controller lets frames, keyboard handlers, and drag handling share expansion state without putting it in the document or undo history.

## Changes

- Add `createToggleFrame` and migrate both built-in toggle block types.
- Create a first child when Enter is pressed at the end of an expanded title; collapsed titles retain sibling insertion.
- Share first-child insertion between Enter, the add-block button, and whole-block drops. Resolve empty-toggle drop placement and the drop cursor through the same helper.
- Preserve local expansion when storage is unavailable, including failed writes followed by successful reads.
- Unregister frames on conversion and destruction, retain nested DOM on collapse, and keep read-only controls accurate.
- Add lifecycle, keyboard, undo, storage, legacy HTML, and browser regressions; add the tests project's Mantine reference for type checking.

## Impact

`createToggleWrapper` and React `ToggleWrapper` remain available and are deprecated. Built-in toggles use the new helper. Static HTML includes expanded frame markup; legacy wrapper HTML remains parseable. There is no document schema change and no new playground example.

## Testing

- 20 toggle unit tests passed, alongside focused frame, split, titled-block, and keyboard tests.
- 688 HTML/Markdown conversion tests passed.
- 14 Docker toggle browser checks passed across Chromium, Firefox, and WebKit; Firefox's native drag simulation is skipped.
- Core/React lint and the full staged-file pre-commit checks passed.
- Static/editor and exporter visual parity was reviewed during the rendering migration.

## Additional Notes

Informed by #2988. This implementation uses frames for rendering and keeps its editing-behavior improvements separate from the generic APIs now in #3059.
