### PR TITLE
Restore correct menu drag dropdown behavior in ShadCN

### DIFF
--- a/packages/shadcn/src/menu/Menu.tsx
+++ b/packages/shadcn/src/menu/Menu.tsx
@@ -57,6 +57,11 @@ export const MenuTrigger = (
   } else {
     return (
       <ShadCNComponents.DropdownMenu.DropdownMenuTrigger
+        // Open on click so pressing a draggable trigger can start a drag.
+        // Also skip Base UI's pointer tracking: otherwise it ignores the click
+        // because it expects the preceding mouse-down to have opened the menu.
+        onPointerDown={(event) => event.preventBaseUIHandler()}
+        onMouseDown={(event) => event.preventBaseUIHandler()}
         render={children as ReactElement}
       />
     );

--- a/tests/src/end-to-end/shadcn/shadcn.test.tsx
+++ b/tests/src/end-to-end/shadcn/shadcn.test.tsx
@@ -3,7 +3,7 @@ import App from "@examples/01-basic/09-shadcn/src/App";
 // to bootstrap Tailwind v4 + the ShadCN theme variables. Without it the
 // ShadCN UI components render unstyled (no popovers, no borders, no theme).
 import "@examples/01-basic/09-shadcn/tailwind.css";
-import { beforeEach, describe, test } from "vite-plus/test";
+import { beforeEach, describe, expect, test, vi } from "vite-plus/test";
 import { render } from "vitest-browser-react";
 import { userEvent } from "../../utils/context.js";
 import {
@@ -25,6 +25,17 @@ import {
   moveMouseOverElement,
 } from "../../utils/mouse.js";
 import { executeSlashCommand } from "../../utils/slashmenu.js";
+
+// ShadCN portals the dropdown outside .bn-side-menu.
+const DRAG_HANDLE_MENU_SELECTOR = ".bn-drag-handle-menu";
+
+async function waitForMenuUpdates() {
+  // Base UI schedules mouse-down opening in an animation frame. Wait through
+  // the following frame so absence assertions also observe deferred updates.
+  await new Promise<void>((resolve) => {
+    requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
+  });
+}
 
 beforeEach(async () => {
   await render(<App />);
@@ -98,6 +109,80 @@ describe("Check ShadCN UI", () => {
       "shadcn-drag-handle-menu",
     );
   });
+  test("Drag handle menu opens on release instead of press", async () => {
+    await focusOnEditor();
+    await waitForSelector(PARAGRAPH_SELECTOR);
+    await moveMouseOverElement(PARAGRAPH_SELECTOR);
+
+    const dragHandle = await waitForSelector(DRAG_HANDLE_SELECTOR);
+    await moveMouseOverElement(dragHandle);
+    await mouseSequence([{ type: "down" }]);
+
+    await waitForMenuUpdates();
+    expect(document.querySelector(DRAG_HANDLE_MENU_SELECTOR)).toBeNull();
+
+    await mouseSequence([{ type: "up" }]);
+    await waitForSelector(DRAG_HANDLE_MENU_SELECTOR);
+  });
+  test.each(["click", "Enter", "Space"] as const)(
+    "Dragging keeps the menu closed and allows a subsequent %s",
+    async (activation) => {
+      await focusOnEditor();
+      await waitForSelector(PARAGRAPH_SELECTOR);
+      await moveMouseOverElement(PARAGRAPH_SELECTOR);
+
+      const dragHandle = await waitForSelector(DRAG_HANDLE_SELECTOR);
+      const dragHandleButton = dragHandle.closest("button");
+      if (!dragHandleButton) {
+        throw new Error("Drag handle button not found");
+      }
+      const onDragStart = vi.fn();
+      dragHandleButton.addEventListener("dragstart", onDragStart, {
+        once: true,
+      });
+      const dragHandleRect = getRect(dragHandle);
+      const x = dragHandleRect.x + dragHandleRect.width / 2;
+      const y = dragHandleRect.y + dragHandleRect.height / 2;
+      await mouseSequence([
+        { type: "move", x, y },
+        { type: "down" },
+        { type: "move", x: x + 20, y: y + 20, steps: 5 },
+      ]);
+
+      expect(onDragStart).toHaveBeenCalledOnce();
+      await waitForMenuUpdates();
+      expect(document.querySelector(DRAG_HANDLE_MENU_SELECTOR)).toBeNull();
+
+      // Release over the trigger itself: a mouse-up there must not be treated
+      // as a click after a drag, even when the block ends up in the same place.
+      await mouseSequence([{ type: "move", x, y, steps: 5 }, { type: "up" }]);
+      await waitForMenuUpdates();
+      expect(document.querySelector(DRAG_HANDLE_MENU_SELECTOR)).toBeNull();
+
+      await moveMouseOverElement(PARAGRAPH_SELECTOR);
+      const dragHandleAfterDragging =
+        await waitForSelector(DRAG_HANDLE_SELECTOR);
+      const buttonAfterDragging = dragHandleAfterDragging.closest("button");
+      if (!buttonAfterDragging) {
+        throw new Error("Drag handle button not found");
+      }
+      switch (activation) {
+        case "click":
+          await moveMouseOverElement(buttonAfterDragging);
+          await mouseSequence([{ type: "down" }, { type: "up" }]);
+          break;
+        case "Enter":
+          buttonAfterDragging.focus();
+          await userEvent.keyboard("{Enter}");
+          break;
+        case "Space":
+          buttonAfterDragging.focus();
+          await userEvent.keyboard(" ");
+          break;
+      }
+      await waitForSelector(DRAG_HANDLE_MENU_SELECTOR);
+    },
+  );
   test("Check image toolbar", async () => {
     await focusOnEditor();
     await executeSlashCommand("image");


### PR DESCRIPTION
## Summary

Restores the previous drag handle behavior in ShadCN UI: clicking the block drag handle opens its dropdown, while dragging a block keeps the dropdown closed.

## Rationale

Base UI opens menus on mouse down, unlike the previous Radix implementation and the current Mantine and Ariakit integrations. Because the block drag handle is both draggable and a menu trigger, this caused the dropdown to appear as soon as a block drag started. The regression was also visible in the ShadCN demos.

Opening the menu after a completed click restores the behavior from before the Base UI migration.

## Changes

- Open ShadCN menus on click instead of mouse down.
- Preserve block dragging without displaying the drag handle dropdown.
- Preserve mouse and keyboard activation through click, Enter, and Space.
- Add browser tests covering menu timing, dragging, and subsequent activation.

## Impact

This changes non-submenu ShadCN menu triggers to open when the click completes instead of when the pointer is pressed. Submenus are unaffected.

The behavior now matches the previous Radix implementation and the Mantine and Ariakit integrations.

## Testing

- Added end-to-end coverage confirming that:
  - The dropdown remains closed while the pointer is pressed.
  - Starting and completing a block drag does not open the dropdown.
  - The menu can still be opened after dragging with a click, Enter, or Space.
- Ran the focused tests in Chromium, Firefox, and WebKit: 12 tests passed.
- Ran lint on the changed menu and test files with no errors or warnings.
- Ran React Doctor with a score of 100/100 and no reported issues.
- Started the ShadCN example against the local workspace sources for manual verification.

## Screenshots/Video
| Before | After |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/fec88d02-1c06-4e2e-9a56-e5d8203cd8b2"></video> | <video src="https://github.com/user-attachments/assets/cd9d3202-315f-46f2-81ac-2109a613dec4"></video> | 


## Checklist

- [x] Code follows the project's coding standards.
- [x] Unit tests covering the new feature have been added.
- [x] All existing tests pass.


## Additional Notes

The regression was introduced by the difference between Base UI's mouse-down menu activation and the click-based behavior used by the other UI integrations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Menus triggered from draggable controls now open correctly on click or keyboard activation.
  - Starting a drag no longer unintentionally opens the menu.
  - Menu interactions now behave consistently when using mouse, Enter, or Space. 


<!-- end of auto-generated comment: release notes by coderabbit.ai -->