### PR TITLE
fix: Grid suggestion menu width overflows viewport (BLO-1361)

### DIFF
--- a/packages/ariakit/src/style.css
+++ b/packages/ariakit/src/style.css
@@ -157,6 +157,8 @@
   height: fit-content;
   justify-items: center;
   max-height: inherit;
+  max-width: inherit;
+  overflow-x: auto;
   overflow-y: auto;
   padding: 20px;
 }

--- a/packages/ariakit/src/style.css
+++ b/packages/ariakit/src/style.css
@@ -157,6 +157,7 @@
   height: fit-content;
   justify-items: center;
   max-height: inherit;
+  box-sizing: border-box;
   max-width: inherit;
   overflow-x: auto;
   overflow-y: auto;

--- a/packages/mantine/src/blocknoteStyles.css
+++ b/packages/mantine/src/blocknoteStyles.css
@@ -441,6 +441,8 @@
   height: fit-content;
   justify-items: center;
   max-height: inherit;
+  max-width: inherit;
+  overflow-x: auto;
   overflow-y: auto;
   padding: 20px;
 }

--- a/packages/mantine/src/blocknoteStyles.css
+++ b/packages/mantine/src/blocknoteStyles.css
@@ -441,6 +441,7 @@
   height: fit-content;
   justify-items: center;
   max-height: inherit;
+  box-sizing: border-box;
   max-width: inherit;
   overflow-x: auto;
   overflow-y: auto;

--- a/packages/react/src/components/SuggestionMenu/GridSuggestionMenu/GridSuggestionMenuController.tsx
+++ b/packages/react/src/components/SuggestionMenu/GridSuggestionMenu/GridSuggestionMenuController.tsx
@@ -144,8 +144,9 @@ export function GridSuggestionMenuController<
           }),
           shift(),
           size({
-            apply({ elements, availableHeight }) {
+            apply({ elements, availableHeight, availableWidth }) {
               elements.floating.style.maxHeight = `${Math.max(0, availableHeight)}px`;
+              elements.floating.style.maxWidth = `${Math.max(0, availableWidth)}px`;
             },
             padding: 10,
           }),

--- a/packages/shadcn/src/suggestionMenu/gridSuggestionMenu/GridSuggestionMenu.tsx
+++ b/packages/shadcn/src/suggestionMenu/gridSuggestionMenu/GridSuggestionMenu.tsx
@@ -16,7 +16,7 @@ export const GridSuggestionMenu = forwardRef<
     <div
       // Styles from ShadCN DropdownMenuContent component
       className={cn(
-        "bg-popover text-popover-foreground z-50 min-w-32 overflow-x-hidden overflow-y-auto rounded-md p-1 shadow-md ring-1 ring-foreground/10",
+        "bg-popover text-popover-foreground z-50 min-w-32 max-w-[inherit] overflow-x-auto overflow-y-auto rounded-md p-1 shadow-md ring-1 ring-foreground/10",
         "grid",
         className,
       )}

--- a/packages/shadcn/src/suggestionMenu/gridSuggestionMenu/GridSuggestionMenu.tsx
+++ b/packages/shadcn/src/suggestionMenu/gridSuggestionMenu/GridSuggestionMenu.tsx
@@ -16,7 +16,7 @@ export const GridSuggestionMenu = forwardRef<
     <div
       // Styles from ShadCN DropdownMenuContent component
       className={cn(
-        "bg-popover text-popover-foreground z-50 min-w-32 max-w-[inherit] overflow-x-auto overflow-y-auto rounded-md p-1 shadow-md ring-1 ring-foreground/10",
+        "bg-popover text-popover-foreground z-50 box-border max-w-[inherit] overflow-x-auto overflow-y-auto rounded-md p-1 shadow-md ring-1 ring-foreground/10",
         "grid",
         className,
       )}


### PR DESCRIPTION
# Summary

<!-- Briefly describe the feature being introduced. -->

This PR fixes the emoji picker/grid suggestion menu width overflowing in small viewports. It's based on #3082 but changes the width constraint to be set using CSS instead of FloatingUI's `size` middleware, to match how it's done in the regular suggestion menu. I've made a new PR as I don't have permissions to push to the original branch.

Thanks to @Ishkirat-Singh for his original PR!

Closes #3078

## Rationale

<!-- Explain the reasoning behind this feature and its benefits to the project. -->

This is a bug.

## Changes

<!-- List the major changes made in this pull request. -->

- Updated CSS

## Impact

<!-- Discuss any potential impacts this feature may have on existing functionalities. -->

N/A

## Testing

<!-- Describe how the feature has been tested, including both automated and manual testing strategies. -->

N/A

## Screenshots/Video

<!-- Include screenshots or video demonstrating the new feature, if applicable. -->

N/A

## Checklist

- [X] Code follows the project's coding standards.
- [ ] Unit tests covering the new feature have been added.
- [X] All existing tests pass.
- [ ] The documentation has been updated to reflect the new feature

## Additional Notes

<!-- Any additional information or context relevant to this PR. -->

N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved suggestion menu layout across themes by limiting menus to the viewport width.
  - Added horizontal scrolling for wide menu content instead of hiding overflow.
  - Removed the enforced minimum width to improve responsiveness on smaller screens.
  - Improved overflow handling so menus respond correctly when content extends beyond the left or right edge of the available space.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->