### PR TITLE
Ignore read-only editors for side menu targeting

### DIFF
--- a/packages/core/src/extensions/SideMenu/SideMenu.ts
+++ b/packages/core/src/extensions/SideMenu/SideMenu.ts
@@ -324,8 +324,13 @@ export class SideMenuView<
     clientX: number;
     clientY: number;
   }) => {
-    // Get all editor elements in the document
-    const editors = Array.from(this.pmView.root.querySelectorAll(".bn-editor"));
+    // Read-only editors cannot show a side menu or accept a dropped block, so
+    // they must not compete with editable editors that overlap them.
+    const editors = Array.from(
+      this.pmView.root.querySelectorAll(
+        '.bn-editor:not([contenteditable="false"])',
+      ),
+    );
 
     if (editors.length === 0) {
       return null;

--- a/tests/src/end-to-end/draghandle/overlappingEditors.test.tsx
+++ b/tests/src/end-to-end/draghandle/overlappingEditors.test.tsx
@@ -1,0 +1,38 @@
+import "@blocknote/core/fonts/inter.css";
+import { BlockNoteView } from "@blocknote/mantine";
+import "@blocknote/mantine/style.css";
+import { useCreateBlockNote } from "@blocknote/react";
+import { describe, test } from "vite-plus/test";
+import { render } from "vitest-browser-react";
+import { DRAG_HANDLE_SELECTOR } from "../../utils/const.js";
+import { waitForSelector } from "../../utils/editor.js";
+import { moveMouseOverElement } from "../../utils/mouse.js";
+
+function OverlappingEditors() {
+  const readOnlyEditor = useCreateBlockNote();
+  const editableEditor = useCreateBlockNote();
+
+  return (
+    <div style={{ display: "grid" }}>
+      <div style={{ gridArea: "1 / 1" }}>
+        <BlockNoteView editor={readOnlyEditor} editable={false} />
+      </div>
+      <div style={{ gridArea: "1 / 1", zIndex: 1 }}>
+        <BlockNoteView editor={editableEditor} />
+      </div>
+    </div>
+  );
+}
+
+describe("Overlapping editors", () => {
+  test("shows the side menu for an editable editor over a read-only editor", async () => {
+    await render(<OverlappingEditors />);
+
+    const editableBlock = await waitForSelector(
+      '.bn-editor[contenteditable="true"] [data-content-type="paragraph"]',
+    );
+    await moveMouseOverElement(editableBlock);
+
+    await waitForSelector(DRAG_HANDLE_SELECTOR);
+  });
+});


### PR DESCRIPTION
# Summary

Ignore read-only editors when determining the nearest editor for SideMenu hover and drag/drop behavior. This addresses the overlapping-dialog scenario reported in #2559 with a small selector change.

## Rationale

A read-only editor behind an editable dialog can currently win the proximity calculation, preventing the foreground editor from showing its SideMenu or receiving drops. Excluding non-editable editors is a simple, low-risk fix that should resolve most cases involving an editable dialog above read-only content without adding stacking-order logic.

## Changes

- Exclude `.bn-editor[contenteditable="false"]` from nearest-editor selection.
- Apply the behavior to both SideMenu hover detection and drag/drop targeting through the shared lookup.

## Impact

Read-only editors no longer compete with editable editors as SideMenu or drop targets. Overlapping editable editors remain outside the scope of this change.

## Testing

- Pre-commit `vp check --fix` passed.
- test added
- I created a temporary new example to verify it, but I don't think it's worth keeping it. 


## Checklist

- [x] Code follows the project's coding standards.
- [x] Unit tests covering the new feature have been added.
- [x] All existing tests pass.
- [ ] The documentation has been updated to reflect the new feature.

## Additional Notes

This intentionally targets the read-only background case from #2559 rather than introducing a general z-index ranking system.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved side-menu positioning and block-drop targeting when multiple editors overlap.
  - Read-only editors are no longer incorrectly selected as drag-handle targets when an editable editor is active.

- **Tests**
  - Added coverage for drag-handle behavior with overlapping editable and read-only editors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->