### PR TITLE
fix(core): keep the next block's children at their depth when merging blocks

### DIFF
--- a/packages/core/src/api/blockManipulation/commands/mergeBlocks/__snapshots__/mergeBlocks.test.ts.snap
+++ b/packages/core/src/api/blockManipulation/commands/mergeBlocks/__snapshots__/mergeBlocks.test.ts.snap
@@ -1673,34 +1673,35 @@ exports[`Test mergeBlocks > Second block has children 1`] = `
     "type": "paragraph",
   },
   {
-    "children": [],
-    "content": [
-      {
-        "styles": {},
-        "text": "Paragraph 1Paragraph with children",
-        "type": "text",
-      },
-    ],
-    "id": "paragraph-1",
-    "props": {
-      "backgroundColor": "default",
-      "textAlignment": "left",
-      "textColor": "default",
-    },
-    "type": "paragraph",
-  },
-  {
     "children": [
       {
-        "children": [],
+        "children": [
+          {
+            "children": [],
+            "content": [
+              {
+                "styles": {},
+                "text": "Double Nested Paragraph 0",
+                "type": "text",
+              },
+            ],
+            "id": "double-nested-paragraph-0",
+            "props": {
+              "backgroundColor": "default",
+              "textAlignment": "left",
+              "textColor": "default",
+            },
+            "type": "paragraph",
+          },
+        ],
         "content": [
           {
             "styles": {},
-            "text": "Double Nested Paragraph 0",
+            "text": "Nested Paragraph 0",
             "type": "text",
           },
         ],
-        "id": "double-nested-paragraph-0",
+        "id": "nested-paragraph-0",
         "props": {
           "backgroundColor": "default",
           "textAlignment": "left",
@@ -1712,11 +1713,11 @@ exports[`Test mergeBlocks > Second block has children 1`] = `
     "content": [
       {
         "styles": {},
-        "text": "Nested Paragraph 0",
+        "text": "Paragraph 1Paragraph with children",
         "type": "text",
       },
     ],
-    "id": "nested-paragraph-0",
+    "id": "paragraph-1",
     "props": {
       "backgroundColor": "default",
       "textAlignment": "left",

--- a/packages/core/src/api/blockManipulation/commands/mergeBlocks/mergeBlocks.test.ts
+++ b/packages/core/src/api/blockManipulation/commands/mergeBlocks/mergeBlocks.test.ts
@@ -18,6 +18,13 @@ function getPosBeforeSelectedBlock() {
   );
 }
 
+type Document = ReturnType<typeof getEditor>["document"];
+
+// Block ids with their nesting, e.g. [["a", [["b", []]]]].
+function outline(blocks: Document): unknown[] {
+  return blocks.map((block) => [block.id, outline(block.children)]);
+}
+
 describe("Test mergeBlocks", () => {
   it("Basic", () => {
     getEditor().setTextCursorPosition("paragraph-1");
@@ -41,6 +48,79 @@ describe("Test mergeBlocks", () => {
     mergeBlocks(getPosBeforeSelectedBlock());
 
     expect(getEditor().document).toMatchSnapshot();
+  });
+
+  it("Second block has children, first block is nested", () => {
+    getEditor().replaceBlocks(getEditor().document, [
+      {
+        id: "a",
+        type: "bulletListItem",
+        content: "A",
+        children: [{ id: "b", type: "bulletListItem", content: "B" }],
+      },
+      {
+        id: "c",
+        type: "paragraph",
+        content: "C",
+        children: [{ id: "d", type: "bulletListItem", content: "D" }],
+      },
+    ]);
+    getEditor().setTextCursorPosition("c");
+
+    mergeBlocks(getPosBeforeSelectedBlock());
+
+    expect(outline(getEditor().document)).toEqual([
+      [
+        "a",
+        [
+          ["b", []],
+          ["d", []],
+        ],
+      ],
+    ]);
+    expect(getEditor().getBlock("b")?.content).toEqual([
+      { type: "text", text: "BC", styles: {} },
+    ]);
+  });
+
+  it("Second block has children, first block is nested twice", () => {
+    getEditor().replaceBlocks(getEditor().document, [
+      {
+        id: "a",
+        type: "bulletListItem",
+        content: "A",
+        children: [
+          {
+            id: "b",
+            type: "bulletListItem",
+            content: "B",
+            children: [{ id: "e", type: "bulletListItem", content: "E" }],
+          },
+        ],
+      },
+      {
+        id: "c",
+        type: "paragraph",
+        content: "C",
+        children: [{ id: "d", type: "bulletListItem", content: "D" }],
+      },
+    ]);
+    getEditor().setTextCursorPosition("c");
+
+    mergeBlocks(getPosBeforeSelectedBlock());
+
+    expect(outline(getEditor().document)).toEqual([
+      [
+        "a",
+        [
+          ["b", [["e", []]]],
+          ["d", []],
+        ],
+      ],
+    ]);
+    expect(getEditor().getBlock("e")?.content).toEqual([
+      { type: "text", text: "EC", styles: {} },
+    ]);
   });
 
   it("Second block is empty", () => {

--- a/packages/core/src/api/blockManipulation/commands/mergeBlocks/mergeBlocks.ts
+++ b/packages/core/src/api/blockManipulation/commands/mergeBlocks/mergeBlocks.ts
@@ -119,28 +119,10 @@ const mergeBlocks = (
   prevBlockInfo: BlockInfo,
   nextBlockInfo: BlockInfo,
 ) => {
-  // Un-nests all children of the next block.
   if (!nextBlockInfo.isBlockContainer) {
     throw new Error(
       `Attempted to merge block at position ${nextBlockInfo.bnBlock.beforePos} into previous block at position ${prevBlockInfo.bnBlock.beforePos}, but next block is not a block container`,
     );
-  }
-
-  // Removes a level of nesting all children of the next block by 1 level, if it contains both content and block
-  // group nodes.
-  if (nextBlockInfo.childContainer) {
-    const childBlocksStart = state.doc.resolve(
-      nextBlockInfo.childContainer.beforePos + 1,
-    );
-    const childBlocksEnd = state.doc.resolve(
-      nextBlockInfo.childContainer.afterPos - 1,
-    );
-    const childBlocksRange = childBlocksStart.blockRange(childBlocksEnd);
-
-    if (dispatch) {
-      const pos = state.doc.resolve(nextBlockInfo.bnBlock.beforePos);
-      state.tr.lift(childBlocksRange!, pos.depth);
-    }
   }
 
   // Deletes the boundary between the two blocks. Can be thought of as
@@ -153,13 +135,46 @@ const mergeBlocks = (
       );
     }
 
+    const tr = state.tr;
+    const childGroup = nextBlockInfo.childContainer;
+
+    // Takes the next block's children out first, so the merge leaves no empty
+    // shell of the next block behind.
+    if (childGroup) {
+      tr.delete(childGroup.beforePos, childGroup.afterPos);
+    }
+
     // TODO: test merging between a columnList and paragraph, between two columnLists, and v.v.
-    dispatch(
-      state.tr.delete(
-        prevBlockInfo.blockContent.afterPos - 1,
-        nextBlockInfo.blockContent.beforePos + 1,
-      ),
+    tr.delete(
+      tr.mapping.map(prevBlockInfo.blockContent.afterPos - 1),
+      tr.mapping.map(nextBlockInfo.blockContent.beforePos + 1),
     );
+
+    // Puts the children back at the depth they had: appended to the merged
+    // block's ancestor at that depth when there is one, otherwise nested under
+    // the merged block.
+    if (childGroup) {
+      const childDepth = state.doc.resolve(childGroup.beforePos + 1).depth;
+      const $merged = tr.doc.resolve(
+        tr.mapping.map(prevBlockInfo.blockContent.beforePos) + 1,
+      );
+      const ancestor =
+        childDepth < $merged.depth - 1 ? $merged.node(childDepth) : undefined;
+
+      if (
+        ancestor?.canReplace(
+          ancestor.childCount,
+          ancestor.childCount,
+          childGroup.node.content,
+        )
+      ) {
+        tr.insert($merged.end(childDepth), childGroup.node.content);
+      } else {
+        tr.insert($merged.after($merged.depth), childGroup.node);
+      }
+    }
+
+    dispatch(tr);
   }
 
   return true;


### PR DESCRIPTION
# Summary

Fixes #3018. With a list like `A > [B, C, D]` and the caret at the start of `C`, pressing Backspace turns `C` into a paragraph, then un-nests it (which makes `D` a child of `C`), then merges `C` into `B`. That last step put `D` at the root instead of keeping it under `A`, so every sibling after the caret lost a level of nesting.

## Rationale

`mergeBlocksCommand` lifted the next block's children to the next block's own level before stitching the text. The merge target is the deepest last descendant of the previous block, so whenever that target sits deeper than the next block, the children ended up one level shallower than they were. Keeping their depth is what users expect (and what Notion does): the children are appended to the merged block's ancestor at the depth they had, or nested under the merged block when there is no such ancestor.

## Changes

- `packages/core/src/api/blockManipulation/commands/mergeBlocks/mergeBlocks.ts`: take the next block's children out first (so the merge leaves no empty shell of the next block behind), stitch the text as before, then put the children back at their original depth. Both the Backspace and the Delete path go through this command.
- `mergeBlocks.test.ts`: two new cases, previous block nested once and nested twice, with explicit outline assertions.
- Snapshot `Second block has children` changes: `nested-paragraph-0` now stays nested under the merged `paragraph-1` instead of moving to the root. That is the same behaviour change applied to a same-depth merge, and it is intentional.

## Impact

Behaviour change only for merging a block that has children: the children keep their indentation instead of being un-indented by one level. Blocks without children merge exactly as before. I saw that #3050 and #3014 touch this file as part of the container refactor; the change is small, so I am happy to rebase onto whichever lands first.

## Testing

`mergeBlocks.test.ts` (14 pass), the full `packages/core` and `packages/react` suites, `vp lint` on the touched folder and `tsc --noEmit` for `@blocknote/core`, all run locally.

## Checklist

- [x] Code follows the project's coding standards.
- [x] Unit tests covering the new feature have been added.
- [x] All existing tests pass.
- [ ] The documentation has been updated to reflect the new feature (no docs change needed).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved block merging to preserve content and nested child blocks correctly.
  - Fixed merging behavior when blocks contain children or are nested within other blocks.
  - Ensured merged documents maintain the expected structure across single- and multiple-level nesting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->