### PR TITLE
fix(core): resolve links at boundary positions in editLink and deleteLink

### DIFF
--- a/packages/core/src/editor/managers/StyleManager.test.ts
+++ b/packages/core/src/editor/managers/StyleManager.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vite-plus/test";
+
+import { BlockNoteEditor } from "../BlockNoteEditor.js";
+
+/**
+ * @vitest-environment jsdom
+ */
+
+function createEditorWithLink() {
+  const editor = BlockNoteEditor.create();
+  editor.mount(document.createElement("div"));
+  editor.replaceBlocks(editor.document, [
+    {
+      id: "block",
+      type: "paragraph",
+      content: [
+        {
+          type: "link",
+          href: "https://google.com",
+          content: [{ type: "text", text: "Google", styles: {} }],
+        },
+      ],
+    },
+  ]);
+  return editor;
+}
+
+function linkContent(editor: BlockNoteEditor<any, any, any>) {
+  const block = editor.getBlock("block")!;
+  return (block.content as any[]).map((inline) => ({
+    type: inline.type,
+    href: inline.href,
+    text: inline.type === "link" ? inline.content[0].text : inline.text,
+  }));
+}
+
+describe("StyleManager link editing at boundaries", () => {
+  it("edits the link when the caret is at its end", () => {
+    const editor = createEditorWithLink();
+    editor.setTextCursorPosition("block", "end");
+
+    editor.editLink("https://google.com", "Google Search");
+
+    expect(linkContent(editor)).toEqual([
+      { type: "link", href: "https://google.com", text: "Google Search" },
+    ]);
+  });
+
+  it("deletes the link when the caret is at its end", () => {
+    const editor = createEditorWithLink();
+    editor.setTextCursorPosition("block", "end");
+
+    editor.deleteLink();
+
+    expect(linkContent(editor)).toEqual([
+      { type: "text", href: undefined, text: "Google" },
+    ]);
+  });
+
+  it("edits the link when the caret is at its start", () => {
+    const editor = createEditorWithLink();
+    editor.setTextCursorPosition("block", "start");
+
+    editor.editLink("https://google.com", "Google Search");
+
+    expect(linkContent(editor)).toEqual([
+      { type: "link", href: "https://google.com", text: "Google Search" },
+    ]);
+  });
+
+  it("does not throw for a position at the very end of the document", () => {
+    const editor = createEditorWithLink();
+    const end = editor.prosemirrorState.doc.content.size;
+
+    expect(() =>
+      editor.editLink("https://github.com", "GitHub", end),
+    ).not.toThrow();
+    expect(() => editor.deleteLink(end)).not.toThrow();
+  });
+});

--- a/packages/core/src/editor/managers/StyleManager.ts
+++ b/packages/core/src/editor/managers/StyleManager.ts
@@ -176,6 +176,25 @@ export class StyleManager<
   }
 
   /**
+   * Find the link mark touching `position`: inside it, or at its start or end boundary,
+   * where the resolved position's marks alone would miss a non-inclusive link.
+   * Positions outside the document are skipped, so a caret at the very end never throws.
+   */
+  private getLinkMarkAround(position: number) {
+    const size = this.editor.transact((tr) => tr.doc.content.size);
+    for (const pos of [position + 1, position, position - 1]) {
+      if (pos < 0 || pos > size) {
+        continue;
+      }
+      const linkData = this.getLinkMarkAtPos(pos);
+      if (linkData && position >= linkData.from && position <= linkData.to) {
+        return linkData;
+      }
+    }
+    return undefined;
+  }
+
+  /**
    * Gets the URL of the last link in the current selection, or `undefined` if there are no links in the selection.
    */
   public getSelectedLinkUrl() {
@@ -222,7 +241,7 @@ export class StyleManager<
     position = this.editor.transact((tr) => tr.selection.anchor),
   ) {
     this.editor.transact((tr) => {
-      const linkData = this.getLinkMarkAtPos(position + 1);
+      const linkData = this.getLinkMarkAround(position);
       const { from, to } = linkData || {
         from: tr.selection.from,
         to: tr.selection.to,
@@ -246,7 +265,7 @@ export class StyleManager<
     position = this.editor.transact((tr) => tr.selection.anchor),
   ) {
     this.editor.transact((tr) => {
-      const linkData = this.getLinkMarkAtPos(position + 1);
+      const linkData = this.getLinkMarkAround(position);
       const { from, to } = linkData || {
         from: tr.selection.from,
         to: tr.selection.to,


### PR DESCRIPTION
# Summary

Fixes #3073. `StyleManager.editLink` and `deleteLink` looked up the link mark at `position + 1` unconditionally. At the end of the document that position does not exist and `tr.doc.resolve` throws a `RangeError`; at the end of a link (the usual place for the caret after clicking the link text) the lookup misses the link, falls back to the collapsed selection, and `editLink` inserts the new text next to the old link instead of replacing it.

## Rationale

The link mark is not inclusive, so a resolved position at either boundary does not carry the mark. Probing one position inside the link on both sides, and only accepting a link whose range actually contains the caret, finds the link at its start, inside it and at its end, without changing behaviour for a caret that is not on a link at all.

## Changes

- `packages/core/src/editor/managers/StyleManager.ts`: new private `getLinkMarkAround(position)` that probes `position + 1`, `position` and `position - 1`, skips positions outside the document, and returns the first link whose `[from, to]` range contains `position`. `editLink` and `deleteLink` use it instead of `getLinkMarkAtPos(position + 1)`.

## Impact

No public API change. Callers that pass a position outside the document no longer crash, and callers with the caret at a link boundary now edit or delete that link, which is the documented intent of both methods.

## Testing

New `packages/core/src/editor/managers/StyleManager.test.ts` (jsdom): edit and delete with the caret at the end of the link, edit with the caret at the start, and no throw for a position at the very end of the document. Ran it with `vp test --run` together with `vp lint src`.

## Checklist

- [x] Code follows the project's coding standards.
- [x] Unit tests covering the new feature have been added.
- [x] All existing tests pass.
- [ ] The documentation has been updated to reflect the new feature (no docs change needed).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved link editing and deletion at the start and end boundaries of linked text.
  - Prevented errors when link actions are triggered at the end of a document.
  - Ensured link deletion correctly converts linked text to plain text in boundary cases.

- **Tests**
  - Added coverage for link editing and deletion at document and link boundaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->